### PR TITLE
update inference/build_and_install_lib

### DIFF
--- a/doc/fluid/advanced_usage/deploy/inference/build_and_install_lib_cn.rst
+++ b/doc/fluid/advanced_usage/deploy/inference/build_and_install_lib_cn.rst
@@ -7,15 +7,15 @@
 -------------
 
 ..  csv-table:: c++预测库列表
-    :header: "版本说明", "预测库(1.3版本)", "预测库(develop版本)"
+    :header: "版本说明", "预测库(1.4版本)", "预测库(develop版本)"
     :widths: 1, 3, 3
 
-    "cpu_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.3.0-cpu-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-mkl/fluid_inference.tgz>`_"
-    "cpu_avx_openblas", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.3.0-cpu-avx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-openblas/fluid_inference.tgz>`_"
-    "cpu_noavx_openblas","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.3.0-cpu-noavx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-noavx-openblas/fluid_inference.tgz>`_"
-    "cuda8.0_cudnn5_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.3.0-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_"
-    "cuda8.0_cudnn7_avx_mkl","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.3.0-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_"
-    "cuda9.0_cudnn7_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.3.0-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_"
+    "cpu_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-cpu-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-mkl/fluid_inference.tgz>`_"
+    "cpu_avx_openblas", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-cpu-avx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-openblas/fluid_inference.tgz>`_"
+    "cpu_noavx_openblas","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-cpu-noavx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-noavx-openblas/fluid_inference.tgz>`_"
+    "cuda8.0_cudnn5_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_"
+    "cuda8.0_cudnn7_avx_mkl","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_"
+    "cuda9.0_cudnn7_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_"
 
 
 从源码编译
@@ -27,8 +27,6 @@
 ============================  =========
 CMAKE_BUILD_TYPE              Release
 FLUID_INFERENCE_INSTALL_DIR   安装路径
-WITH_FLUID_ONLY               ON（推荐）
-WITH_SWIG_PY                  OFF（推荐）
 WITH_PYTHON                   OFF（推荐）
 ON_INFER                      ON（推荐）
 WITH_GPU                      ON/OFF
@@ -48,8 +46,6 @@ WITH_MKL                      ON/OFF
      cd build
      cmake -DFLUID_INFERENCE_INSTALL_DIR=$PADDLE_ROOT \
            -DCMAKE_BUILD_TYPE=Release \
-           -DWITH_FLUID_ONLY=ON \
-           -DWITH_SWIG_PY=OFF \
            -DWITH_PYTHON=OFF \
            -DWITH_MKL=OFF \
            -DWITH_GPU=OFF  \
@@ -71,6 +67,7 @@ WITH_MKL                      ON/OFF
      │   │   ├── paddle_analysis_config.h
      │   │   ├── paddle_api.h
      │   │   ├── paddle_inference_api.h
+     │   │   ├── paddle_mkldnn_quantizer_config.h
      │   │   └── paddle_pass_builder.h
      │   └── lib
      │       ├── libpaddle_fluid.a

--- a/doc/fluid/advanced_usage/deploy/inference/build_and_install_lib_en.rst
+++ b/doc/fluid/advanced_usage/deploy/inference/build_and_install_lib_en.rst
@@ -7,15 +7,15 @@ Direct Download and Installation
 ---------------------------------
 
 ..  csv-table:: c++ inference library list
-    :header: "version description", "inference library(1.2 version)", "inference library(develop version)"
+    :header: "version description", "inference library(1.4 version)", "inference library(develop version)"
     :widths: 1, 3, 3
 
-    "cpu_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.2.0-cpu-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-mkl/fluid_inference.tgz>`_"
-    "cpu_avx_openblas", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.2.0-cpu-avx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-openblas/fluid_inference.tgz>`_"
-    "cpu_noavx_openblas","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.2.0-cpu-noavx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-noavx-openblas/fluid_inference.tgz>`_"
-    "cuda8.0_cudnn5_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.2.0-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_"
-    "cuda8.0_cudnn7_avx_mkl","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.2.0-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_"
-    "cuda9.0_cudnn7_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.2.0-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_"
+    "cpu_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-cpu-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-mkl/fluid_inference.tgz>`_"
+    "cpu_avx_openblas", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-cpu-avx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-avx-openblas/fluid_inference.tgz>`_"
+    "cpu_noavx_openblas","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-cpu-noavx-openblas/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-cpu-noavx-openblas/fluid_inference.tgz>`_"
+    "cuda8.0_cudnn5_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn5-avx-mkl/fluid_inference.tgz>`_"
+    "cuda8.0_cudnn7_avx_mkl","`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda8-cudnn7-avx-mkl/fluid_inference.tgz>`_"
+    "cuda9.0_cudnn7_avx_mkl", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/1.4.0-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_", "`fluid_inference.tgz <https://paddle-inference-lib.bj.bcebos.com/latest-gpu-cuda9-cudnn7-avx-mkl/fluid_inference.tgz>`_"
 
 
 Build from Source Code
@@ -28,8 +28,6 @@ Option                        Value
 ============================  ======================
 CMAKE_BUILD_TYPE              Release
 FLUID_INFERENCE_INSTALL_DIR   Path of installation
-WITH_FLUID_ONLY               ON（recommended）
-WITH_SWIG_PY                  OFF（recommended）
 WITH_PYTHON                   OFF（recommended）
 ON_INFER                      ON（recommended）
 WITH_GPU                      ON/OFF
@@ -50,8 +48,6 @@ The following code snippet pulls the latest code from github and specifies the c
      cd build
      cmake -DFLUID_INFERENCE_INSTALL_DIR=$PADDLE_ROOT \
            -DCMAKE_BUILD_TYPE=Release \
-           -DWITH_FLUID_ONLY=ON \
-           -DWITH_SWIG_PY=OFF \
            -DWITH_PYTHON=OFF \
            -DWITH_MKL=OFF \
            -DWITH_GPU=OFF  \
@@ -74,6 +70,7 @@ The directory structure is:
      │   │   ├── paddle_analysis_config.h
      │   │   ├── paddle_api.h
      │   │   ├── paddle_inference_api.h
+     │   │   ├── paddle_mkldnn_quantizer_config.h
      │   │   └── paddle_pass_builder.h
      │   └── lib
      │       ├── libpaddle_fluid.a


### PR DESCRIPTION
- 更新预测库下载地址
- 去掉已失效的`WITH_FLUID_ONLY`和`WITH_SWIG_PY`
- 新增预测库头文件`paddle_mkldnn_quantizer_config.h`