### PR TITLE
fixed link error for install doc in develop

### DIFF
--- a/doc/fluid/beginners_guide/install/compile/compile_Ubuntu.md
+++ b/doc/fluid/beginners_guide/install/compile/compile_Ubuntu.md
@@ -122,7 +122,7 @@
 
 8. 执行cmake：
 
-	>具体编译选项含义请参见[编译选项表](/documentation/docs/zh/develop/beginners_guide/install/Tables.html/#Compile)
+	>具体编译选项含义请参见[编译选项表](../Tables.html/#Compile)
 
 	>请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本, 例如`-DPY_VERSION=3.5`表示python版本为3.5.x
 
@@ -215,7 +215,7 @@
 
 8. 执行cmake：
 
-	>具体编译选项含义请参见[编译选项表](/documentation/docs/zh/develop/beginners_guide/install/Tables.html/#Compile)
+	>具体编译选项含义请参见[编译选项表](../Tables.html/#Compile)
 
 	*  对于需要编译**CPU版本PaddlePaddle**的用户：
 

--- a/doc/fluid/beginners_guide/install/compile/compile_Ubuntu.md
+++ b/doc/fluid/beginners_guide/install/compile/compile_Ubuntu.md
@@ -122,7 +122,7 @@
 
 8. 执行cmake：
 
-	>具体编译选项含义请参见[编译选项表](../Tables.html/#Compile)
+	>具体编译选项含义请参见[编译选项表](/documentation/docs/zh/develop/beginners_guide/install/Tables.html/#Compile)
 
 	>请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本, 例如`-DPY_VERSION=3.5`表示python版本为3.5.x
 
@@ -215,7 +215,7 @@
 
 8. 执行cmake：
 
-	>具体编译选项含义请参见[编译选项表](../Tables.html/#Compile)
+	>具体编译选项含义请参见[编译选项表](/documentation/docs/zh/develop/beginners_guide/install/Tables.html/#Compile)
 
 	*  对于需要编译**CPU版本PaddlePaddle**的用户：
 

--- a/doc/fluid/beginners_guide/install/install_CentOS.md
+++ b/doc/fluid/beginners_guide/install/install_CentOS.md
@@ -42,8 +42,8 @@ CentOS系统下有4种安装方式：
 
 * pip安装（推荐）
 * [Docker安装](./install_Docker.html)
-* [源码编译安装](./compile/compile_CentOS.html/#ct_source)
-* [Docker源码编译安装](./compile/compile_CentOS.html/#ct_docker)
+* [源码编译安装](./compile/compile_CentOS.html#ct_source)
+* [Docker源码编译安装](./compile/compile_CentOS.html#ct_docker)
 
 这里为您介绍pip安装方式
 

--- a/doc/fluid/beginners_guide/install/install_MacOS.md
+++ b/doc/fluid/beginners_guide/install/install_MacOS.md
@@ -21,8 +21,8 @@ MacOS系统下有4种安装方式：
 
 * pip安装（推荐）
 * [Docker安装](./install_Docker.html)
-* [源码编译安装](./compile/compile_MacOS.html/#mac_source)
-* [Docker源码编译安装](./compile/compile_MacOS.html/#mac_docker)
+* [源码编译安装](./compile/compile_MacOS.html#mac_source)
+* [Docker源码编译安装](./compile/compile_MacOS.html#mac_docker)
 
 这里为您介绍pip安装方式
 

--- a/doc/fluid/beginners_guide/install/install_Ubuntu.md
+++ b/doc/fluid/beginners_guide/install/install_Ubuntu.md
@@ -43,8 +43,8 @@ Ubuntu系统下有4种安装方式：
 
 * pip安装（推荐）
 * [Docker安装](./install_Docker.html)
-* [源码编译安装](./compile/compile_Ubuntu.html/#ubt_source)
-* [Docker源码编译安装](./compile/compile_Ubuntu.html/#ubt_docker)
+* [源码编译安装](./compile/compile_Ubuntu.html#ubt_source)
+* [Docker源码编译安装](./compile/compile_Ubuntu.html#ubt_docker)
 
 这里为您介绍pip安装方式
 

--- a/doc/fluid/beginners_guide/install/install_Windows.md
+++ b/doc/fluid/beginners_guide/install/install_Windows.md
@@ -29,7 +29,7 @@ Windows系统下有3种安装方式：
 
 * pip安装（推荐）
 * [Docker安装](./install_Docker.html)
-* [源码编译安装](./compile/compile_Windows.html/#win_source)
+* [源码编译安装](./compile/compile_Windows.html#win_source)
 
 这里为您介绍pip安装方式
 


### PR DESCRIPTION
修复了https://www.paddlepaddle.org.cn/documentation/docs/zh/1.5/beginners_guide/install/compile/compile_Ubuntu.html/#ubt_source 链接中“编译选项表”死链的问题。
![image](https://user-images.githubusercontent.com/16509038/63014026-24afa580-bec0-11e9-8e62-2363d0dc37fa.png)