### PR TITLE
CUDA and CUDnn support will need to be updated for Windows installation

### DIFF
--- a/doc/fluid/beginners_guide/install/compile/compile_Windows.md
+++ b/doc/fluid/beginners_guide/install/compile/compile_Windows.md
@@ -2,10 +2,9 @@
 
 ## 环境准备
 
-* *64位操作系统*
-* *Windows 10 家庭版/专业版/企业版*
-* *Python（64 bit） 2.7/3.5.1+/3.6/3.7*
-* *pip或pip3（64 bit） >= 9.0.1*
+* *Windows 7/8/10 专业版/企业版 (64bit) (GPU版本支持CUDA 8.0/9.0/10.0, 且仅支持单卡)*
+* *Python 版本 2.7/3.5.1+/3.6/3.7 (64 bit)*
+* *pip 或 pip3 版本 9.0.1+ (64 bit)*
 * *Visual Studio 2015 Update3*
 
 ## 选择CPU/GPU
@@ -13,7 +12,7 @@
 * 如果您的计算机没有 NVIDIA® GPU，请编译CPU版的PaddlePaddle
 
 * 如果您的计算机有NVIDIA® GPU，并且满足以下条件，推荐编译GPU版的PaddlePaddle
-    * *CUDA 工具包8.0/9.2配合cuDNN v7.3+*
+    * *CUDA 工具包8.0配合cuDNN v7.1+, 9.0/10.0配合cuDNN v7.3+*
     * *GPU运算能力超过1.0的硬件设备*
 
 ## 安装步骤
@@ -69,11 +68,11 @@
 
 		For Python2: `cmake .. -G "Visual Studio 14 2015 Win64" -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS}
 			 -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
-			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release`
+			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DWITH_FLUID_ONLY=ON -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release`
 
 		For Python3: `cmake .. -G "Visual Studio 14 2015 Win64" -DPY_VERSION=3.5 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS}
 			 -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
-			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release`
+			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DWITH_FLUID_ONLY=ON -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release`
 
 	*  编译**GPU版本PaddlePaddle**：
 
@@ -86,6 +85,22 @@
 			 -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
 			 -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 			 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}`
+	
+    注意：上述命令中对应的参数应修改为你所在设备上的对应路径，或者将它们加入环境变量中，以编译GPU版本的PaddlePaddle的python3.6版本为例，
+	
+	    -DPY_VERSION 为python版本
+	    -DPYTHON_INCLUDE_DIR 为对应版本python的include目录
+	    -DPYTHON_LIBRARY 为对应版本python的lib目录
+	    -DPYTHON_EXECUTABLE 为对应版本python的可执行程序的路径
+	    -DCUDA_TOOLKIT_ROOT_DIR 为安装cuda的根目录
+	
+	将相关路径加入环境变量中后，这个例子所用cmake命令为：
+	
+     `cmake .. -G "Visual Studio 14 2015 Win64" -DPY_VERSION=3.6 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release `
+	
+	若设备上存在多个版本python，或者多个版本cuda，或者没有将路径加入环境变量，这个例子所用cmake命令为：
+	
+     `cmake .. -G "Visual Studio 14 2015 Win64" -DPY_VERSION=3.6 -DPYTHON_INCLUDE_DIR=C:\\Python36\\include -DPYTHON_LIBRARY=C:\\Python36\\Lib -DPYTHON_EXECUTABLE=C:\\Python36\\python3.exe -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=D:\\cuda`
 
 6. 部分第三方依赖包（openblas，snappystream）目前需要用户自己提供预编译版本，也可以到 `https://github.com/wopeizl/Paddle_deps` 下载预编译好的文件， 将整个 `third_party` 文件夹放到 `build` 目录下.
 

--- a/doc/fluid/beginners_guide/install/compile/compile_Windows_en.md
+++ b/doc/fluid/beginners_guide/install/compile/compile_Windows_en.md
@@ -1,4 +1,3 @@
-***
 # **Compile on Windows from Source Code**
 
 This instruction will show you how to compile PaddlePaddle on a *64-bit desktop or laptop* and Windows 10. The Windows systems we support must meet the following requirements:
@@ -59,8 +58,7 @@ Please note: The current version does not support NCCL and distributed related f
 
 6. Execute cmake:
 
-	> For details on the compilation options, see [the compilation options list](../Tables.html/#Compile).
-
+	> For details on the compilation options, see [the compilation options list](../Tables.html/#Compile).	
 	* For users who need to compile **the CPU version PaddlePaddle**:
 
 		For Python2:`cmake .. -G "Visual Studio 14 2015 Win64" -DPYTHON_INCLUDE_DIR = $ {PYTHON_INCLUDE_DIRS} 

--- a/doc/fluid/beginners_guide/install/install_Windows.md
+++ b/doc/fluid/beginners_guide/install/install_Windows.md
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-* *Windows 7/8/10 专业版/企业版 (64bit) (GPU版本支持CUDA 8.0/9.0，且仅支持单卡)*
+* *Windows 7/8/10 专业版/企业版 (64bit) (GPU版本支持CUDA 8.0/9.0/10.0，且仅支持单卡)*
 * *Python 版本 2.7.15+/3.5.1+/3.6/3.7 (64 bit)*
 * *pip 或 pip3 版本 9.0.1+ (64 bit)*
 
@@ -60,10 +60,10 @@
 * 如果您的计算机没有 NVIDIA® GPU，请安装CPU版的PaddlePaddle
 
 * 如果您的计算机有 NVIDIA® GPU，并且满足以下条件，推荐安装GPU版的PaddlePaddle
-    * *CUDA 工具包8.0配合cuDNN v7.1+， 9.0配合cuDNN v7.3+*
+    * *CUDA 工具包8.0配合cuDNN v7.1+, 9.0/10.0配合cuDNN v7.3+*
     * *GPU运算能力超过1.0的硬件设备*
 
-注: 目前官方发布的windows安装包仅包含 CUDA 8.0/9.0 的单卡模式，不包含 CUDA 9.1/9.2/10.0/10.1，如需使用，请通过源码自行编译。
+注: 目前官方发布的windows安装包仅包含 CUDA 8.0/9.0/10.0 的单卡模式，不包含 CUDA 9.1/9.2/10.1，如需使用，请通过源码自行编译。
 
 您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -91,7 +91,7 @@ Windows系统下有3种安装方式：
 * 如果是python2.7, 建议使用`python`命令; 如果是python3.x, 则建议使用`python3`命令
 
 
-* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 8.0/9.0 cuDNN v7.3+的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`或 `python3 -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
+* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 8.0(配合cuDNN v7.1+)或者CUDA 9.0/10.0(配合cuDNN v7.3+)的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`或 `python3 -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu/#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html/#whls)
 
 
 <a name="check"></a>

--- a/doc/fluid/beginners_guide/install/install_Windows_en.md
+++ b/doc/fluid/beginners_guide/install/install_Windows_en.md
@@ -2,10 +2,9 @@
 
 ## Operating Environment
 
-* *64-bit operating system*
-* *Windows 7/8, Windows 10 Pro/Enterprise*
-* *Python 2.7/3.5/3.6/3.7*
-* *pip or pip3 >= 9.0.1*
+* *Windows 7/8/10 Pro/Enterprise(64bit)(CUDA 8.0/9.0/10.0 are supported, and only single GPU is supported)*
+* *Python 2.7.15+/3.5.1+/3.6/3.7(64bit)*
+* *pip or pip3 9.0.1+(64bit)*
 
 ### Precautions
 
@@ -17,8 +16,10 @@
 * If your computer doesn’t have NVIDIA® GPU, please install the CPU version of PaddlePaddle
 
 * If your computer has NVIDIA® GPU, and it satisfies the following requirements, we recommend you to install the GPU version of PaddlePaddle
-    * *CUDA Toolkit 8.0/9.2 with cuDNN v7.3+*
+    * *CUDA Toolkit 8.0 with cuDNN v7.1+, or 9.0/10.0 with cuDNN v7.3+*
     * *GPU's computing capability exceeds 1.0*
+
+Note: currently, the official Windows installation package only support CUDA 8.0/9.0/10.0 with single GPU, and don't support CUDA 9.1/9.2/10.1. if you need to use, please compile by yourself through the source code.
 
 Please refer to the NVIDIA official documents for the installation process and the configuration methods of [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/) and [cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/).
 
@@ -42,7 +43,7 @@ There is a checking function below for [verifyig whether the installation is suc
 Notice:
 
 * The version of pip and the version of python should be corresponding: python2.7 corresponds to `pip`; python3.x corresponds to `pip3`.
-* `pip install paddlepaddle-gpu` This command will install PaddlePaddle that supports CUDA 8.0 cuDNN v7. Currently, PaddlePaddle doesn't support any other version of CUDA or cuDNN on Windows.
+* `pip install paddlepaddle-gpu` This command will install PaddlePaddle that supports CUDA 8.0(with cuDNN v7.1+), or CUDA 9.0/10.0(with cuDNN v7.3+).
 
 <a name="check"></a>
 ## Installation Verification


### PR DESCRIPTION
With the release of 1.5.2, CUDA and CUDnn support will also need to be updated for Windows installation.
There are following changes:
1. Release of 1.5.2 support CUDA10, 
2. CUDA8 should match up cuDNN v7.1+,
3. The path Settings on CMAKE command line have been explained in detail.
---
Note: this PR is the sum of PR[#1142 ](https://github.com/PaddlePaddle/FluidDoc/pull/1142) and PR[#1051 ](https://github.com/PaddlePaddle/FluidDoc/pull/1051) on develop branch.