### PR TITLE
Use timeout function to force timeout on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - $HOME/.ccache
     - $HOME/.cache/pip
     - $HOME/docker
- #   - $TRAVIS_BUILD_DIR/external/
     - $TRAVIS_BUILD_DIR/external/Paddle/build/third_party
 
 sudo: required
@@ -24,26 +23,20 @@ addons:
       - python2.7-dev
   ssh_known_hosts: 13.229.163.131
 before_install:
-  -  sudo pip install pylint pytest astroid isort 
-  # Load cached docker images
-  #- if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+  - sudo pip install pylint pytest astroid isort 
+
+before_install:
+  - sudo pip install pylint pytest astroid isort
+  # Force the script to be timed out after certain duration
+  - function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
 
 jobs:
   include:
-    - script: scripts/deploy_docs.sh full 
+    # Force the deploy_docs.sh to time out after 40 minutes.
+    # Travis CI will terminate the build completely after 50 minutes and won't allow caching to happen.
+    # Time out the build preemptively to cache built libraries.
+    - script: timeout 2400 scripts/deploy_docs.sh full
       name: Generate Docs
-    - script: scripts/deploy_docs.sh pybind
-      name: Cache pybind build
-    - script: scripts/deploy_docs.sh proto
-      name: Cache proto build
-    - script: scripts/deploy_en_external_docs.sh
-      name: Generate EN external docs
-
-#before_cache:
-#  # Save tagged docker images
-#  - >
-#    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format 'paddlepaddle/paddle:latest-dev {{.ID}}'
-#    | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
     
 notifications:
   email:


### PR DESCRIPTION
If the build exceeds 50 minutes, Travis will terminate the job completely. The cache won't even happen. 

This change will time out the script preemptively, cache currently built libraries and failed the job. 
We can then restart the job and take advantage of caches. 