### PR TITLE
fix the building and installing doc of inference lib

### DIFF
--- a/doc/fluid/advanced_usage/deploy/inference/windows_cpp_inference.md
+++ b/doc/fluid/advanced_usage/deploy/inference/windows_cpp_inference.md
@@ -1,4 +1,3 @@
-.. _install_or_build_windows_inference_lib:
 
 安装与编译Windows预测库
 ===========================
@@ -23,36 +22,42 @@
 
 |选项                        |   值     |
 |:---------|:-------------------|
-|CMAKE_BUILD_TYPE             | Release   |
-|FLUID_INFERENCE_INSTALL_DIR  | 安装路径   |
-|WITH_PYTHON                  | OFF（推荐）|
+|CMAKE_BUILD_TYPE             | Release    |
+|FLUID_INFERENCE_INSTALL_DIR  | 安装路径(可选)  |
 |ON_INFER                     | ON（推荐） |
-|WITH_GPU                     | ON/OFF    | 
-|WITH_MKL                     | ON/OFF    |
+|WITH_PYTHON                  | ON         |
+|WITH_GPU                     | ON/OFF     | 
+|WITH_MKL                     | ON/OFF     |
 
 
 建议按照推荐值设置，以避免链接不必要的库。其它可选编译选项按需进行设定。
 
-下面的代码片段从github拉取最新代码，配制编译选项（需要将PADDLE_ROOT替换为PaddlePaddle预测库的安装路径）：
+Windows下安装与编译预测库步骤：(在Windows命令提示符下执行以下指令)
 
-  .. code-block:: 
+1. 设置预测库的安装路径，将path_to_paddle替换为PaddlePaddle预测库的安装路径：
 
-     PADDLE_ROOT=\path_to_paddle
-     git clone https://github.com/PaddlePaddle/Paddle.git
-     cd Paddle
-     mkdir build
-     cd build
-     cmake -DFLUID_INFERENCE_INSTALL_DIR=$PADDLE_ROOT \
-           -DCMAKE_BUILD_TYPE=Release \
-           -DWITH_PYTHON=OFF \
-           -DWITH_MKL=OFF \
-           -DWITH_GPU=OFF  \
-           -DON_INFER=ON \
-           ..
+     `PADDLE_ROOT=path_to_paddle`(不设置则使用默认路径)
 
-使用 vs2015 打开 paddle.sln 文件，选择 Release 编译即可。
+2. 将PaddlePaddle的源码clone在当下目录的Paddle文件夹中，并进入Paddle目录：
 
-成功编译后，使用C++预测库所需的依赖（包括：（1）编译出的PaddlePaddle预测库和头文件；（2）第三方链接库和头文件；（3）版本信息与编译选项信息）
+     - `git clone https://github.com/PaddlePaddle/Paddle.git`
+     - `cd Paddle`
+
+3. 创建名为build的目录并进入：
+
+     - `mkdir build`
+     - `cd build`
+
+4. 执行cmake：
+
+     - `cmake .. -G "Visual Studio 14 2015 Win 64" -DFLUID_INFERENCE_INSTALL_DIR=${PADDLE_ROOT} -DCMAKE_BUILD_TYPE=Release -DWITH_PYTHON=ON -DWITH_MKL=OFF -DWITH_GPU=OFF -DON_INFER=ON`
+     - `-DFLUID_INFERENCE_INSTALL_DIR=$PADDLE_ROOT`为可选配置选项，如未设置，则使用默认路径
+
+5. 从`https://github.com/wopeizl/Paddle_deps`下载预编译好的第三方依赖包（openblas, snappystream），将整个`third_party`文件夹复制到当前的`build`目录下.
+
+6. 使用Blend for Visual Studio 2015 打开 `paddle.sln` 文件，选择平台为`x64`，配置为`Release`，先编译third_party模块，再编译其他模块.   
+
+编译成功后，使用C++预测库所需的依赖（包括：（1）编译出的PaddlePaddle预测库和头文件；（2）第三方链接库和头文件；（3）版本信息与编译选项信息）
 均会存放于PADDLE_ROOT目录中。目录结构如下：
 
   .. code-block:: text

--- a/doc/fluid/beginners_guide/install/install_Windows.md
+++ b/doc/fluid/beginners_guide/install/install_Windows.md
@@ -19,6 +19,8 @@
     * *CUDA 工具包8.0/9.0配合cuDNN v7.3+*
     * *GPU运算能力超过1.0的硬件设备*
 
+注: Windows下仅支持 CUDA 8.0/9.0 的单卡模式，不支持 CUDA 9.1/9.2/10.0/10.1
+
 您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 ## 安装方式

--- a/doc/fluid/beginners_guide/install/install_Windows_en.md
+++ b/doc/fluid/beginners_guide/install/install_Windows_en.md
@@ -19,6 +19,8 @@
     * *CUDA Toolkit 8.0/9.0 with cuDNN v7.3+*
     * *GPU's computing capability exceeds 1.0*
 
+Notice: Windows only supports CUDA 8.0/9.0 with single GPU, while CUDA 9.1/9.2/10.0/10.1 is not currently supported
+
 Please refer to the NVIDIA official documents for the installation process and the configuration methods of [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/) and [cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/).
 
 ## Installation Method


### PR DESCRIPTION
Update the code of compilation of inference lib, the current bug is that most of files under the inference library path are missed. So the building and installing documentation should be updated.