### PR TITLE
fix for install doc in release/1.5, test=release/1.5

### DIFF
--- a/doc/fluid/beginners_guide/install/index_cn.rst
+++ b/doc/fluid/beginners_guide/install/index_cn.rst
@@ -46,7 +46,7 @@
 
 * 需要安装 `CUDA <https://docs.nvidia.com/cuda/cuda-installation-guide-windows/>`_，根据您系统不同，对 CUDA 版本要求不同：
     * Windows 安装 GPU 版本
-        * Windows 7/8/10.0 支持 CUDA 8.0/9.0 单卡模式
+        * Windows 7/8/10 支持 CUDA 8.0/9.0 单卡模式
 		
         * 不支持 `nvidia-docker` 方式安装
 

--- a/doc/fluid/beginners_guide/install/index_cn.rst
+++ b/doc/fluid/beginners_guide/install/index_cn.rst
@@ -46,31 +46,31 @@
 
 * 需要安装 `CUDA <https://docs.nvidia.com/cuda/cuda-installation-guide-windows/>`_，根据您系统不同，对 CUDA 版本要求不同：
     * Windows 安装 GPU 版本
-        * Windows 7/8/10 支持 CUDA 8.0/9.0 单卡模式
+        * Windows 7/8/10 支持 CUDA 8.0/9.0 单卡模式，不支持 CUDA 9.1/9.2/10.0/10.1
 		
         * 不支持 `nvidia-docker` 方式安装
 
     * Ubuntu 安装 GPU 版本
-        * Ubuntu 14.04 支持 CUDA 8/10.0
+        * Ubuntu 14.04 支持 CUDA 8.0/10.0，不支持CUDA 9.0/9.1/9.2/10.1
 
-        * Ubuntu 16.04 支持 CUDA 8/9/10.0
+        * Ubuntu 16.04 支持 CUDA 8.0/9.0/9.1/9.2/10.0，不支持10.1
 
-        * Ubuntu 18.04 支持 CUDA 10.0
+        * Ubuntu 18.04 支持 CUDA 10.0，不支持CUDA 8.0/9.0/9.1/9.2/10.1
 
-        * 如果您是使用 `nvidia-docker` 安装，支持 CUDA 8/9/10.0
+        * 如果您是使用 `nvidia-docker` 安装，支持 CUDA 8.0/9.0/9.1/9.2/10.0，不支持10.1
 
     * CentOS 安装 GPU 版本
         * 如果您是使用本机 `pip` 安装：
-            * CentOS 7 支持 CUDA 9/10.0，支持 CUDA 8 但仅支持单卡模式
+            * CentOS 7 支持 CUDA 9.0/9.1/9.2/10.0，不支持10.1，支持 CUDA 8.0 但仅支持单卡模式
 
-            * CentOS 6 支持 CUDA 8/9 单卡模式
+            * CentOS 6 支持 CUDA 8.0/9.0/9.1/9.2 单卡模式，不支持10.0/10.1
 
         * 如果您是使用本机源码编译安装：
-            * CentOS 7 支持 CUDA 9/10.0
+            * CentOS 7 支持 CUDA 9.0/9.1/9.2/10.0
 
             * CentOS 6 不推荐，不提供编译出现问题时的官方支持
 		
-        * 如果您是使用 `nvidia-docker` 安装，在CentOS 7 下支持 CUDA 8/9/10.0。
+        * 如果您是使用 `nvidia-docker` 安装，在CentOS 7 下支持 CUDA 8.0/9.0/9.1/9.2/10.0，不支持10.1
 
     * MacOS 不支持：PaddlePaddle 在 MacOS 平台没有 GPU 支持
 
@@ -90,15 +90,32 @@
 3. 确认您需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
 
     如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
-    ::
+    
+        在 Windows 环境下，输出 Python 路径的命令为：
+        
+        ::
 
-        where python
+            where python
+
+        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+
+        ::
+
+            which python
 
     如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
 
-    ::
+        在 Windows 环境下，输出 Python 路径的命令为：
 
-        where python3
+        ::
+
+            where python3
+
+        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+
+        ::
+
+            which python3
 
 4. 检查 Python 的版本
 
@@ -117,12 +134,14 @@
     如果您是使用 Python 2
     ::
     
-        pip --version
+        python -m ensurepip 
+        python -m pip --version
 
     如果您是使用 Python 3
     ::
     
-        pip3 --version
+        python3 -m ensurepip
+        python3 -m pip --version
 
 6. 确认 Python 和 pip 是 64 bit，并且处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是 "64bit" ，第二行输出的是 "x86_64" 、 "x64" 或 "AMD64" 即可：
 
@@ -138,19 +157,19 @@
 
 7. 如果您希望使用 `pip <https://pypi.org/project/pip/>`_ 进行安装PaddlePaddle可以直接使用以下命令:
 
-    (1). **CPU版本**：如果您只是想安装CPU版本请参考如下命令安装  
+    (1). **CPU版本**：如果您只是想安装CPU版本请参考如下命令安装（使用清华源） 
 
         如果您是使用 Python 2，安装CPU版本的命令为：
         ::
     
-            pip install paddlepaddle
+            python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple
         
         如果您是使用 Python 3，安装CPU版本的命令为：
         ::
     
-            pip3 install paddlepaddle
+            python3 -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple
 
-    (2). **GPU版本**：如果您想使用GPU版本请参考如下命令安装 
+    (2). **GPU版本**：如果您想使用GPU版本请参考如下命令安装（使用清华源） 
 
         注意：
             * 需要您确认您的 GPU 满足上方列出的要求
@@ -158,27 +177,32 @@
         如果您是使用 Python2，请注意用以下指令安装的PaddlePaddle在Windows下默认支持CUDA9，Ubuntu、CentOS下默认支持CUDA10.0：
         ::
 
-            pip install paddlepaddle-gpu 
+            python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple
 
         如果您是使用 Python 2，CUDA 8，cuDNN 7.1+，安装GPU版本的命令为：
         ::
     
-            pip install paddlepaddle-gpu==1.5.1.post87
+            python -m pip install paddlepaddle-gpu==1.5.1.post87 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
         如果您是使用 Python 2，CUDA 9，cuDNN 7.3+，安装GPU版本的命令为：
         ::
     
-            pip install paddlepaddle-gpu==1.5.1.post97
-        
+            python -m pip install paddlepaddle-gpu==1.5.1.post97 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
         如果您是使用 Python 2，CUDA 10.0，cuDNN 7.3+，安装GPU版本的命令为：
         ::
     
-            pip install paddlepaddle-gpu==1.5.1.post107
+            python -m pip install paddlepaddle-gpu==1.5.1.post107 -i https://pypi.tuna.tsinghua.edu.cn/simple
         
-        如果您是使用 Python 3，请将上述命令中的 `pip` 更换为 `pip3` 进行安装。
+        如果您是使用 Python 3，请将上述命令中的 `python` 更换为 `python3` 进行安装。
 
-8. 更多帮助信息请参考：
+8. 验证安装
+
+    使用 python 或 python3 进入python解释器，输入import paddle.fluid ，再输入 paddle.fluid.install_check.run_check()。
+
+    如果出现 Your Paddle Fluid is installed succesfully!，说明您已成功安装。
+
+9. 更多帮助信息请参考：
     `Ubuntu下安装 <install_Ubuntu.html>`_
 
     `CentOS下安装 <install_Ubuntu.html>`_
@@ -199,36 +223,76 @@
 
 2. 需要您确认您的 处理器 满足上方列出的要求
 
-3. 如果您需要新建 conda 的虚拟环境专门给 Paddle 使用（--name后边的环境名称，您可以自己选择）：
+3. 对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源进行安装。
 
-    如果您是使用 Python2，
+    ::
+
+        conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
+        conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
+        conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+        conda config --set show_channel_urls yes
+
+4. 如果您需要新建 conda 的虚拟环境专门给 Paddle 使用（--name后边的环境名称，您可以自己选择）：
+
+    如果您是使用 Python2 并且在 Window 环境下
     
     ::
 
         conda create --name paddle python=2.7
         activate paddle
 
-    如果您是使用 Python3，注意：python3版本可以是3.5.1+/3.6/3.7
+    如果您是使用 Python2 并且在 MacOS/Linux 环境下
+
+    ::
+
+        conda create --name paddle python=2.7
+        conda activate paddle
+
+    如果您是使用 Python3 并且在 Window 环境下，注意：python3版本可以是3.5.1+/3.6/3.7
 
     ::
 
         conda create --name paddle python=3.7
         activate paddle
 
-4. 确认您需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python，进入 Anaconda 的命令行终端，输入以下指令确认 Python 位置
+    如果您是使用 Python3 并且在 MacOS/Linux 环境下，注意：python3版本可以是3.5.1+/3.6/3.7
 
-    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
     ::
 
-        where python
+        conda create --name paddle python=3.7
+        conda activate paddle
+
+5. 确认您需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python，进入 Anaconda 的命令行终端，输入以下指令确认 Python 位置
+
+    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+        
+        在 Windows 环境下，输出 Python 路径的命令为：
+        
+        ::
+
+            where python
+
+        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+
+        ::
+
+            which python
 
     如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
 
-    ::
+        在 Windows 环境下，输出 Python 路径的命令为：
+        
+        ::
 
-        where python3
+            where python3
 
-5. 检查 Python 的版本
+        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+
+        ::
+
+            which python3
+
+6. 检查 Python 的版本
 
     如果您是使用 Python 2，使用以下命令确认是 2.7.15+
     ::
@@ -240,19 +304,21 @@
     
         python3 --version
     
-6. 检查 pip 的版本，确认是 9.0.1+  
+7. 检查 pip 的版本，确认是 9.0.1+  
 
     如果您是使用 Python 2
     ::
     
-        pip --version
+        python -m ensurepip 
+        python -m pip --version
 
     如果您是使用 Python 3
     ::
     
-        pip3 --version
+        python3 -m ensurepip
+        python3 -m pip --version
 
-7. 确认 Python 和 pip 是 64 bit，并且处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是 "64bit" ，第二行输出的是 "x86_64" 、 "x64" 或 "AMD64" 即可：
+8. 确认 Python 和 pip 是 64 bit，并且处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是 "64bit" ，第二行输出的是 "x86_64" 、 "x64" 或 "AMD64" 即可：
 
     如果您是使用 Python 2
     ::
@@ -264,7 +330,7 @@
     
         python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
-8. 如果您希望使用 conda 进行安装PaddlePaddle可以直接使用以下命令:
+9. 如果您希望使用 conda 进行安装PaddlePaddle可以直接使用以下命令:
 
     (1). **CPU版本**：如果您只是想安装CPU版本请参考如下命令安装  
 
@@ -293,15 +359,15 @@
         ::
     
             conda install paddlepaddle-gpu cudatoolkit=10.0
-        
-9. 更多帮助信息请参考：
-    `Ubuntu下安装 <install_Ubuntu.html>`_
 
-    `CentOS下安装 <install_Ubuntu.html>`_
+10. 验证安装
 
-    `MacOS下安装 <install_Ubuntu.html>`_
+    使用 python 或 python3 进入python解释器，输入import paddle.fluid ，再输入 paddle.fluid.install_check.run_check()。
 
-    `Windows下安装 <install_Ubuntu.html>`_
+    如果出现 Your Paddle Fluid is installed succesfully!，说明您已成功安装。
+
+11. 更多帮助信息请参考：
+    `conda下安装 <install_Conda.html>`_
 
 
 第三种安装方式：使用 docker 安装
@@ -356,7 +422,7 @@
 
         * 需要安装 `CUDA <https://docs.nvidia.com/cuda/cuda-installation-guide-windows/>`_，根据您系统不同，对 CUDA 版本要求不同：
 
-            * Ubuntu/CentOS 7 ，如果您是使用 `nvidia-docker` 安装，支持 CUDA 8/9/10.0
+            * Ubuntu/CentOS 7 ，如果您是使用 `nvidia-docker` 安装，支持 CUDA 8.0/9.0/9.1/9.2/10.0
 
             * Windows/MacOS/CentOS 6 不支持 `nvidia-docker` 方式安装
 
@@ -394,7 +460,13 @@
 
         > paddlepaddle/paddle:1.5.1 是需要使用的image名称；/bin/bash是在Docker中要执行的命令
 
-4. 更多帮助信息请参考：`使用Docker安装 <install_Docker.html>`_。
+4. 验证安装
+
+    使用 python 或 python3 进入python解释器，输入import paddle.fluid ，再输入 paddle.fluid.install_check.run_check()。
+
+    如果出现 Your Paddle Fluid is installed succesfully!，说明您已成功安装。
+
+5. 更多帮助信息请参考：`使用Docker安装 <install_Docker.html>`_。
 	
 第四种安装方式：使用源代码编译安装
 ====================================

--- a/doc/fluid/beginners_guide/install/index_cn.rst
+++ b/doc/fluid/beginners_guide/install/index_cn.rst
@@ -16,7 +16,14 @@
 
 * 操作系统要求是 64 位版本
 
-2. Python 和 pip 版本要求：
+2. 处理器要求
+============================
+
+* 处理器支持 MKL
+
+* 处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构
+
+3. Python 和 pip 版本要求：
 ============================
 
 * Python 2 的版本要求 2.7.15+
@@ -27,19 +34,19 @@
 
 * Python 和 pip 要求是 64 位版本
 
-3. PaddlePaddle 对 GPU 支持情况：
+4. PaddlePaddle 对 GPU 支持情况：
 =================================
 
 * 目前 `PaddlePaddle` 仅支持 `NVIDIA` 显卡的 `CUDA` 驱动
 
-* 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.3+
+* 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.3+(For CUDA9/10), 7.1+(For CUDA 8)
 
 * 如果您需要 GPU 多卡模式，需要安装 `NCCL 2 <https://developer.nvidia.com/nccl/>`_
     * 仅 Ubuntu/CentOS 支持 NCCL 2 技术
 
 * 需要安装 `CUDA <https://docs.nvidia.com/cuda/cuda-installation-guide-windows/>`_，根据您系统不同，对 CUDA 版本要求不同：
     * Windows 安装 GPU 版本
-        * Windows 7/8/10.0 支持 CUDA 8/9 单卡模式
+        * Windows 7/8/10.0 支持 CUDA 8.0/9.0 单卡模式
 		
         * 不支持 `nvidia-docker` 方式安装
 
@@ -72,15 +79,28 @@
 第一种安装方式：使用 pip 安装
 ================================
 
-您可以选择“使用pip安装”、“使用docker安装”、“从源码编译安装” 三种方式中的任意一种方式进行安装。
+您可以选择“使用pip安装”、“使用conda安装”、“使用docker安装”、“从源码编译安装” 四种方式中的任意一种方式进行安装。
 
 本节将介绍使用 `pip` 的安装方式。
 
 1. 需要您确认您的 操作系统 满足上方列出的要求
 
-2. 处理器支持 MKL
+2. 需要您确认您的 处理器 满足上方列出的要求
 
-3. 检查 Python 的版本
+3. 确认您需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
+
+    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+    ::
+
+        where python
+
+    如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+    ::
+
+        where python3
+
+4. 检查 Python 的版本
 
     如果您是使用 Python 2，使用以下命令确认是 2.7.15+
     ::
@@ -92,7 +112,7 @@
     
         python3 --version
     
-4. 检查 pip 的版本，确认是 9.0.1+  
+5. 检查 pip 的版本，确认是 9.0.1+  
 
     如果您是使用 Python 2
     ::
@@ -104,22 +124,19 @@
     
         pip3 --version
 
-5. 确认 Python 和 pip 是 64 bit，下面的命令输出的是 "64bit" 即可：
+6. 确认 Python 和 pip 是 64 bit，并且处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是 "64bit" ，第二行输出的是 "x86_64" 、 "x64" 或 "AMD64" 即可：
 
     如果您是使用 Python 2
     ::
-    
-        python -c "import platform;print(platform.architecture()[0])"
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
     如果您是使用 Python 3
     ::
     
-        python3 -c "import platform;print(platform.architecture()[0])"
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
-6. 如果您希望使用 `pip <https://www.docker.com>`_ 进行安装PaddlePaddle可以直接使用以下命令:
-
-- 注意：目前官方没有对 `conda` 和 `anaconda` 进行支持，使用他们所附带的 `pip` 安装 `paddlepaddle` 也可能会带来冲突。所以建议使用纯净的 Python 环境的 `pip` 进行安装。
-
+7. 如果您希望使用 `pip <https://pypi.org/project/pip/>`_ 进行安装PaddlePaddle可以直接使用以下命令:
 
     (1). **CPU版本**：如果您只是想安装CPU版本请参考如下命令安装  
 
@@ -136,37 +153,14 @@
     (2). **GPU版本**：如果您想使用GPU版本请参考如下命令安装 
 
         注意：
-            * 您的计算机需要具有支持 `CUDA` 驱动的 `NVIDIA` 显卡
-
-            * 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.3+
-
-            * 如果您需要 GPU 多卡模式，需要安装 `NCCL 2 <https://developer.nvidia.com/nccl/>`_
-                * 仅 Ubuntu/CentOS 支持 NCCL 2 技术
-
-            * 需要安装 `CUDA <https://docs.nvidia.com/cuda/cuda-installation-guide-windows/>`_，根据您系统不同，对 CUDA 版本要求不同：
-                * Windows 7/8/10.0 支持 CUDA 8/9 单卡模式
-
-                * Ubuntu
-                    * Ubuntu 14.04 支持 CUDA 8/10.0
-
-                    * Ubuntu 16.04 支持 CUDA 8/9/10.0
-
-                    * Ubuntu 18.04 支持 CUDA 10.0
-
-             	* CentOS 
-                    * CentOS 7 支持 CUDA 9/10.0 ，CUDA 8 仅具有单卡模式支持
-
-                    * CentOS 6 支持 CUDA 8/9 单卡模式
-
-                * MacOS 不支持：PaddlePaddle 在 MacOS 平台没有 GPU 支持
-
+            * 需要您确认您的 GPU 满足上方列出的要求
 
         如果您是使用 Python2，请注意用以下指令安装的PaddlePaddle在Windows下默认支持CUDA9，Ubuntu、CentOS下默认支持CUDA10.0：
         ::
 
             pip install paddlepaddle-gpu 
 
-        如果您是使用 Python 2，CUDA 8，cuDNN 7.3+，安装GPU版本的命令为：
+        如果您是使用 Python 2，CUDA 8，cuDNN 7.1+，安装GPU版本的命令为：
         ::
     
             pip install paddlepaddle-gpu==1.5.1.post87
@@ -184,7 +178,7 @@
         
         如果您是使用 Python 3，请将上述命令中的 `pip` 更换为 `pip3` 进行安装。
 
-7. 更多帮助信息请参考：
+8. 更多帮助信息请参考：
     `Ubuntu下安装 <install_Ubuntu.html>`_
 
     `CentOS下安装 <install_Ubuntu.html>`_
@@ -194,10 +188,126 @@
     `Windows下安装 <install_Ubuntu.html>`_
 
 
-第二种安装方式：使用 docker 安装
+第二种安装方式：使用 conda 安装
 ================================
 
-您可以选择“使用pip安装”、“使用docker安装”、“从源码编译安装” 三种方式中的任意一种方式进行安装。
+您可以选择“使用pip安装”、“使用conda安装”、“使用docker安装”、“从源码编译安装” 四种方式中的任意一种方式进行安装。
+
+本节将介绍使用 `conda` 的安装方式。
+
+1. 需要您确认您的 操作系统 满足上方列出的要求
+
+2. 需要您确认您的 处理器 满足上方列出的要求
+
+3. 如果您需要新建 conda 的虚拟环境专门给 Paddle 使用（--name后边的环境名称，您可以自己选择）：
+
+    如果您是使用 Python2，
+    
+    ::
+
+        conda create --name paddle python=2.7
+        activate paddle
+
+    如果您是使用 Python3，注意：python3版本可以是3.5.1+/3.6/3.7
+
+    ::
+
+        conda create --name paddle python=3.7
+        activate paddle
+
+4. 确认您需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python，进入 Anaconda 的命令行终端，输入以下指令确认 Python 位置
+
+    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+    ::
+
+        where python
+
+    如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+    ::
+
+        where python3
+
+5. 检查 Python 的版本
+
+    如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+    ::
+    
+        python --version
+
+    如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+    ::
+    
+        python3 --version
+    
+6. 检查 pip 的版本，确认是 9.0.1+  
+
+    如果您是使用 Python 2
+    ::
+    
+        pip --version
+
+    如果您是使用 Python 3
+    ::
+    
+        pip3 --version
+
+7. 确认 Python 和 pip 是 64 bit，并且处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是 "64bit" ，第二行输出的是 "x86_64" 、 "x64" 或 "AMD64" 即可：
+
+    如果您是使用 Python 2
+    ::
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+    如果您是使用 Python 3
+    ::
+    
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+8. 如果您希望使用 conda 进行安装PaddlePaddle可以直接使用以下命令:
+
+    (1). **CPU版本**：如果您只是想安装CPU版本请参考如下命令安装  
+
+    ::
+
+        conda install paddlepaddle
+    
+
+    (2). **GPU版本**：如果您想使用GPU版本请参考如下命令安装 
+
+        注意：
+            * 需要您确认您的 GPU 满足上方列出的要求
+
+        如果您是使用 CUDA 8，cuDNN 7.1+，安装GPU版本的命令为：
+        ::
+    
+            conda install paddlepaddle-gpu cudatoolkit=8.0
+
+        如果您是使用 CUDA 9，cuDNN 7.3+，安装GPU版本的命令为：
+        ::
+    
+            conda install paddlepaddle-gpu cudatoolkit=9.0
+        
+
+        如果您是使用 CUDA 10.0，cuDNN 7.3+，安装GPU版本的命令为：
+        ::
+    
+            conda install paddlepaddle-gpu cudatoolkit=10.0
+        
+9. 更多帮助信息请参考：
+    `Ubuntu下安装 <install_Ubuntu.html>`_
+
+    `CentOS下安装 <install_Ubuntu.html>`_
+
+    `MacOS下安装 <install_Ubuntu.html>`_
+
+    `Windows下安装 <install_Ubuntu.html>`_
+
+
+第三种安装方式：使用 docker 安装
+================================
+
+您可以选择“使用pip安装”、“使用conda安装”、“使用docker安装”、“从源码编译安装” 四种方式中的任意一种方式进行安装。
 
 本节将介绍使用 `docker` 的安装方式。
 
@@ -239,7 +349,7 @@
 
         * 您的计算机需要具有支持 `CUDA` 驱动的 `NVIDIA` 显卡
 
-        * 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.3+
+        * 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.3+(For CUDA9/10), 7.1+(For CUDA 8)
 
         * 如果您需要 GPU 多卡模式，需要安装 `NCCL 2 <https://developer.nvidia.com/nccl/>`_
             * 仅 Ubuntu/CentOS 支持 NCCL 2 技术
@@ -269,7 +379,7 @@
 
         > hub.baidubce.com/paddlepaddle/paddle:1.5.1-gpu-cuda10.0-cudnn7 是需要使用的image名称；/bin/bash是在Docker中要执行的命令  
 
-    或如果您需要支持 `CUDA 8` 或者 `CUDA 9` 的版本，将上述命令的 `cuda10.0` 替换成 `cuda8.0` 或者 `cuda9.0` 即可，cuDNN 仅支持 `cuDNN 7.3+`
+    或如果您需要支持 `CUDA 8` 或者 `CUDA 9` 的版本，将上述命令的 `cuda10.0` 替换成 `cuda8.0` 或者 `cuda9.0` 即可
 
 3. 如果您的机器不在中国大陆地区，可以直接从DockerHub拉取镜像：
     ::
@@ -286,10 +396,10 @@
 
 4. 更多帮助信息请参考：`使用Docker安装 <install_Docker.html>`_。
 	
-第三种安装方式：使用源代码编译安装
+第四种安装方式：使用源代码编译安装
 ====================================
 
-- 如果您只是使用 `PaddlePaddle` ，建议从 `pip` 和 `docker` 两种安装方式中选取一种进行安装即可。
+- 如果您只是使用 `PaddlePaddle` ，建议从 `pip` 和 `conda` 、 `docker` 三种安装方式中选取一种进行安装即可。
 - 如果您有开发PaddlePaddle的需求，请参考：`从源码编译 <compile/fromsource.html>`_
 
 ..	toctree::
@@ -299,6 +409,7 @@
 	install_CentOS.md
 	install_MacOS.md
 	install_Windows.md
+	install_Conda.md
 	install_Docker.md
 	compile/fromsource.rst
 	Tables.md

--- a/doc/fluid/beginners_guide/install/install_CentOS.md
+++ b/doc/fluid/beginners_guide/install/install_CentOS.md
@@ -29,7 +29,7 @@
 
     * 如果您是使用 Python 3
 
-       pip3 --version
+        pip3 --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 

--- a/doc/fluid/beginners_guide/install/install_CentOS.md
+++ b/doc/fluid/beginners_guide/install/install_CentOS.md
@@ -3,14 +3,24 @@
 ## 环境准备
 
 * *CentOS 版本 (64 bit)*
-    * *CentOS 6 (GPU版本支持CUDA 8/9, 仅支持单卡)*
-    * *CentOS 7 (GPU版本支持CUDA 9/10.0, 其中CUDA 8仅支持单卡)*
+    * *CentOS 6 (GPU版本支持CUDA 8.0/9.0/9.1/9.2, 仅支持单卡)*
+    * *CentOS 7 (GPU版本支持CUDA 9.0/9.1/9.2/10.0, 其中CUDA 8.0仅支持单卡)*
 * *Python 版本 2.7.15+/3.5.1+/3.6/3.7 (64 bit)*
 * *pip 或 pip3 版本 9.0.1+ (64 bit)*
 
 ### 注意事项
 
 * 可以使用`uname -m && cat /etc/*release`查看本机的操作系统和位数信息
+* 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
+
+    * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+
+        which python
+
+    * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+        which python3 
+
 * 需要确认python的版本是否满足要求
 
     * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
@@ -25,11 +35,15 @@
 
     * 如果您是使用 Python 2 
 
-        pip --version
+        python -m ensurepip
+
+        python -m pip --version
 
     * 如果您是使用 Python 3
 
-        pip3 --version
+        python3 -m ensurepip
+
+        python3 -m pip --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
@@ -80,17 +94,17 @@ CentOS系统下有5种安装方式：
 
 ## 安装步骤
 
-* CPU版PaddlePaddle：`pip install -U paddlepaddle` 或 `pip3 install -U paddlepaddle`
-* GPU版PaddlePaddle：`pip install -U paddlepaddle-gpu` 或 `pip3 install  -U paddlepaddle-gpu`
+* CPU版PaddlePaddle：`python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
+* GPU版PaddlePaddle：`python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
 
 注：
 
-* pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
+* 如果是python2.7, 建议使用`python`命令; 如果是python3.x, 则建议使用`python3`命令
 
 
-* `pip install -U paddlepaddle-gpu` 此命令将安装支持CUDA 10.0 cuDNN v7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
+* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 10.0 cuDNN v7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`或 `python3 -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
 
 
 * 默认下载最新稳定版的安装包，如需获取开发版安装包，请参考[这里](./Tables.html/#ciwhls)
@@ -105,6 +119,6 @@ CentOS系统下有5种安装方式：
 ## ***如何卸载***
 请使用以下命令卸载PaddlePaddle：
 
-* ***CPU版本的PaddlePaddle***: `pip uninstall paddlepaddle` 或 `pip3 uninstall paddlepaddle`
+* ***CPU版本的PaddlePaddle***: `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`
 
-* ***GPU版本的PaddlePaddle***: `pip uninstall paddlepaddle-gpu` 或 `pip3 uninstall paddlepaddle-gpu`
+* ***GPU版本的PaddlePaddle***: `python -m pip uninstall paddlepaddle-gpu` 或 `python3 -m pip uninstall paddlepaddle-gpu`

--- a/doc/fluid/beginners_guide/install/install_CentOS.md
+++ b/doc/fluid/beginners_guide/install/install_CentOS.md
@@ -3,15 +3,45 @@
 ## 环境准备
 
 * *CentOS 版本 (64 bit)*
-    * *CentOS 6 (GPU版本支持CUDA 9/10.0, 仅支持单卡)*
-    * *CentOS 7 (GPU版本支持CUDA 8/9/10.0, 其中CUDA 8仅支持单卡)*
+    * *CentOS 6 (GPU版本支持CUDA 8/9, 仅支持单卡)*
+    * *CentOS 7 (GPU版本支持CUDA 9/10.0, 其中CUDA 8仅支持单卡)*
 * *Python 版本 2.7.15+/3.5.1+/3.6/3.7 (64 bit)*
 * *pip 或 pip3 版本 9.0.1+ (64 bit)*
 
 ### 注意事项
 
 * 可以使用`uname -m && cat /etc/*release`查看本机的操作系统和位数信息
-* 可以使用`pip -V`(Python版本为2.7)或`pip3 -V`(Python版本为3.5/3.6/3.7)，确认pip/pip3版本是否满足要求
+* 需要确认python的版本是否满足要求
+
+    * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+
+        python --version
+
+    * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+
+        python3 --version
+
+* 需要确认pip的版本是否满足要求，要求pip版本为9.0.1+
+
+    * 如果您是使用 Python 2 
+
+        pip --version
+
+    * 如果您是使用 Python 3
+
+       pip3 --version
+
+* 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
+
+    * 如果您是使用 Python 2
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+    * 如果您是使用 Python 3
+    
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+* 默认提供的安装包需要计算机支持MKL
 * 如果您对机器环境不了解，请下载使用[快速安装脚本](https://fast-install.bj.bcebos.com/fast_install.sh)，配套说明请参考[这里](https://github.com/PaddlePaddle/FluidDoc/tree/develop/doc/fluid/beginners_guide/install/install_script.md)。
 
 ## 选择CPU/GPU
@@ -22,7 +52,7 @@
 	
 	* *CUDA 工具包10.0配合cuDNN v7.3+(如需多卡支持，需配合NCCL2.3.7及更高)*
 	* *CUDA 工具包9.0配合cuDNN v7.3+(如需多卡支持，需配合NCCL2.3.7及更高)*
-	* *CUDA 工具包8.0配合cuDNN v7.3+(官方不支持多卡）*
+	* *CUDA 工具包8.0配合cuDNN v7.1+(官方不支持多卡）*
 	* *GPU运算能力超过1.0的硬件设备*
 
 		您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
@@ -38,9 +68,10 @@
 
 ## 安装方式
 
-CentOS系统下有4种安装方式：
+CentOS系统下有5种安装方式：
 
 * pip安装（推荐）
+* [conda安装](./install_Conda.html)
 * [Docker安装](./install_Docker.html)
 * [源码编译安装](./compile/compile_CentOS.html#ct_source)
 * [Docker源码编译安装](./compile/compile_CentOS.html#ct_docker)

--- a/doc/fluid/beginners_guide/install/install_Conda.md
+++ b/doc/fluid/beginners_guide/install/install_Conda.md
@@ -12,7 +12,7 @@
 
     首先根据具体的Python版本创建Anaconda虚拟环境，前PaddlePaddle的Anaconda安装支持以下四种Python安装环境。
 
-    例如您想使用的python版本为2.7:
+    如果您想使用的python版本为2.7:
 
         conda create -n paddle_env python=2.7
 
@@ -28,17 +28,29 @@
 
         conda create -n paddle_env python=3.7
 
-    使用conda activate paddle_env命令进入Anaconda虚拟环境。
+    activate paddle_env (for Windows) 或 conda activate paddle_env (for MacOS/Linux) 命令进入Anaconda虚拟环境。
 
 2. 确认您的conda虚拟环境和需要安装PaddlePaddle的Python是您预期的位置，因为您计算机可能有多个Python。进入Anaconda的命令行终端，输入以下指令确认Python位置。
 
     如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
 
-        where python
+        在 Windows 环境下，输出 Python 路径的命令为：
+        
+            where python
+
+        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+
+            which python
 
     如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
 
-        where python3 
+        在 Windows 环境下，输出 Python 路径的命令为：
+        
+            where python3
+
+        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+
+            which python3
 
 3. 检查Python的版本
 
@@ -50,7 +62,7 @@
     
         python3 --version
 
-4. 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"即可：
+4. 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64（或x64、AMD64）"即可：
 
     如果您是使用 Python 2
 

--- a/doc/fluid/beginners_guide/install/install_Conda.md
+++ b/doc/fluid/beginners_guide/install/install_Conda.md
@@ -1,0 +1,94 @@
+# **使用conda安装**
+
+[Anaconda](https://www.anaconda.com/)是一个免费开源的Python和R语言的发行版本，用于计算科学，Anaconda致力于简化包管理和部署。Anaconda的包使用软件包管理系统Conda进行管理。Conda是一个开源包管理系统和环境管理系统，可在Windows、macOS和Linux上运行。
+
+## 环境准备
+
+在进行PaddlePaddle安装之前请确保您的Anaconda软件环境已经正确安装。软件下载和安装参见Anaconda官网(https://www.anaconda.com/)。在您已经正确安装Anaconda的情况下请按照下列步骤安装PaddlePaddle。
+
+## 安装步骤
+
+1. 创建虚拟环境
+
+    首先根据具体的Python版本创建Anaconda虚拟环境，前PaddlePaddle的Anaconda安装支持以下四种Python安装环境。
+
+    例如您想使用的python版本为2.7:
+
+        conda create -n paddle_env python=2.7
+
+    如果您想使用的python版本为3.5:
+
+        conda create -n paddle_env python=3.5
+
+    如果您想使用的python版本为3.6:
+
+        conda create -n paddle_env python=3.6
+
+    如果您想使用的python版本为3.7:
+
+        conda create -n paddle_env python=3.7
+
+    使用conda activate paddle_env命令进入Anaconda虚拟环境。
+
+2. 确认您的conda虚拟环境和需要安装PaddlePaddle的Python是您预期的位置，因为您计算机可能有多个Python。进入Anaconda的命令行终端，输入以下指令确认Python位置。
+
+    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+
+        where python
+
+    如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+        where python3 
+
+3. 检查Python的版本
+
+    如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+    
+        python --version
+
+    如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+    
+        python3 --version
+
+4. 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"即可：
+
+    如果您是使用 Python 2
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+    如果您是使用 Python 3
+    
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+5. 安装PaddlePaddle
+
+    (1). **CPU版本**：如果您只是想安装CPU版本请参考如下命令安装
+
+        conda install paddlepaddle
+
+    (2). **GPU版本**：如果您想使用GPU版本请参考如下命令安装 
+
+        如果您是使用 CUDA 8，cuDNN 7.1+，安装GPU版本的命令为：
+    
+            conda install paddlepaddle-gpu cudatoolkit=8.0
+
+        如果您是使用 CUDA 9，cuDNN 7.3+，安装GPU版本的命令为：
+    
+            conda install paddlepaddle-gpu cudatoolkit=9.0
+        
+        如果您是使用 CUDA 10.0，cuDNN 7.3+，安装GPU版本的命令为：
+    
+            conda install paddlepaddle-gpu cudatoolkit=10.0
+
+6. 安装环境验证
+
+    使用python进入python解释器，输入import paddle.fluid，再输入 paddle.fluid.install_check.run_check()。如果出现“Your Paddle Fluid is installed succesfully!”，说明您已成功安装。
+
+## 注意
+
+对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源进行安装。
+
+    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
+    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
+    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+    conda config --set show_channel_urls yes

--- a/doc/fluid/beginners_guide/install/install_MacOS.md
+++ b/doc/fluid/beginners_guide/install/install_MacOS.md
@@ -8,6 +8,16 @@
 
 ### 注意事项
 
+* 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
+
+    * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+
+        which python
+
+    * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+        which python3 
+
 * 需要确认python的版本是否满足要求
 
     * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
@@ -22,11 +32,15 @@
 
     * 如果您是使用 Python 2 
 
-        pip --version
+        python -m ensurepip
+
+        python -m pip --version
 
     * 如果您是使用 Python 3
 
-        pip3 --version
+        python3 -m ensurepip
+
+        python3 -m pip --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
@@ -58,14 +72,14 @@ MacOS系统下有5种安装方式：
 
 ## 安装步骤
 
-* CPU版PaddlePaddle：`pip install -U paddlepaddle` 或 `pip3 install -U  paddlepaddle`
+* CPU版PaddlePaddle：`python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
 
 注：
 
 * MacOS上您需要安装unrar以支持PaddlePaddle，可以使用命令`brew install unrar`
-* pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
+* 如果是python2.7, 建议使用`python`命令; 如果是python3.x, 则建议使用`python3`命令
 
 
 * 默认下载最新稳定版的安装包，如需获取开发版安装包，请参考[这里](./Tables.html/#ciwhls)
@@ -84,4 +98,4 @@ MacOS系统下有5种安装方式：
 
 请使用以下命令卸载PaddlePaddle：
 
-* `pip uninstall paddlepaddle` 或 `pip3 uninstall paddlepaddle`
+* `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`

--- a/doc/fluid/beginners_guide/install/install_MacOS.md
+++ b/doc/fluid/beginners_guide/install/install_MacOS.md
@@ -26,7 +26,7 @@
 
     * 如果您是使用 Python 3
 
-       pip3 --version
+        pip3 --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 

--- a/doc/fluid/beginners_guide/install/install_MacOS.md
+++ b/doc/fluid/beginners_guide/install/install_MacOS.md
@@ -8,8 +8,37 @@
 
 ### 注意事项
 
-* 可以使用`pip -V`(Python版本为2.7)或`pip3 -V`(Python版本为3.5/3.6/3.7)，确认pip/pip3版本是否满足要求
-* 默认提供的安装包需要计算机支持AVX指令集和MKL
+* 需要确认python的版本是否满足要求
+
+    * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+
+        python --version
+
+    * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+
+        python3 --version
+
+* 需要确认pip的版本是否满足要求，要求pip版本为9.0.1+
+
+    * 如果您是使用 Python 2 
+
+        pip --version
+
+    * 如果您是使用 Python 3
+
+       pip3 --version
+
+* 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
+
+    * 如果您是使用 Python 2
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+    * 如果您是使用 Python 3
+    
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+* 默认提供的安装包需要计算机支持MKL
 
 ## 选择CPU/GPU
 
@@ -17,9 +46,10 @@
 
 ## 安装方式
 
-MacOS系统下有4种安装方式：
+MacOS系统下有5种安装方式：
 
 * pip安装（推荐）
+* [conda安装](./install_Conda.html)
 * [Docker安装](./install_Docker.html)
 * [源码编译安装](./compile/compile_MacOS.html#mac_source)
 * [Docker源码编译安装](./compile/compile_MacOS.html#mac_docker)
@@ -34,8 +64,13 @@ MacOS系统下有4种安装方式：
 
 注：
 
+* MacOS上您需要安装unrar以支持PaddlePaddle，可以使用命令`brew install unrar`
 * pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
+
+
 * 默认下载最新稳定版的安装包，如需获取开发版安装包，请参考[这里](./Tables.html/#ciwhls)
+
+
 * 使用MacOS中自带Python可能会导致安装失败。对于**Python2**，建议您使用[Homebrew](https://brew.sh)或[Python.org](https://www.python.org/ftp/python/2.7.15/python-2.7.15-macosx10.9.pkg)提供的python2.7.15；对于**Python3**，请使用[Python.org](https://www.python.org/downloads/mac-osx/)提供的python3.5.x、python3.6.x或python3.7.x。
 
 <a name="check"></a>

--- a/doc/fluid/beginners_guide/install/install_Ubuntu.md
+++ b/doc/fluid/beginners_guide/install/install_Ubuntu.md
@@ -3,8 +3,8 @@
 ## 环境准备
 
 * *Ubuntu 版本 (64 bit)*
-    * *Ubuntu 14.04 (GPU 版本支持 CUDA 8/10.0)*
-    * *Ubuntu 16.04 (GPU 版本支持 CUDA 8/9/10.0)*
+    * *Ubuntu 14.04 (GPU 版本支持 CUDA 8.0/10.0)*
+    * *Ubuntu 16.04 (GPU 版本支持 CUDA 8.0/9.0/9.1/9.2/10.0)*
     * *Ubuntu 18.04 (GPU 版本支持 CUDA 10.0)*
 * *Python 版本 2.7.15+/3.5.1+/3.6/3.7 (64 bit)*
 * *pip或pip3 版本 9.0.1+ (64 bit)*
@@ -12,6 +12,16 @@
 ### 注意事项
 
 * 可以使用`uname -m && cat /etc/*release`查看本机的操作系统和位数信息
+* 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
+
+    * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+
+        which python
+
+    * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+        which python3 
+
 * 需要确认python的版本是否满足要求
 
     * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
@@ -26,11 +36,15 @@
 
     * 如果您是使用 Python 2 
 
-        pip --version
+        python -m ensurepip
+
+        python -m pip --version
 
     * 如果您是使用 Python 3
 
-        pip3 --version
+        python3 -m ensurepip
+
+        python3 -m pip --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
@@ -81,19 +95,19 @@ Ubuntu系统下有5种安装方式：
 
 ## 安装步骤
 
-* CPU版PaddlePaddle：`pip install -U paddlepaddle` 或 `pip3 install -U paddlepaddle`
+* CPU版PaddlePaddle：`python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 
-* GPU版PaddlePaddle：`pip install -U paddlepaddle-gpu` 或 `pip3 install   -U paddlepaddle-gpu`
+* GPU版PaddlePaddle：`python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
 
 注：
 
-* pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
+* 如果是python2.7, 建议使用`python`命令; 如果是python3.x, 则建议使用`python3`命令
 
 
-* `pip install -U paddlepaddle-gpu` 此命令将安装支持CUDA 10.0 cuDNN v7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history)，关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
+* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 10.0 cuDNN v7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`或 `python3 -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history)，关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
 
 
 * 默认下载最新稳定版的安装包，如需获取开发版安装包，请参考[这里](./Tables.html/#ciwhls)
@@ -108,6 +122,6 @@ Ubuntu系统下有5种安装方式：
 ## 如何卸载
 请使用以下命令卸载PaddlePaddle：
 
-* ***CPU版本的PaddlePaddle***: `pip uninstall paddlepaddle` 或 `pip3 uninstall paddlepaddle`
+* ***CPU版本的PaddlePaddle***: `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`
 
-* ***GPU版本的PaddlePaddle***: `pip uninstall paddlepaddle-gpu` 或 `pip3 uninstall paddlepaddle-gpu`
+* ***GPU版本的PaddlePaddle***: `python -m pip uninstall paddlepaddle-gpu` 或 `python3 -m pip uninstall paddlepaddle-gpu`

--- a/doc/fluid/beginners_guide/install/install_Ubuntu.md
+++ b/doc/fluid/beginners_guide/install/install_Ubuntu.md
@@ -12,7 +12,37 @@
 ### 注意事项
 
 * 可以使用`uname -m && cat /etc/*release`查看本机的操作系统和位数信息
-* 可以使用`pip -V`(Python版本为2.7)或`pip3 -V`(Python版本为3.5/3.6/3.7)，确认pip/pip3版本是否满足要求
+* 需要确认python的版本是否满足要求
+
+    * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+
+        python --version
+
+    * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+
+        python3 --version
+
+* 需要确认pip的版本是否满足要求，要求pip版本为9.0.1+
+
+    * 如果您是使用 Python 2 
+
+        pip --version
+
+    * 如果您是使用 Python 3
+
+       pip3 --version
+
+* 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
+
+    * 如果您是使用 Python 2
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+    * 如果您是使用 Python 3
+    
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+* 默认提供的安装包需要计算机支持MKL
 * 如果您对机器环境不了解，请下载使用[快速安装脚本](https://fast-install.bj.bcebos.com/fast_install.sh)，配套说明请参考[这里](https://github.com/PaddlePaddle/FluidDoc/tree/develop/doc/fluid/beginners_guide/install/install_script.md)。
 
 ## 选择CPU/GPU
@@ -22,7 +52,7 @@
 * 如果您的计算机有 NVIDIA® GPU，并且满足以下条件，推荐安装GPU版的PaddlePaddle
 	* *CUDA 工具包10.0配合cuDNN v7.3+(如需多卡支持，需配合NCCL2.3.7及更高)*
 	* *CUDA 工具包9.0配合cuDNN v7.3+(如需多卡支持，需配合NCCL2.3.7及更高)*
-	* *CUDA 工具包8.0配合cuDNN v7.3+(如需多卡支持，需配合NCCL2.1.15-2.2.13）*
+	* *CUDA 工具包8.0配合cuDNN v7.1+(如需多卡支持，需配合NCCL2.1.15-2.2.13）*
 	* *GPU运算能力超过1.0的硬件设备*
 
 
@@ -39,9 +69,10 @@
 
 ## 安装方式
 
-Ubuntu系统下有4种安装方式：
+Ubuntu系统下有5种安装方式：
 
 * pip安装（推荐）
+* [conda安装](./install_Conda.html)
 * [Docker安装](./install_Docker.html)
 * [源码编译安装](./compile/compile_Ubuntu.html#ubt_source)
 * [Docker源码编译安装](./compile/compile_Ubuntu.html#ubt_docker)
@@ -51,6 +82,8 @@ Ubuntu系统下有4种安装方式：
 ## 安装步骤
 
 * CPU版PaddlePaddle：`pip install -U paddlepaddle` 或 `pip3 install -U paddlepaddle`
+
+
 * GPU版PaddlePaddle：`pip install -U paddlepaddle-gpu` 或 `pip3 install   -U paddlepaddle-gpu`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
@@ -60,7 +93,7 @@ Ubuntu系统下有4种安装方式：
 * pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
 
 
-* `pip install -U paddlepaddle-gpu` 此命令将安装支持CUDA 10.0 cuDNN v7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
+* `pip install -U paddlepaddle-gpu` 此命令将安装支持CUDA 10.0 cuDNN v7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history)，关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
 
 
 * 默认下载最新稳定版的安装包，如需获取开发版安装包，请参考[这里](./Tables.html/#ciwhls)

--- a/doc/fluid/beginners_guide/install/install_Ubuntu.md
+++ b/doc/fluid/beginners_guide/install/install_Ubuntu.md
@@ -30,7 +30,7 @@
 
     * 如果您是使用 Python 3
 
-       pip3 --version
+        pip3 --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 

--- a/doc/fluid/beginners_guide/install/install_Windows.md
+++ b/doc/fluid/beginners_guide/install/install_Windows.md
@@ -8,6 +8,16 @@
 
 ### 注意事项
 
+* 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
+
+    * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+
+        where python
+
+    * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+
+        where python3 
+
 * 需要确认python的版本是否满足要求
 
     * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
@@ -22,11 +32,15 @@
 
     * 如果您是使用 Python 2 
 
-        pip --version
+        python -m ensurepip
+
+        python -m pip --version
 
     * 如果您是使用 Python 3
 
-        pip3 --version
+        python3 -m ensurepip
+
+        python3 -m pip --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
@@ -65,19 +79,19 @@ Windows系统下有3种安装方式：
 
 ## 安装步骤
 
-* CPU版PaddlePaddle：`pip install -U paddlepaddle` 或 `pip3 install -U paddlepaddle`
+* CPU版PaddlePaddle：`python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 
-* GPU版PaddlePaddle：`pip install -U paddlepaddle-gpu` 或 `pip3 install -U paddlepaddle-gpu`
+* GPU版PaddlePaddle：`python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 或 `python3 -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
 
 注：
 
-* pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
+* 如果是python2.7, 建议使用`python`命令; 如果是python3.x, 则建议使用`python3`命令
 
 
-* `pip3 install -U paddlepaddle-gpu` 此命令将安装支持CUDA 8.0/9.0 cuDNN v7.3+的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
+* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 8.0/9.0 cuDNN v7.3+的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`或 `python3 -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
 
 
 <a name="check"></a>
@@ -89,6 +103,6 @@ Windows系统下有3种安装方式：
 
 ## 如何卸载
 
-* ***CPU版本的PaddlePaddle***: `pip uninstall paddlepaddle` 或 `pip3 uninstall paddlepaddle`
+* ***CPU版本的PaddlePaddle***: `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`
 
-* ***GPU版本的PaddlePaddle***: `pip uninstall paddlepaddle-gpu` 或 `pip3 uninstall paddlepaddle-gpu`
+* ***GPU版本的PaddlePaddle***: `python -m pip uninstall paddlepaddle-gpu` 或 `python3 -m pip uninstall paddlepaddle-gpu`

--- a/doc/fluid/beginners_guide/install/install_Windows.md
+++ b/doc/fluid/beginners_guide/install/install_Windows.md
@@ -26,7 +26,7 @@
 
     * 如果您是使用 Python 3
 
-       pip3 --version
+        pip3 --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 

--- a/doc/fluid/beginners_guide/install/install_Windows.md
+++ b/doc/fluid/beginners_guide/install/install_Windows.md
@@ -2,14 +2,43 @@
 
 ## 环境准备
 
-* *64位操作系统*
-* *Windows 7/8 ，Windows 10 专业版/企业版*
-* *Python（64 bit） 2.7/3.5.1+/3.6/3.7*
-* *pip或pip3（64 bit） >= 9.0.1*
+* *Windows 7/8/10 专业版/企业版 (64bit) (GPU版本支持CUDA 8.0/9.0，且仅支持单卡)*
+* *Python 版本 2.7.15+/3.5.1+/3.6/3.7 (64 bit)*
+* *pip 或 pip3 版本 9.0.1+ (64 bit)*
 
 ### 注意事项
 
-* 默认提供的安装包需要计算机支持AVX指令集和MKL，如果您的环境不支持，请在[这里](./Tables.html/#ciwhls-release)下载`openblas`版本的安装包
+* 需要确认python的版本是否满足要求
+
+    * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+
+        python --version
+
+    * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+
+        python3 --version
+
+* 需要确认pip的版本是否满足要求，要求pip版本为9.0.1+
+
+    * 如果您是使用 Python 2 
+
+        pip --version
+
+    * 如果您是使用 Python 3
+
+       pip3 --version
+
+* 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
+
+    * 如果您是使用 Python 2
+
+        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+    * 如果您是使用 Python 3
+    
+        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+* 默认提供的安装包需要计算机支持MKL，如果您的环境不支持，请在[这里](./Tables.html/#ciwhls-release)下载`openblas`版本的安装包
 * 当前版本暂不支持NCCL，分布式等相关功能
 
 ## 选择CPU/GPU
@@ -17,8 +46,10 @@
 * 如果您的计算机没有 NVIDIA® GPU，请安装CPU版的PaddlePaddle
 
 * 如果您的计算机有 NVIDIA® GPU，并且满足以下条件，推荐安装GPU版的PaddlePaddle
-    * *CUDA 工具包8.0/9.2配合cuDNN v7.3+*
+    * *CUDA 工具包8.0配合cuDNN v7.1+， 9.0配合cuDNN v7.3+*
     * *GPU运算能力超过1.0的硬件设备*
+
+注: 目前官方发布的windows安装包仅包含 CUDA 8.0/9.0 的单卡模式，不包含 CUDA 9.1/9.2/10.0/10.1，如需使用，请通过源码自行编译。
 
 您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -27,7 +58,7 @@
 Windows系统下有3种安装方式：
 
 * pip安装（推荐）
-* [Docker安装](./install_Docker.html)
+* [conda安装](./install_Conda.html)
 * [源码编译安装](./compile/compile_Windows.html#win_source)
 
 这里为您介绍pip安装方式
@@ -35,6 +66,8 @@ Windows系统下有3种安装方式：
 ## 安装步骤
 
 * CPU版PaddlePaddle：`pip install -U paddlepaddle` 或 `pip3 install -U paddlepaddle`
+
+
 * GPU版PaddlePaddle：`pip install -U paddlepaddle-gpu` 或 `pip3 install -U paddlepaddle-gpu`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
@@ -44,7 +77,7 @@ Windows系统下有3种安装方式：
 * pip与python版本对应。如果是python2.7, 建议使用`pip`命令; 如果是python3.x, 则建议使用`pip3`命令
 
 
-* `pip3 install -U paddlepaddle-gpu` 此命令将安装支持CUDA 9.0 cuDNN 7的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
+* `pip3 install -U paddlepaddle-gpu` 此命令将安装支持CUDA 8.0/9.0 cuDNN v7.3+的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`pip install -U paddlepaddle-gpu==[版本号]`或 `pip3 install -U paddlepaddle-gpu==[版本号]`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
 
 
 <a name="check"></a>


### PR DESCRIPTION
1. 增加conda维度
2. 在安装文档首页、各个操作系统首页明确CPU仅支持x86_64架构，不支持arm64、GPU仅支持NVIDIA显卡。
3. 在各个操作系统页面合适的位置添加提示：
<1>Python检查版本的步骤
<2>pip检查版本的步骤
<3>Python检查64位的步骤
<4>确认Python是用户预期的位置

涉及文件为doc/fluid/beginners_guide/install/index_cn.rst、doc/fluid/beginners_guide/install/install_CentOS.md、doc/fluid/beginners_guide/install/install_Conda.md、doc/fluid/beginners_guide/install/install_MacOS.md 、doc/fluid/beginners_guide/install/install_Ubuntu.md、doc/fluid/beginners_guide/install/install_Windows.md。