### PR TITLE
modify the op of uniform_random document

### DIFF
--- a/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
@@ -5,7 +5,7 @@ uniform_random
 
 .. py:function:: paddle.fluid.layers.uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0)
 
-该OP初始化一个Tensor，该Tensor的值是从均匀分布中抽样的随机值
+该OP使用从均匀分布中抽样的随机值初始化一个Tensor。
 
 ::
 
@@ -16,15 +16,15 @@ uniform_random
                  result=[[0.8505902, 0.8397286]]
 
 参数：
-    - **shape** (list|tuple|Variable)-返回Tensor的维度，数据类型是int64，如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor。如果shape的类型是Variable，则是1D的Tensor。
-    - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 数据的类型，例如float32， float64。 默认数据类型为float32。
+    - **shape** (list|tuple|Variable)-输出Tensor的维度，数据类型是int64，如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor。如果shape的类型是Variable，则是1D的Tensor。
+    - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 输出tensor的数据类型，支持float32（默认）， float64。
     - **min** (float，可选）-均匀随机分布的最小值，为闭区间。数据类型为float。默认值为-1.0。
     - **max** (float，可选)-均匀随机分布的最大值，为开区间。数据类型为floa。默认值为1.0。
     - **seed** (int，可选)-随机种子，用于生成样本。0表示使用系统生成的种子。注意如果种子不为0，该操作符每次都生成同样的随机数。数据类型为int。默认为 0。
 
-    返回：表示随机初始化结果的Tensor，该Tensor的数据类型由dtype参数决定，该Tensor的维度由shape参数决定。
+返回：表示一个随机初始化结果的Tensor，该Tensor的数据类型由dtype参数决定，该Tensor的维度由shape参数决定。
     
-    返回类型：Variable
+返回类型：Variable
 
 抛出异常：
     - :code:`ValueError`: shape的类型应该是list、tuple 或 Variable。

--- a/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
@@ -7,6 +7,14 @@ uniform_random
 
 该OP初始化一个Tensor，该Tensor的值是从均匀分布中抽样的随机值
 
+::
+
+    示例1:
+             给定：
+                 shape=[1,2]
+             则输出为：
+                 result=[[0.8505902, 0.8397286]]
+
 参数：
     - **shape** (list|tuple|Variable)-返回Tensor的维度，数据类型是int64，如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor。如果shape的类型是Variable，则是1D的Tensor。
     - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 数据的类型，例如float32， float64。 默认数据类型为float32。
@@ -17,6 +25,9 @@ uniform_random
     返回：表示随机初始化结果的Tensor，该Tensor的数据类型由dtype参数决定，该Tensor的维度由shape参数决定。
     
     返回类型：Variable
+
+抛出异常：
+    - :code:`ValueError`: shape的类型应该是list、tuple 或 Variable。
 
 **代码示例**：
 

--- a/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
@@ -17,9 +17,9 @@ uniform_random
 
 参数：
     - **shape** (list|tuple|Variable)-输出Tensor的维度，数据类型是int64，如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor。如果shape的类型是Variable，则是1D的Tensor。
-    - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 输出tensor的数据类型，支持float32（默认）， float64。
+    - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 输出Tensor的数据类型，支持float32（默认）， float64。
     - **min** (float，可选）-均匀随机分布的最小值，为闭区间。数据类型为float。默认值为-1.0。
-    - **max** (float，可选)-均匀随机分布的最大值，为开区间。数据类型为floa。默认值为1.0。
+    - **max** (float，可选)-均匀随机分布的最大值，为开区间。数据类型为float。默认值为1.0。
     - **seed** (int，可选)-随机种子，用于生成样本。0表示使用系统生成的种子。注意如果种子不为0，该操作符每次都生成同样的随机数。数据类型为int。默认为 0。
 
 返回：表示一个随机初始化结果的Tensor，该Tensor的数据类型由dtype参数决定，该Tensor的维度由shape参数决定。

--- a/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
@@ -4,26 +4,47 @@ uniform_random
 -------------------------------
 
 .. py:function:: paddle.fluid.layers.uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0)
-该操作符初始化一个张量，该张量的值是从均匀分布中抽样的随机值
+
+该OP初始化一个Tensor，该Tensor的值是从均匀分布中抽样的随机值
 
 参数：
-    - **shape** (LONGS)-输出张量的维
-    - **dtype** (np.dtype|core.VarDesc.VarType|str) – 数据的类型, 例如float32, float64。 默认: float32.
-    - **min** (FLOAT)-均匀随机分布的最小值。[默认 -1.0]
-    - **max** (FLOAT)-均匀随机分布的最大值。[默认 1.0]
-    - **seed** (INT)-随机种子，用于生成样本。0表示使用系统生成的种子。注意如果种子不为0，该操作符每次都生成同样的随机数。[默认 0]
+    - **shape** (list|tuple|Variable)-返回Tensor的维度，数据类型是int64，如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor。如果shape的类型是Variable，则是1D的Tensor。
+    - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 数据的类型，例如float32， float64。 默认数据类型为float32。
+    - **min** (float，可选）-均匀随机分布的最小值，为闭区间。数据类型为float。默认值为-1.0。
+    - **max** (float，可选)-均匀随机分布的最大值，为开区间。数据类型为floa。默认值为1.0。
+    - **seed** (int，可选)-随机种子，用于生成样本。0表示使用系统生成的种子。注意如果种子不为0，该操作符每次都生成同样的随机数。数据类型为int。默认为 0。
 
+    返回：表示随机初始化结果的Tensor，该Tensor的数据类型由dtype参数决定，该Tensor的维度由shape参数决定。
+    
+    返回类型：Variable
 
 **代码示例**：
 
 .. code-block:: python
 
     import paddle.fluid as fluid
-    result = fluid.layers.uniform_random(shape=[32, 784])
+    import numpy as np
 
+    startup_program = fluid.Program()
+    train_program = fluid.Program()
+    with fluid.program_guard(train_program, startup_program):
+        # example 1:
+        # attr shape is a list which doesn't contain tensor Variable.
+        result_1 = fluid.layers.uniform_random(shape=[3, 4])
 
+        # example 2:
+        # attr shape is a list which contains tensor Variable.
+        dim_1 = fluid.layers.fill_constant([1],"int64",3)
+        result_2 = fluid.layers.uniform_random(shape=[dim_1, 5])
 
+        # example 3:
+        # attr shape is a Variable, the data type must be int64
+        var_shape = fluid.layers.data(name='var_shape',shape=[2],append_batch_size=False)
+        result_3 = fluid.layers.uniform_random(var_shape)
 
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(startup_program)
+        outs = exe.run(train_program, feed = {'var_shape':np.array([3,4])}, fetch_list=[result_1, result_2, result_3])
 
 
 

--- a/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
@@ -27,7 +27,7 @@ uniform_random
 返回类型：Variable
 
 抛出异常：
-    - :code:`ValueError`: shape的类型应该是list、tuple 或 Variable。
+    - :code:`TypeError`: shape的类型应该是list、tuple 或 Variable。
 
 **代码示例**：
 

--- a/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/uniform_random_cn.rst
@@ -16,7 +16,7 @@ uniform_random
                  result=[[0.8505902, 0.8397286]]
 
 参数：
-    - **shape** (list|tuple|Variable)-输出Tensor的维度，数据类型是int64，如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor。如果shape的类型是Variable，则是1D的Tensor。
+    - **shape** (list|tuple|Variable)-输出Tensor的维度，shape类型支持list，tuple，Variable。如果shape类型是list或者tuple，它的元素可以是整数或者形状为[1]的Tensor，其中整数的数据类型为int，Tensor的数据类型为int64。如果shape的类型是Variable，则是1D的Tensor，Tensor的数据类型为int64。
     - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) – 输出Tensor的数据类型，支持float32（默认）， float64。
     - **min** (float，可选）-均匀随机分布的最小值，为闭区间。数据类型为float。默认值为-1.0。
     - **max** (float，可选)-均匀随机分布的最大值，为开区间。数据类型为float。默认值为1.0。


### PR DESCRIPTION
添加对uniform_random shape参数的tensor支持说明，并且添加对应的例子

Before：
![image](https://user-images.githubusercontent.com/35439432/65370899-6a664780-dc90-11e9-830a-01d71ef309c2.png)
After：
![image](https://user-images.githubusercontent.com/35439432/65588293-dbbc3800-dfb9-11e9-88f8-719a17556f1e.png)
![image](https://user-images.githubusercontent.com/35439432/65490818-66306900-dee0-11e9-8388-ded49c4db15d.png)


