### PR TITLE
Fix array_read code example error.

### DIFF
--- a/doc/fluid/api_cn/layers_cn.rst
+++ b/doc/fluid/api_cn/layers_cn.rst
@@ -79,9 +79,9 @@ array_read
 
 .. code-block:: python
 
-    tmp = fluid.layers.zeros(shape=[10],dtype='int32')
+    array = fluid.layers.create_array(dtype='float32')
     i = fluid.layers.fill_constant(shape=[1],dtype='int64',value=10)
-    arr = layers.array_read(tmp,i=i)
+    item = fluid.layers.array_read(array, i)
 
 
 


### PR DESCRIPTION
Fix array read code example errors.
the new doc content as follows:

![image](https://user-images.githubusercontent.com/45989343/53715474-e2a02380-3e8c-11e9-9df6-135b0fac6ce8.png)

