### PR TITLE
add missed unique_name_cn index

### DIFF
--- a/doc/fluid/api_cn/index_cn.rst
+++ b/doc/fluid/api_cn/index_cn.rst
@@ -24,6 +24,7 @@ API
     profiler_cn.rst
     regularizer_cn.rst
     transpiler_cn.rst
+    unique_name_cn.rst
     data/dataset_cn.rst
     data/data_reader_cn.rst
 


### PR DESCRIPTION
**api_cn/index_cn missed unique_name_cn.rst  in the translation of 1.5**
and this pr is to recover this miss :) 