### PR TITLE
Add directory  doc/fluid/api_guides_en

### DIFF
--- a/doc/fluid/api_guides_en/high_low_level_api_en.md
+++ b/doc/fluid/api_guides_en/high_low_level_api_en.md
@@ -1,0 +1,14 @@
+## Introduction to High/Low-level API
+
+Currently PaddlePaddle Fluid has 2 branches of API interfaces:
+
+- Low-level API:
+
+	- It is highly flexible and relatively mature. The model trained by it can directly support C++ inference deployment and release.
+	- There are a large number of models as examples, including all chapters in [book](https://github.com/PaddlePaddle/book), and [models](https://github.com/PaddlePaddle/models).
+	- Recommended for users who have a certain understanding of deep learning and need to customize a network for training/inference/online deployment.
+
+- High-level API:
+
+	- Simple to use
+    - Still under development. The interface is temporarily in [paddle.fluid.contrib](https://github.com/PaddlePaddle/Paddle/tree/develop/python/paddle/fluid/contrib).

--- a/doc/fluid/api_guides_en/index_en.rst
+++ b/doc/fluid/api_guides_en/index_en.rst
@@ -1,0 +1,20 @@
+===========
+API Guides
+===========
+
+This section introduces the Fluid API structure and usage, to help you quickly get the full picture of the PaddlePaddle Fluid API. This section is divided into the following modules:
+
+..  toctree::
+    :maxdepth: 1
+
+    high_low_level_api_en.md
+    low_level/layers/index_en.rst
+    low_level/executor_en.rst
+    low_level/optimizer_en.rst
+    low_level/metrics_en.rst
+    low_level/model_save_reader_en.rst
+    low_level/inference_en.rst
+    low_level/distributed/index_en.rst
+    low_level/memory_optimize_en.rst
+    low_level/nets_en.rst
+    low_level/parallel_executor_en.rst

--- a/doc/fluid/api_guides_en/low_level/distributed/index_en.rst
+++ b/doc/fluid/api_guides_en/low_level/distributed/index_en.rst
@@ -1,0 +1,14 @@
+====================
+Distributed Training
+====================
+
+..  toctree::
+    :maxdepth: 1
+
+    sync_training_en.rst
+    async_training_en.rst
+    cpu_train_best_practice_en.rst
+    large_scale_sparse_feature_training_en.rst
+    cluster_train_data_en.rst
+
+

--- a/doc/fluid/api_guides_en/low_level/layers/index_en.rst
+++ b/doc/fluid/api_guides_en/low_level/layers/index_en.rst
@@ -1,0 +1,21 @@
+=====================
+Neural Network Layer
+=====================
+
+..  toctree::
+    :maxdepth: 1
+
+    conv_en.rst
+    pooling_en.rst
+    detection_en.rst
+    sequence_en.rst
+    math_en.rst
+    activations_en.rst
+    loss_function_en.rst
+    data_in_out_en.rst
+    control_flow_en.rst
+    sparse_update_en.rst
+    data_feeder_en.rst
+    learning_rate_scheduler_en.rst
+    tensor_en.rst
+


### PR DESCRIPTION
# Add directory  doc/fluid/api_guides_en
- a temporary directory to hold all translation of "API使用指南" , this directory is not added to fluid/index_en.
- Add high_low_api.md and internal indices of *English "API使用指南"*