### PR TITLE
remove unused inference header

### DIFF
--- a/doc/fluid/advanced_usage/deploy/inference/build_and_install_lib_cn.rst
+++ b/doc/fluid/advanced_usage/deploy/inference/build_and_install_lib_cn.rst
@@ -71,7 +71,6 @@ WITH_MKL                      ON/OFF
      │   │   ├── paddle_analysis_config.h
      │   │   ├── paddle_api.h
      │   │   ├── paddle_inference_api.h
-     │   │   ├── paddle_inference_pass.h
      │   │   └── paddle_pass_builder.h
      │   └── lib
      │       ├── libpaddle_fluid.a


### PR DESCRIPTION
删除预测库多余的头文件
related https://github.com/PaddlePaddle/Paddle/pull/14595