### PR TITLE
添加了window源码编译的CMAKE命令的举例说明

### DIFF
--- a/doc/fluid/beginners_guide/install/compile/compile_Windows.md
+++ b/doc/fluid/beginners_guide/install/compile/compile_Windows.md
@@ -85,6 +85,14 @@
 			 -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
 			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 			 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}`
+	注意：上述命令中对应的参数应修改为你所在设备上的对应路径，以编译GPU版本的PaddlePaddle的python3版本为例，其中，
+	-DPY_VERSION 为python版本
+	-DPYTHON_INCLUDE_DIR 为对应版本python的include目录
+	-DPYTHON_LIBRARY 为对应版本python的lib目录
+	-DPYTHON_EXECUTABLE 为对应版本python的可执行程序的路径
+	-DCUDA_TOOLKIT_ROOT_DIR 为安装cuda的根目录
+	该命令应为：
+	cmake .. -G "Visual Studio 14 2015 Win64" -DPY_VERSION=3.6 -DPYTHON_INCLUDE_DIR=C:\\Python36\\include -DPYTHON_LIBRARY=C:\\Python36\\Lib -DPYTHON_EXECUTABLE=C:\\Python36\\python3.exe -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=D:\\cuda
 
 6. 部分第三方依赖包（openblas，snappystream）目前需要用户自己提供预编译版本，也可以到 `https://github.com/wopeizl/Paddle_deps` 下载预编译好的文件， 将整个 `third_party` 文件夹放到 `build` 目录下.
 

--- a/doc/fluid/beginners_guide/install/compile/compile_Windows.md
+++ b/doc/fluid/beginners_guide/install/compile/compile_Windows.md
@@ -85,14 +85,17 @@
 			 -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
 			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 			 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}`
-	注意：上述命令中对应的参数应修改为你所在设备上的对应路径，以编译GPU版本的PaddlePaddle的python3版本为例，其中，
+	注意：上述命令中对应的参数应修改为你所在设备上的对应路径，或者将它们加入环境变量中，以编译GPU版本的PaddlePaddle的python3版本为例，其中，
 	-DPY_VERSION 为python版本
 	-DPYTHON_INCLUDE_DIR 为对应版本python的include目录
 	-DPYTHON_LIBRARY 为对应版本python的lib目录
 	-DPYTHON_EXECUTABLE 为对应版本python的可执行程序的路径
 	-DCUDA_TOOLKIT_ROOT_DIR 为安装cuda的根目录
-	该命令应为：
+	将相关路径加入环境变量中后，命令为：
+	cmake .. -G "Visual Studio 14 2015 Win64" -DPY_VERSION=3.6 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release 
+	若设备上存在多个版本的python或cuda版本，或者没有将路径加入环境变量，应使用命令：
 	cmake .. -G "Visual Studio 14 2015 Win64" -DPY_VERSION=3.6 -DPYTHON_INCLUDE_DIR=C:\\Python36\\include -DPYTHON_LIBRARY=C:\\Python36\\Lib -DPYTHON_EXECUTABLE=C:\\Python36\\python3.exe -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=D:\\cuda
+	
 
 6. 部分第三方依赖包（openblas，snappystream）目前需要用户自己提供预编译版本，也可以到 `https://github.com/wopeizl/Paddle_deps` 下载预编译好的文件， 将整个 `third_party` 文件夹放到 `build` 目录下.
 


### PR DESCRIPTION
在compile_Windows.md文件中，添加了window源码编译的CMAKE命令的举例说明