### PR TITLE
polish cn document of unique_name

### DIFF
--- a/doc/fluid/api_cn/unique_name_cn/generate_cn.rst
+++ b/doc/fluid/api_cn/unique_name_cn/generate_cn.rst
@@ -5,14 +5,14 @@ generate
 
 .. py:function:: paddle.fluid.unique_name.generate(key)
 
-产生以前缀key开头的唯一名称。
+该接口产生以前缀key开头的唯一名称。目前，Paddle通过从0开始的编号对相同前缀key的名称进行区分。例如，使用key=fc连续调用该接口会产生fc_0, fc_1, fc_2等不同名称。
 
 参数:
-  - **key** (str) - 产生的名称前缀。所有产生的名称都以此前缀开头。
+  - **key** (str) - 产生的唯一名称的前缀。
 
-返回：含前缀key的唯一字符串。
+返回：含前缀key的唯一名称。
 
-返回类型：str
+返回类型：str。
 
 **代码示例**
 
@@ -21,7 +21,6 @@ generate
         import paddle.fluid as fluid
         name1 = fluid.unique_name.generate('fc')
         name2 = fluid.unique_name.generate('fc')
-        # 结果为fc_0, fc_1
-        print name1, name2
+        print(name1, name2)  # fc_0, fc_1 
 
 

--- a/doc/fluid/api_cn/unique_name_cn/guard_cn.rst
+++ b/doc/fluid/api_cn/unique_name_cn/guard_cn.rst
@@ -5,10 +5,10 @@ guard
 
 .. py:function:: paddle.fluid.unique_name.guard(new_generator=None)
 
-该接口用于更改命名空间，与with语句一起使用。使用后，在with的上下文中使用新的命名空间，相同前缀的名称将从0开始重新编号。
+该接口用于更改命名空间，与with语句一起使用。使用后，在with语句的上下文中使用新的命名空间，调用generate接口时相同前缀的名称将从0开始重新编号。
 
 参数:
-  - **new_generator** (None|str|bytes) - 新命名空间的名称。请注意，Python2中的str在Python3中被区分为str和bytes两种，因此这里有两种类型。 默认值None。若不为None，new_generator将添加为产生的唯一名称的前缀。
+  - **new_generator** (str|bytes, 可选) - 新命名空间的名称。请注意，Python2中的str在Python3中被区分为str和bytes两种，因此这里有两种类型。 缺省值为None，若不为None，new_generator将作为前缀添加到generate接口产生的唯一名称中。
 
 返回: 无。
 

--- a/doc/fluid/api_cn/unique_name_cn/guard_cn.rst
+++ b/doc/fluid/api_cn/unique_name_cn/guard_cn.rst
@@ -5,11 +5,13 @@ guard
 
 .. py:function:: paddle.fluid.unique_name.guard(new_generator=None)
 
-使用with语句更改全局命名空间。
+该接口用于更改命名空间，与with语句一起使用。使用后，在with的上下文中使用新的命名空间，相同前缀的名称将从0开始重新编号。
 
 参数:
-  - **new_generator** (None|str|bytes) - 全局命名空间的新名称。请注意，Python2中的str在Python3中被区分为str和bytes两种，因此这里有两种类型。 默认值None。
- 
+  - **new_generator** (None|str|bytes) - 新命名空间的名称。请注意，Python2中的str在Python3中被区分为str和bytes两种，因此这里有两种类型。 默认值None。若不为None，new_generator将添加为产生的唯一名称的前缀。
+
+返回: 无。
+
 **代码示例**
 
 .. code-block:: python
@@ -19,14 +21,12 @@ guard
             name_1 = fluid.unique_name.generate('fc')
         with fluid.unique_name.guard():
             name_2 = fluid.unique_name.generate('fc')
-        # 结果为fc_0, fc_0
-        print name_1, name_2
+        print(name_1, name_2)  # fc_0, fc_0
          
         with fluid.unique_name.guard('A'):
             name_1 = fluid.unique_name.generate('fc')
         with fluid.unique_name.guard('B'):
             name_2 = fluid.unique_name.generate('fc')
-        # 结果为Afc_0, Bfc_0
-        print name_1, name_2
+        print(name_1, name_2)  # Afc_0, Bfc_0
 
 

--- a/doc/fluid/api_cn/unique_name_cn/switch_cn.rst
+++ b/doc/fluid/api_cn/unique_name_cn/switch_cn.rst
@@ -5,14 +5,14 @@ switch
 
 .. py:function:: paddle.fluid.unique_name.switch(new_generator=None)
 
-将Global命名空间切换到新的命名空间。
+该接口将当前上下文的命名空间切换到新的命名空间。
 
 参数:
-  - **new_generator** (None|UniqueNameGenerator) - 一个新的UniqueNameGenerator
+  - **new_generator** (None|UniqueNameGenerator) - 新的命名空间，若为None，则切换到一个新的匿名命名空间。默认为None。
 
-返回：先前的UniqueNameGenerator
+返回：先前的命名空间。
 
-返回类型：UniqueNameGenerator
+返回类型：UniqueNameGenerator。
 
 **代码示例**
 
@@ -21,10 +21,8 @@ switch
         import paddle.fluid as fluid
         name1 = fluid.unique_name.generate('fc')
         name2 = fluid.unique_name.generate('fc')
-        # 结果为fc_0, fc_1
-        print name1, name2
+        print(name1, name2)  ## fc_0, fc_1
          
         fluid.unique_name.switch()
         name2 = fluid.unique_name.generate('fc')
-        # 结果为fc_0
-        print name2
+        print(name2)  # fc_0

--- a/doc/fluid/api_cn/unique_name_cn/switch_cn.rst
+++ b/doc/fluid/api_cn/unique_name_cn/switch_cn.rst
@@ -5,12 +5,12 @@ switch
 
 .. py:function:: paddle.fluid.unique_name.switch(new_generator=None)
 
-该接口将当前上下文的命名空间切换到新的命名空间。
+该接口将当前上下文的命名空间切换到新的命名空间。该接口与guard接口都可用于更改命名空间，推荐使用guard接口，配合with语句管理命名空间上下文。
 
 参数:
-  - **new_generator** (None|UniqueNameGenerator) - 新的命名空间，若为None，则切换到一个新的匿名命名空间。默认为None。
+  - **new_generator** (UniqueNameGenerator, 可选) - 要切换到的新命名空间，一般无需设置。缺省值为None，表示切换到一个匿名的新命名空间。
 
-返回：先前的命名空间。
+返回：先前的命名空间，一般无需操作该返回值。
 
 返回类型：UniqueNameGenerator。
 

--- a/doc/fluid/api_cn/unique_name_cn/switch_cn.rst
+++ b/doc/fluid/api_cn/unique_name_cn/switch_cn.rst
@@ -21,8 +21,12 @@ switch
         import paddle.fluid as fluid
         name1 = fluid.unique_name.generate('fc')
         name2 = fluid.unique_name.generate('fc')
-        print(name1, name2)  ## fc_0, fc_1
+        print(name1, name2)  # fc_0, fc_1
          
-        fluid.unique_name.switch()
+        pre_generator = fluid.unique_name.switch()  # 切换到新命名空间
         name2 = fluid.unique_name.generate('fc')
         print(name2)  # fc_0
+
+        fluid.unique_name.switch(pre_generator)  # 切换回原命名空间
+        name3 = fluid.unique_name.generate('fc')
+        print(name3)  # fc_2, 因为原命名空间已生成fc_0, fc_1


### PR DESCRIPTION
This PR updates Chinese document of three APIs, i.e., fluid.unique_name.generate(), fluid.unique_name.switch() and fluid.unique_name.guard().