### PR TITLE
refine api docs name param

### DIFF
--- a/doc/fluid/api_cn/layers_cn/IfElse_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/IfElse_cn.rst
@@ -56,7 +56,7 @@ IfElse OP同其他的OP在使用上有一定的区别，可能会对一些用户
 
 参数：
     - **cond** (Variable)- cond是一个shape为[N, 1]、数据类型为bool的2-D tensor，表示N个输入数据的对应的执行条件。数据类型为bool。
-    - **Name** (str，可选)- 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` , 默认值为None。
+    - **Name** (str，可选)- 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 **返回：**    
 

--- a/doc/fluid/api_cn/layers_cn/Switch_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/Switch_cn.rst
@@ -24,7 +24,7 @@ Switch
             i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
 
 参数：
-    - **name** (str，可选) - 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` ，默认值为None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 **代码示例**
 

--- a/doc/fluid/api_cn/layers_cn/While_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/While_cn.rst
@@ -12,7 +12,7 @@ While
 参数：
     - **cond** (Variable) – 用于判断循环继续进行的条件，为数据类型bool型的Tensor，其shape必须为[1]。
     - **is_test** (bool，可选) – 用于表明是否在测试阶段执行，默认值为False。
-    - **name** (str，可选) - 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` ，默认值为None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 **代码示例**
 

--- a/doc/fluid/api_cn/layers_cn/round_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/round_cn.rst
@@ -21,7 +21,7 @@ round
 参数:
 
     - **x** (Variable) - 支持任意维度的Tensor。数据类型为float32，float64或float16。
-    - **name** (str，可选) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` , 默认值为None。
+    - **name** (str，可选) – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回：返回类型为Variable(Tensor|LoDTensor)， 数据类型同输入一致。
 

--- a/doc/fluid/api_cn/layers_cn/scale_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/scale_cn.rst
@@ -20,12 +20,12 @@ scale
                         Out=scale*(X+bias)
 
 参数:
-        - **x** (Variable) - 要进行缩放的多维Tensor，数据类型可以为int8，uint8，int16，int32，int64，float32，float64。
+        - **x** (Variable) - 要进行缩放的多维Tensor，数据类型可以为float32，float64，int8，int16，int32，int64，uint8。
         - **scale** (float) - 缩放的比例。
-        - **bias** (float) - 缩放的的偏置。 
+        - **bias** (float) - 缩放的偏置。 
         - **bias_after_scale** (bool) - 判断在缩放之前或之后添加偏置。为True时，先缩放再偏置；为False时，先偏置再缩放。该参数在某些情况下，对数值稳定性很有用。
         - **act** (str，可选) - 应用于输出的激活函数，如tanh、softmax、sigmoid、relu等。
-        - **name** (str，可选) - 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` ，默认值为None。
+        - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回: 缩放后的输出Tensor。
 

--- a/doc/fluid/api_cn/layers_cn/scatter_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/scatter_cn.rst
@@ -37,7 +37,7 @@ scatter
   - **input** （Variable） - 支持任意纬度的Tensor。支持的数据类型为float32。
   - **index** （Variable） - 表示索引，仅支持1-D Tensor。 支持的数据类型为int32，int64。
   - **updates** （Variable） - 根据索引的值将updates Tensor中的对应值更新到input Tensor中，updates Tensor的维度需要和input tensor保持一致，且除了第一维外的其他的维度的大小需要和input Tensor保持相同。支持的数据类型为float32。
-  - **name** （str，可选） - 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` 。 默认值为None。
+  - **name** （str，可选） - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
   - **overwrite** （bool，可选） - 如果index中的索引值有重复且overwrite 为True，旧更新值将被新的更新值覆盖；如果为False，新的更新值将同旧的更新值相加。默认值为True。
 
 返回：返回类型为Variable(Tensor|LoDTensor)，数据类型以及shape大小同输入一致。

--- a/doc/fluid/api_cn/layers_cn/selu_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/selu_cn.rst
@@ -20,7 +20,7 @@ SeLU激活函数，其公式如下：
   - **x** (Variable) - 输入变量，为数据类型为float32，float64的多维Tensor或者LoDTensor。
   - **scale** (float，可选) – 可选，表示SeLU激活函数中的λ的值，其默认值为 1.0507009873554804934193349852946。 详情请见： `Self-Normalizing Neural Networks <https://arxiv.org/abs/1706.02515.pdf>`_。
   - **alpha** (float，可选) – 可选，表示SeLU激活函数中的α的值，其默认值为 1.6732632423543772848170429916717。 详情请见： `Self-Normalizing Neural Networks <https://arxiv.org/abs/1706.02515.pdf>`_。
-  - **name** (str，可选) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` ，默认值为None。
+  - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回：一个Tensor，shape和输入Tensor相同。
 

--- a/doc/fluid/api_cn/layers_cn/shape_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/shape_cn.rst
@@ -10,7 +10,7 @@ shape层。
 获得输入Tensor的shape。
 
 参数：
-        - **input** （Variable）-  输入的多维Tensor，数据类型为int32，int64，float32，float64。
+        - **input** （Variable）-  输入的多维Tensor，数据类型为float32，float64，int32，int64。
 
 返回： 一个Tensor，表示输入Tensor的shape。
 

--- a/doc/fluid/api_cn/layers_cn/sin_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sin_cn.rst
@@ -9,7 +9,7 @@ sin
 
 参数:
     - **x** (Variable) - 支持任意维度的Tensor。数据类型为float32，float64或float16。
-    - **name** (str，可选) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` , 默认值为None。
+    - **name** (str，可选) – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回：返回类型为Variable(Tensor|LoDTensor)， 数据类型同输入一致。
 

--- a/doc/fluid/api_cn/layers_cn/soft_relu_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/soft_relu_cn.rst
@@ -12,7 +12,7 @@ SoftReLU 激活函数.
 参数:
     - **x** (Variable) - SoftReLU激活函数的输入，为数据类型为float32，float64的多维Tensor或者LoDTensor。
     - **threshold** (float) - SoftRelu的阈值，默认为40.0。
-    - **name** (str，可选) - 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` ，默认值为None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回：一个Tensor，shape和输入Tensor相同。
 

--- a/doc/fluid/api_cn/layers_cn/split_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/split_cn.rst
@@ -8,10 +8,10 @@ split
 将输入Tensor分割成多个子Tensor。
 
 参数：
-    - **input** (Variable) - 输入变量，为数据类型为int32，int64，float32，float64的多维Tensor或者LoDTensor。
+    - **input** (Variable) - 输入变量，为数据类型为float32，float64，int32，int64的多维Tensor或者LoDTensor。
     - **num_or_sections** (int|list) - 整数或元素为整数的列表。如果\ ``num_or_sections``\ 是一个整数，则表示Tensor平均划分为的相同大小子Tensor的数量。如果\ ``num_or_sections``\ 是一个整数列表，则列表的长度代表子Tensor的数量，列表中的整数依次代表子Tensor的需要分割成的维度的大小。列表长度不能超过输入Tensor待分割的维度的大小。
     - **dim** (int) - 需要分割的维度。如果dim < 0,划分的维度为rank(input) + dim，数据类型为int32，int64。
-    - **name** (str，可选) - 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` ，默认值为None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回：分割后的Tensor列表。
 

--- a/doc/fluid/api_cn/layers_cn/sqrt_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sqrt_cn.rst
@@ -14,7 +14,7 @@ sqrt
 参数:
 
     - **x** (Variable) - 支持任意维度的Tensor。数据类型为float32，float64或float16。
-    - **name** (str，可选) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` , 默认值为None。
+    - **name** (str，可选) – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
 返回：返回类型为Variable(Tensor|LoDTensor)， 数据类型同输入一致。
 


### PR DESCRIPTION
将已经合入的api文档修改中的OP的name参数说明：
由
“该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:`api_guide_Name` , 默认值为None。”
修改为
“具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。”
包括scale, shape, selu, soft_relu, split, While, Switch, round, sqrt, sin, scatter, IfElse共12个OP