### PR TITLE
Improve document of GPU reallocate strategy flags

### DIFF
--- a/doc/fluid/flags/memory_cn.rst
+++ b/doc/fluid/flags/memory_cn.rst
@@ -190,19 +190,20 @@ FLAGS_initial_gpu_memory_in_mb
 *******************************************
 (始于1.4.0)
 
-分配一块指定大小的GPU内存块。之后的内存使用将从该内存块分配。如果内存块没有足够的gpu内存，将从gpu请求大小为FLAGS_reallocate_gpu_memory_in_mb的内存块，直到gpu没有剩余内存为止。
+预分配一块指定大小的GPU显存块。之后的显存使用将从该显存块分配。如果显存块没有足够的显存，将从GPU请求大小为FLAGS_reallocate_gpu_memory_in_mb的显存块，直到GPU没有剩余显存为止。
 
 取值范围
 ---------------
-Uint64型，大于0，为初始GPU内存大小，单位为MB。
+Uint64型，大于0，为初始GPU显存大小，单位为MB。
 
 示例
 -------
-FLAGS_initial_gpu_memory_in_mb=4096 - 分配4GB作为初始GPU内存块大小。
+FLAGS_initial_gpu_memory_in_mb=4096 - 分配4GB作为初始GPU显存块大小。
 
 注意
 -------
-如果设置该flag，则FLAGS_fraction_of_gpu_memory_to_use设置的内存大小将被该flag覆盖。如果未设置该flag，PaddlePaddle将使用FLAGS_fraction_of_gpu_memory_to_use分配GPU内存。
+如果设置该flag，则FLAGS_fraction_of_gpu_memory_to_use设置的显存大小将被该flag覆盖。PaddlePaddle将用该flag指定的值分配初始GPU显存。
+如果未设置该flag，即flag默认值为0时，会关闭此显存策略。PaddlePaddle会使用FLAGS_fraction_of_gpu_memory_to_use的策略来分配初始显存块。
 
 
 FLAGS_memory_fraction_of_eager_deletion
@@ -229,20 +230,20 @@ FLAGS_reallocate_gpu_memory_in_mb
 *******************************************
 (始于1.4.0)
 
-如果耗尽了分配的GPU内存块，则重新分配额外的GPU内存块。
+如果耗尽了分配的GPU显存块，则重新分配额外的GPU显存块。
 
 取值范围
 ---------------
-Int64型，大于0，单位为MB。
+Int64型，大于0，为重新分配的显存大小，单位为MB。
 
 示例
 -------
-FLAGS_reallocate_gpu_memory_in_mb=1024 - 如果耗尽了分配的GPU内存块，重新分配1GB。
+FLAGS_reallocate_gpu_memory_in_mb=1024 - 如果耗尽了分配的GPU显存块，重新分配1GB。
 
 注意
 -------
-如果设置了该flag，PaddlePaddle将重新分配该flag指定大小的gpu内存。否则分配FLAGS_fraction_of_gpu_memory_to_use指定比例的gpu内存。
-
+如果设置了该flag，则FLAGS_fraction_of_gpu_memory_to_use设置的显存大小将被该flag覆盖，PaddlePaddle将用该flag指定的值重分配额外GPU显存。
+如果未设置该flag，即flag默认值为0时，会关闭此显存策略。PaddlePaddle会使用FLAGS_fraction_of_gpu_memory_to_use的策略来重新分配额外显存。
 
 FLAGS_use_pinned_memory
 *******************************************

--- a/doc/fluid/flags/memory_en.rst
+++ b/doc/fluid/flags/memory_en.rst
@@ -192,11 +192,11 @@ FLAGS_initial_gpu_memory_in_mb
 *******************************************
 (since 1.4.0)
 
-Allocate a chunk of GPU memory whose byte size is specified by the flag. Future memory usage will be allocated from the chunk. If the chunk doesn't have enough gpu memory, additional chunks of the gpu memory will be requested from gpu with size specified by FLAGS_reallocate_gpu_memory_in_mb until the gpu has no memory left for the additional chunk.
+Allocate a chunk of GPU memory whose byte size is specified by the flag. Future memory usage will be allocated from the chunk. If the chunk doesn't have enough GPU memory, additional chunks of the GPU memory will be requested from GPU with size specified by FLAGS_reallocate_gpu_memory_in_mb until the GPU has no memory left for the additional chunk.
 
 Values accepted
 ---------------
-Uint64 value greater than 0 which is the initial GPU memory size in MB.
+Uint64 value greater than 0 which is the initial GPU memory size in MB. 
 
 Example
 -------
@@ -204,8 +204,8 @@ FLAGS_initial_gpu_memory_in_mb=4096 will allocate 4 GB as initial GPU chunk.
 
 Note
 -------
-If you set this flag, the memory size set by FLAGS_fraction_of_gpu_memory_to_use will be overrided by this flag.
-If you don't set this flag, PaddlePaddle will use FLAGS_fraction_of_gpu_memory_to_use to allocate gpu memory.
+If you set this flag, the memory size set by FLAGS_fraction_of_gpu_memory_to_use will be overrided by this flag, PaddlePaddle will allocate the initial gpu memory with size specified by this flag.
+If you don't set this flag, the dafault value 0 will disable this GPU memory strategy. PaddlePaddle will use FLAGS_fraction_of_gpu_memory_to_use to allocate the initial GPU chunk.
 
 
 
@@ -237,7 +237,7 @@ Re-allocate additional GPU chunk if run out of allocated GPU memory chunk.
 
 Values accepted
 ---------------
-Int64 value greater than 0 in MB
+Int64 value greater than 0 in MB which is the re-allocated GPU memory size in MB
 
 Example
 -------
@@ -245,9 +245,8 @@ FLAGS_reallocate_gpu_memory_in_mb=1024 will re-allocate 1 GB if run out of GPU m
 
 Note
 -------
-If this flag is set, PaddlePaddle will reallocate the gpu memory with size specified by this flag.
-Else PaddlePaddle will reallocate with size set by FLAGS_fraction_of_gpu_memory_to_use.
-
+If this flag is set, the memory size set by FLAGS_fraction_of_gpu_memory_to_use will be overrided by this flag, PaddlePaddle will re-allocate the gpu memory with size specified by this flag.
+If you don't set this flag, the dafault value 0 will disable this GPU memory strategy. PaddlePaddle will use FLAGS_fraction_of_gpu_memory_to_use to re-allocate GPU memory.
 
 
 FLAGS_use_pinned_memory


### PR DESCRIPTION
1. Add document for setting init_gpu_memory_in_mb to 0
2. Change "gpu" to capitalized "GPU"
3. Change some context-wise memory Chinese translation error： "内存" -> "显存" 

Chinese screenshot:

![image](https://user-images.githubusercontent.com/7913861/65748590-e819cf80-e136-11e9-994f-39d77bcbb954.png)

![image](https://user-images.githubusercontent.com/7913861/65748627-f8ca4580-e136-11e9-9487-625da5d3c2c7.png)


English screenshot:

![image](https://user-images.githubusercontent.com/7913861/65748668-0d0e4280-e137-11e9-9cd1-daa366a2195c.png)

![image](https://user-images.githubusercontent.com/7913861/65748681-17304100-e137-11e9-88aa-ca5268a4abcf.png)

