### PR TITLE
update install doc for 1.5.2, test=develop

### DIFF
--- a/doc/fluid/beginners_guide/install/Tables.md
+++ b/doc/fluid/beginners_guide/install/Tables.md
@@ -224,15 +224,15 @@ PaddePaddle通过编译时指定路径来实现引用各种BLAS/CUDA/cuDNN库。
 	</thead>
 	<tbody>
 	<tr>
-		<td> paddlepaddle==[版本号] 例如 paddlepaddle==1.5.1 </td>
+		<td> paddlepaddle==[版本号] 例如 paddlepaddle==1.5.2 </td>
 		<td> 只支持CPU对应版本的PaddlePaddle，具体版本请参见<a href=https://pypi.org/project/paddlepaddle/#history>Pypi</a> </td>
 	</tr>
 	<tr>
-		<td> paddlepaddle-gpu==[版本号] 例如 paddlepaddle-gpu==1.5.1 </td>
+		<td> paddlepaddle-gpu==[版本号] 例如 paddlepaddle-gpu==1.5.2 </td>
 		<td> 默认安装支持CUDA 10.0和cuDNN 7的对应[版本号]的PaddlePaddle安装包 </td>
 	</tr>
 	<tr>
-		<td> paddlepaddle-gpu==[版本号].postXX 例如 paddlepaddle-gpu==1.5.1.post87 </td>
+		<td> paddlepaddle-gpu==[版本号].postXX 例如 paddlepaddle-gpu==1.5.2.post87 </td>
 		<td> 支持CUDA 8.0和cuDNN 7的对应PaddlePaddle版本的安装包</td>
 	</tr>	
    </tbody>
@@ -265,110 +265,110 @@ PaddePaddle通过编译时指定路径来实现引用各种BLAS/CUDA/cuDNN库。
 	<tbody>
 	<tr>
 		<td> cpu-mkl </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mkl/paddlepaddle-1.5.1-cp27-cp27mu-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp27-cp27mu-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mkl/paddlepaddle-1.5.1-cp27-cp27m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp27-cp27m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mkl/paddlepaddle-1.5.1-cp35-cp35m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp35-cp35m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mkl/paddlepaddle-1.5.1-cp36-cp36m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp36-cp36m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mkl/paddlepaddle-1.5.1-cp37-cp37m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp37-cp37m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mkl/paddlepaddle-1.5.2-cp27-cp27mu-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp27-cp27mu-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mkl/paddlepaddle-1.5.2-cp27-cp27m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp27-cp27m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mkl/paddlepaddle-1.5.2-cp35-cp35m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp35-cp35m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mkl/paddlepaddle-1.5.2-cp36-cp36m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp36-cp36m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mkl/paddlepaddle-1.5.2-cp37-cp37m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp37-cp37m-linux_x86_64.whl</a></td>
 	</tr>	
 	<tr>
 		<td> cpu-openblas </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-openblas/paddlepaddle-1.5.1-cp27-cp27mu-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp27-cp27mu-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-openblas/paddlepaddle-1.5.1-cp27-cp27m-linux_x86_64.whl"> paddlepaddle-1.5.1-cp27-cp27m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-openblas/paddlepaddle-1.5.1-cp35-cp35m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp35-cp35m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-openblas/paddlepaddle-1.5.1-cp36-cp36m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp36-cp36m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-openblas/paddlepaddle-1.5.1-cp37-cp37m-linux_x86_64.whl">
-		paddlepaddle-1.5.1-cp37-cp37m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-openblas/paddlepaddle-1.5.2-cp27-cp27mu-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp27-cp27mu-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-openblas/paddlepaddle-1.5.2-cp27-cp27m-linux_x86_64.whl"> paddlepaddle-1.5.2-cp27-cp27m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-openblas/paddlepaddle-1.5.2-cp35-cp35m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp35-cp35m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-openblas/paddlepaddle-1.5.2-cp36-cp36m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp36-cp36m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-openblas/paddlepaddle-1.5.2-cp37-cp37m-linux_x86_64.whl">
+		paddlepaddle-1.5.2-cp37-cp37m-linux_x86_64.whl</a></td>
 	</tr>
 	<tr>
 		<td> cuda8-cudnn7-openblas </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.1-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27mu-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.1-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.1-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp35-cp35m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.1-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp37-cp37m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.2-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27mu-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.2-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.2-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp35-cp35m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.2-cp36-cp36m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp36-cp36m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-openblas/paddlepaddle_gpu-1.5.2-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp37-cp37m-linux_x86_64.whl</a></td>
 	</tr>
 	<tr>
 		<td> cuda8-cudnn7-mkl </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post87-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27mu-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post87-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post87-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp35-cp35m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post87-cp36-cp36m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post87-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp37-cp37m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post87-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27mu-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post87-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post87-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp35-cp35m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post87-cp36-cp36m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp36-cp36m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda8-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post87-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp37-cp37m-linux_x86_64.whl</a></td>
 	</tr>
 	<tr>
 		<td> cuda9-cudnn7-mkl </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post97-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27mu-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post97-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post97-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp35-cp35m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post97-cp36-cp36m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post97-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp37-cp37m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post97-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27mu-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post97-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post97-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp35-cp35m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post97-cp36-cp36m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp36-cp36m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post97-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp37-cp37m-linux_x86_64.whl</a></td>
 	</tr>
 	<tr>
 		<td> cuda10_cudnn7-mkl </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post107-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27mu-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post107-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp27-cp27m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post107-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.1-cp35-cp35m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post107-cp36-cp36m-linux_x86_64.whl">
-		paddlepaddle_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.1.post107-cp37-cp37m-linux_x86_64.whl">
-		paddlepaddle_gpu-1.5.1-cp37-cp37m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post107-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27mu-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post107-cp27-cp27m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp27-cp27m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post107-cp35-cp35m-linux_x86_64.whl"> paddlepaddle_gpu-1.5.2-cp35-cp35m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post107-cp36-cp36m-linux_x86_64.whl">
+		paddlepaddle_gpu-1.5.2-cp36-cp36m-linux_x86_64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-1.5.2.post107-cp37-cp37m-linux_x86_64.whl">
+		paddlepaddle_gpu-1.5.2-cp37-cp37m-linux_x86_64.whl</a></td>
 	</tr> 
 	<tr>
 		<td> win_cpu_openblas </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp27-cp27m-win_amd64.whl">
-		paddlepaddle-1.5.1-cp27-cp27m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp35-cp35m-win_amd64.whl">
-		paddlepaddle-1.5.1-cp35-cp35m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp36-cp36m-win_amd64.whl">
-		paddlepaddle-1.5.1-cp36-cp36m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp37-cp37m-win_amd64.whl">
-		paddlepaddle-1.5.1-cp37-cp37m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp27-cp27m-win_amd64.whl">
+		paddlepaddle-1.5.2-cp27-cp27m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp35-cp35m-win_amd64.whl">
+		paddlepaddle-1.5.2-cp35-cp35m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp36-cp36m-win_amd64.whl">
+		paddlepaddle-1.5.2-cp36-cp36m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp37-cp37m-win_amd64.whl">
+		paddlepaddle-1.5.2-cp37-cp37m-win_amd64.whl</a></td>
 	</tr>
 	<tr>
 		<td> win_cuda8_cudnn7_openblas </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp27-cp27m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp27-cp27m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp35-cp35m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp35-cp35m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp36-cp36m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp36-cp36m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp37-cp37m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp37-cp37m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp27-cp27m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp27-cp27m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp35-cp35m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp35-cp35m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp36-cp36m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp36-cp36m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp37-cp37m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp37-cp37m-win_amd64.whl</a></td>
 	</tr>
 	<tr>
 		<td> win_cuda9_cudnn7_openblas </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp27-cp27m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp27-cp27m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp35-cp35m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp35-cp35m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp36-cp36m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp36-cp36m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp37-cp37m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.1-cp37-cp37m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp27-cp27m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp27-cp27m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp35-cp35m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp35-cp35m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp36-cp36m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp36-cp36m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp37-cp37m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.2-cp37-cp37m-win_amd64.whl</a></td>
 	</tr>  
 	<tr>
 		<td> mac_cpu </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mac/paddlepaddle-1.5.1-cp27-cp27m-macosx_10_6_intel.whl">
-		paddlepaddle-1.5.1-cp27-cp27m-macosx_10_6_intel.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mac/paddlepaddle-1.5.1-cp35-cp35m-macosx_10_6_intel.whl">
-		paddlepaddle-1.5.1-cp35-cp35m-macosx_10_6_intel.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mac/paddlepaddle-1.5.1-cp36-cp36m-macosx_10_6_intel.whl">
-		paddlepaddle-1.5.1-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-cpu-mac/paddlepaddle-1.5.1-cp37-cp37m-macosx_10_6_intel.whl">
-		paddlepaddle-1.5.1-cp37-cp37m-macosx_10_6_intel.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mac/paddlepaddle-1.5.2-cp27-cp27m-macosx_10_6_intel.whl">
+		paddlepaddle-1.5.2-cp27-cp27m-macosx_10_6_intel.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mac/paddlepaddle-1.5.2-cp35-cp35m-macosx_10_6_intel.whl">
+		paddlepaddle-1.5.2-cp35-cp35m-macosx_10_6_intel.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mac/paddlepaddle-1.5.2-cp36-cp36m-macosx_10_6_intel.whl">
+		paddlepaddle-1.5.2-cp36-cp36m-macosx_10_6_intel.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-cpu-mac/paddlepaddle-1.5.2-cp37-cp37m-macosx_10_6_intel.whl">
+		paddlepaddle-1.5.2-cp37-cp37m-macosx_10_6_intel.whl</a></td>
 	</tr>
    </tbody>
 </table>
@@ -382,7 +382,7 @@ cpu-mkl: 支持CPU训练和预测，使用Intel mkl数学库
 
 cpu-openblas: 支持CPU训练和预测，使用openblas数学库
 
-cuda8-cudnn7-openblas: 支持CPU训练和预测，使用openblas数学库
+cuda8-cudnn7-openblas: 支持GPU训练和预测，使用openblas数学库
 
 cuda8_cudnn7_mkl: 支持GPU训练和预测，使用Intel mkl数学库
 

--- a/doc/fluid/beginners_guide/install/Tables.md
+++ b/doc/fluid/beginners_guide/install/Tables.md
@@ -325,38 +325,38 @@ PaddePaddle通过编译时指定路径来实现引用各种BLAS/CUDA/cuDNN库。
 	<tr>
 		<td> win_cpu_openblas </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp27-cp27m-win_amd64.whl">
-		paddlepaddle-1.5.2-cp27-cp27m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp35-cp35m-win_amd64.whl">
-		paddlepaddle-1.5.2-cp35-cp35m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp36-cp36m-win_amd64.whl">
-		paddlepaddle-1.5.2-cp36-cp36m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle-1.5.2-cp37-cp37m-win_amd64.whl">
-		paddlepaddle-1.5.2-cp37-cp37m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp27-cp27m-win_amd64.whl">
+		paddlepaddle-1.5.1-cp27-cp27m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp35-cp35m-win_amd64.whl">
+		paddlepaddle-1.5.1-cp35-cp35m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp36-cp36m-win_amd64.whl">
+		paddlepaddle-1.5.1-cp36-cp36m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle-1.5.1-cp37-cp37m-win_amd64.whl">
+		paddlepaddle-1.5.1-cp37-cp37m-win_amd64.whl</a></td>
 	</tr>
 	<tr>
 		<td> win_cuda8_cudnn7_openblas </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp27-cp27m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp27-cp27m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp35-cp35m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp35-cp35m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp36-cp36m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp36-cp36m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post87-cp37-cp37m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp37-cp37m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp27-cp27m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp27-cp27m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp35-cp35m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp35-cp35m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp36-cp36m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp36-cp36m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post87-cp37-cp37m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp37-cp37m-win_amd64.whl</a></td>
 	</tr>
 	<tr>
 		<td> win_cuda9_cudnn7_openblas </td>
 		<td> - </td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp27-cp27m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp27-cp27m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp35-cp35m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp35-cp35m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp36-cp36m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp36-cp36m-win_amd64.whl</a></td>
-		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.2-win-open/paddlepaddle_gpu-1.5.2.post97-cp37-cp37m-win_amd64.whl">
-		paddlepaddle_gpu-1.5.2-cp37-cp37m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp27-cp27m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp27-cp27m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp35-cp35m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp35-cp35m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp36-cp36m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp36-cp36m-win_amd64.whl</a></td>
+		<td> <a href="https://paddle-wheel.bj.bcebos.com/1.5.1-win-open/paddlepaddle_gpu-1.5.1.post97-cp37-cp37m-win_amd64.whl">
+		paddlepaddle_gpu-1.5.1-cp37-cp37m-win_amd64.whl</a></td>
 	</tr>  
 	<tr>
 		<td> mac_cpu </td>

--- a/doc/fluid/beginners_guide/install/index_cn.rst
+++ b/doc/fluid/beginners_guide/install/index_cn.rst
@@ -46,7 +46,7 @@
 
 * 需要安装 `CUDA <https://docs.nvidia.com/cuda/cuda-installation-guide-windows/>`_，根据您系统不同，对 CUDA 版本要求不同：
     * Windows 安装 GPU 版本
-        * Windows 7/8/10 支持 CUDA 8.0/9.0 单卡模式，不支持 CUDA 9.1/9.2/10.0/10.1
+        * Windows 7/8/10 支持 CUDA 8.0/9.0/10.0 单卡模式，不支持 CUDA 9.1/9.2/10.1
 		
         * 不支持 `nvidia-docker` 方式安装
 
@@ -212,7 +212,7 @@
         注意：
             * 需要您确认您的 GPU 满足上方列出的要求
 
-        如果您是使用 Python2，请注意用以下指令安装的PaddlePaddle在Windows下默认支持CUDA9，Ubuntu、CentOS下默认支持CUDA10.0：
+        如果您是使用 Python2，请注意用以下指令安装的PaddlePaddle在Windows、Ubuntu、CentOS下默认支持CUDA10.0：
         ::
 
             python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple
@@ -220,17 +220,17 @@
         如果您是使用 Python 2，CUDA 8，cuDNN 7.1+，安装GPU版本的命令为：
         ::
     
-            python -m pip install paddlepaddle-gpu==1.5.1.post87 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle-gpu==1.5.2.post87 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
         如果您是使用 Python 2，CUDA 9，cuDNN 7.3+，安装GPU版本的命令为：
         ::
     
-            python -m pip install paddlepaddle-gpu==1.5.1.post97 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle-gpu==1.5.2.post97 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
         如果您是使用 Python 2，CUDA 10.0，cuDNN 7.3+，安装GPU版本的命令为：
         ::
     
-            python -m pip install paddlepaddle-gpu==1.5.1.post107 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle-gpu==1.5.2.post107 -i https://pypi.tuna.tsinghua.edu.cn/simple
         
         如果您是使用 Python 3，请将上述命令中的 `python` 更换为 `python3` 进行安装。
 
@@ -243,11 +243,11 @@
 9. 更多帮助信息请参考：
     `Ubuntu下安装 <install_Ubuntu.html>`_
 
-    `CentOS下安装 <install_Ubuntu.html>`_
+    `CentOS下安装 <install_CentOS.html>`_
 
-    `MacOS下安装 <install_Ubuntu.html>`_
+    `MacOS下安装 <install_MacOS.html>`_
 
-    `Windows下安装 <install_Ubuntu.html>`_
+    `Windows下安装 <install_Windows.html>`_
 
 
 第二种安装方式：使用 conda 安装
@@ -429,12 +429,12 @@
     (2). 拉取预安装 PaddlePaddle 的镜像：
     ::
 
-        docker pull hub.baidubce.com/paddlepaddle/paddle:1.5.1
+        docker pull hub.baidubce.com/paddlepaddle/paddle:1.5.2
 
     (3). 用镜像构建并进入Docker容器：
     ::
 
-        docker run --name paddle -it -v dir1:dir2 hub.baidubce.com/paddlepaddle/paddle:1.5.1 /bin/bash
+        docker run --name paddle -it -v dir1:dir2 hub.baidubce.com/paddlepaddle/paddle:1.5.2 /bin/bash
 
         > --name [Name of container] 设定Docker的名称；
 
@@ -442,7 +442,7 @@
 
         > -v 参数用于宿主机与容器里文件共享；其中dir1为宿主机目录，dir2为挂载到容器内部的目录，用户可以通过设定dir1和dir2自定义自己的挂载目录；例如：$PWD:/paddle 指定将宿主机的当前路径（Linux中PWD变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
 
-        > hub.baidubce.com/paddlepaddle/paddle:1.5.1 是需要使用的image名称；/bin/bash是在Docker中要执行的命令
+        > hub.baidubce.com/paddlepaddle/paddle:1.5.2 是需要使用的image名称；/bin/bash是在Docker中要执行的命令
 
 2. **GPU 版本**
 
@@ -468,12 +468,12 @@
     (2). 拉取支持`CUDA 10.0`, `cuDNN 7.3+` 预安装 PaddlePaddle 的镜像：
     ::
 
-        nvidia-docker pull hub.baidubce.com/paddlepaddle/paddle:1.5.1-gpu-cuda10.0-cudnn7
+        nvidia-docker pull hub.baidubce.com/paddlepaddle/paddle:1.5.2-gpu-cuda10.0-cudnn7
 
     (3). 用镜像构建并进入Docker容器：
     ::
 
-        nvidia-docker run --name paddle -it -v dir1:dir2 hub.baidubce.com/paddlepaddle/paddle:1.5.1-gpu-cuda10.0-cudnn7 /bin/bash
+        nvidia-docker run --name paddle -it -v dir1:dir2 hub.baidubce.com/paddlepaddle/paddle:1.5.2-gpu-cuda10.0-cudnn7 /bin/bash
 
         > --name [Name of container] 设定Docker的名称；
 
@@ -481,14 +481,14 @@
 
         > -v 参数用于宿主机与容器里文件共享；其中dir1为宿主机目录，dir2为挂载到容器内部的目录，用户可以通过设定dir1和dir2自定义自己的挂载目录；例如：$PWD:/paddle 指定将宿主机的当前路径（Linux中PWD变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
 
-        > hub.baidubce.com/paddlepaddle/paddle:1.5.1-gpu-cuda10.0-cudnn7 是需要使用的image名称；/bin/bash是在Docker中要执行的命令  
+        > hub.baidubce.com/paddlepaddle/paddle:1.5.2-gpu-cuda10.0-cudnn7 是需要使用的image名称；/bin/bash是在Docker中要执行的命令  
 
     或如果您需要支持 `CUDA 8` 或者 `CUDA 9` 的版本，将上述命令的 `cuda10.0` 替换成 `cuda8.0` 或者 `cuda9.0` 即可
 
 3. 如果您的机器不在中国大陆地区，可以直接从DockerHub拉取镜像：
     ::
 
-        docker run --name paddle -it -v dir1:dir2 paddlepaddle/paddle:1.5.1 /bin/bash
+        docker run --name paddle -it -v dir1:dir2 paddlepaddle/paddle:1.5.2 /bin/bash
 
         > --name [Name of container] 设定Docker的名称；
 
@@ -496,7 +496,7 @@
 
         > -v 参数用于宿主机与容器里文件共享；其中dir1为宿主机目录，dir2为挂载到容器内部的目录，用户可以通过设定dir1和dir2自定义自己的挂载目录；例如：$PWD:/paddle 指定将宿主机的当前路径（Linux中PWD变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
 
-        > paddlepaddle/paddle:1.5.1 是需要使用的image名称；/bin/bash是在Docker中要执行的命令
+        > paddlepaddle/paddle:1.5.2 是需要使用的image名称；/bin/bash是在Docker中要执行的命令
 
 4. 验证安装
 


### PR DESCRIPTION
update install doc for 1.5.2.
1. Tables.md and index_cn.rst: update the paddle package to 1.5.2 for linux/mac.
2. index_cn.rst: windows support CUDA10.0.