### PR TITLE
user guides index of all

### DIFF
--- a/doc/fluid/index_en.rst
+++ b/doc/fluid/index_en.rst
@@ -5,6 +5,7 @@
   :maxdepth: 1
 
   beginners_guide/index_en.rst
+  user_guides/index_en.rst
   design/index_en.rst
   howto/index_en.rst
   dev/index_en.rst

--- a/doc/fluid/user_guides/howto/basic_concept/index_en.rst
+++ b/doc/fluid/user_guides/howto/basic_concept/index_en.rst
@@ -1,0 +1,12 @@
+###############
+Basic Concepts
+###############
+
+This section will introduce basic concepts in Fluid：
+
+- `LoD-Tensor User Guide <lod_tensor_en.html>`_ : LoD-Tensor is a unique term of Fluid. It appends sequence information to Tensor，and supports data of variable lengths.
+
+..  toctree::
+    :hidden:
+
+    lod_tensor_en.rst

--- a/doc/fluid/user_guides/howto/evaluation_and_debugging/index_en.rst
+++ b/doc/fluid/user_guides/howto/evaluation_and_debugging/index_en.rst
@@ -1,0 +1,17 @@
+###############################
+Model Evaluation and Debugging
+###############################
+
+
+
+There are two articles in this section:
+
+- `Model Evaluation <../evaluation_and_debugging/evaluation/metrics_en.html>`_：This section will introduce the construction of common metrics.
+
+- `Visual DL <../evaluation_and_debugging/debug/visualdl_en.html>`_：How to use Visual DL to visualise training process.
+
+..  toctree::
+    :hidden:
+
+    evaluation/metrics_en.rst
+    debug/visualdl_en.md

--- a/doc/fluid/user_guides/howto/prepare_data/index_en.rst
+++ b/doc/fluid/user_guides/howto/prepare_data/index_en.rst
@@ -1,0 +1,55 @@
+..  _user_guide_prepare_data_en:
+
+#############
+Prepare Data
+#############
+
+PaddlePaddle Fluid supports two methods to feed data into networks:
+
+1. Synchronous method - Python Reader：Firstly, use :code:`fluid.layers.data` to set up data input layer. Then, feed in the training data through :code:`executor.run(feed=...)` in :code:`fluid.Executor` or :code:`fluid.ParallelExecutor` .
+
+2. Asynchronous method - py_reader：Firstly, use :code:`fluid.layers.py_reader` to set up data input layer. Then configure the data source with functions :code:`decorate_paddle_reader` or :code:`decorate_tensor_provider` of :code:`py_reader` . After that, call :code:`fluid.layers.read_file` to read data.
+
+
+
+Comparisons of the two methods:
+
+=========================  ====================================================   ===============================================
+Aspects                                   Synchronous Python Reader                       Asynchronous py_reader
+=========================  ====================================================   ===============================================
+API interface                          :code:`executor.run(feed=...)`                 :code:`fluid.layers.py_reader`
+data type                                   Numpy Array                                Numpy Array or LoDTensor
+data augmentation          carried out by other libraries on Python end            carried out by other libraries on Python end 
+velocity                                        slow                                            rapid
+recommended applications                model debugging                                      industrial training
+=========================  ====================================================   ===============================================
+
+Synchronous Python Reader
+##########################
+
+Fluid provides Python Reader to feed in data.
+
+Python Reader is a pure Python-side interface, and data feeding is synchronized with the model training/prediction process. Users can pass in data through Numpy Array. For specific operations, please refer to:
+
+
+.. toctree::
+   :maxdepth: 1
+
+   feeding_data_en.rst
+
+Python Reader supports advanced functions like group batch, shuffle. For specific operations, please refer to：
+
+.. toctree::
+   :maxdepth: 1
+
+   reader.md
+
+Asynchronous py_reader
+########################
+
+Fluid provides asynchronous data feeding method PyReader. It is more efficient as data feeding is not synchronized with the model training/prediction process. For specific operations, please refer to：
+
+.. toctree::
+   :maxdepth: 1
+
+   use_py_reader_en.rst

--- a/doc/fluid/user_guides/howto/training/index_en.rst
+++ b/doc/fluid/user_guides/howto/training/index_en.rst
@@ -1,0 +1,12 @@
+######################
+Train Neural Networks
+######################
+
+PaddlePaddle Fluid supports both single-node training and multi-node training. A variety of training methods are supported for each training mode. This section contains the following sections:
+
+.. toctree::
+   :maxdepth: 1
+
+   single_node_en.rst
+   multi_node_en.rst
+   save_load_variables_en.rst

--- a/doc/fluid/user_guides/howto/training/multi_node_en.rst
+++ b/doc/fluid/user_guides/howto/training/multi_node_en.rst
@@ -1,0 +1,10 @@
+####################
+Multi-node Training
+####################
+
+.. toctree::
+   :maxdepth: 1
+
+   cluster_quick_start_en.rst
+   cluster_howto_en.rst
+   train_on_baidu_cloud_en.rst

--- a/doc/fluid/user_guides/index_en.rst
+++ b/doc/fluid/user_guides/index_en.rst
@@ -1,0 +1,33 @@
+###########
+User Guides
+###########
+
+..  todo::
+
+If you have got the hang of Beginner's Guide, and wish to model practical problems and build your original networks, this section will provide
+you with some detailed operations:
+
+
+    - `Basic Concepts <../user_guides/howto/basic_concept/index_en.html>`_ ：It explains basic concepts of Fluid.
+
+    - `Prepare Data <../user_guides/howto/prepare_data/index_en.html>`_ ：This section introduces data types supported and data transmission methods when you are training your networks with Fluid.
+
+    - `Set up Simple Model <../user_guides/howto/configure_simple_model/index_en.html>`_： This section illustrates how to model practical problems and build networks with related operators of Fluid.
+
+    - `Train Neural Networks <../user_guides/howto/training/index_en.html>`_：This section will guide you to perform single-node training, multi-node training, and save or load model variables.
+
+    - `Model Evaluation and Debugging <../user_guides/howto/evaluation_and_debugging/index_en.html>`_：It introduces the model evaluation and debugging methods in Fluid 
+
+Reproduced classic models of multiple directions in Fluid：
+
+    - `Fluid Model Library <../user_guides/models/index_en.html>`_
+
+..  toctree::
+    :hidden:
+
+    howto/basic_concept/index_en.rst
+    howto/prepare_data/index_en.rst
+    howto/configure_simple_model/index_en.rst
+    howto/training/index_en.rst
+    howto/evaluation_and_debugging/index_en.rst
+    models/model12_en.rst


### PR DESCRIPTION
# Add index for English version of User Guides
![image](https://user-images.githubusercontent.com/31058429/51978188-6b115a00-24c4-11e9-9b2c-8db567a31f3c.png)


## The first round of English version of User Guides (使用指南) has done 

**Note** the Fluid Model Library article is only for release/1.2,
whose file is stored in develop but only displayed on release/1.2.
The updated Fluid Model Library is pending ....

