### PR TITLE
Remove needless methods api in English doc

### DIFF
--- a/doc/fluid/api/gen_doc.py
+++ b/doc/fluid/api/gen_doc.py
@@ -94,6 +94,14 @@ class DocGenerator(object):
     :noindex:
 
 '''.format(self.module_prefix, name))
+        elif "fluid.optimizer" in self.module_prefix:
+            self.stream.write('''..  autoclass:: paddle.{0}.{1}
+    :members:
+    :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
+    :noindex:
+
+'''.format(self.module_prefix, name))
         else:
             self.stream.write('''..  autoclass:: paddle.{0}.{1}
     :members:

--- a/doc/fluid/api/optimizer/AdagradOptimizer.rst
+++ b/doc/fluid/api/optimizer/AdagradOptimizer.rst
@@ -9,5 +9,6 @@ AdagradOptimizer
 ..  autoclass:: paddle.fluid.optimizer.AdagradOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 

--- a/doc/fluid/api/optimizer/AdamOptimizer.rst
+++ b/doc/fluid/api/optimizer/AdamOptimizer.rst
@@ -9,5 +9,6 @@ AdamOptimizer
 ..  autoclass:: paddle.fluid.optimizer.AdamOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 

--- a/doc/fluid/api/optimizer/AdamaxOptimizer.rst
+++ b/doc/fluid/api/optimizer/AdamaxOptimizer.rst
@@ -9,5 +9,6 @@ AdamaxOptimizer
 ..  autoclass:: paddle.fluid.optimizer.AdamaxOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 

--- a/doc/fluid/api/optimizer/DecayedAdagradOptimizer.rst
+++ b/doc/fluid/api/optimizer/DecayedAdagradOptimizer.rst
@@ -9,5 +9,6 @@ DecayedAdagradOptimizer
 ..  autoclass:: paddle.fluid.optimizer.DecayedAdagradOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 

--- a/doc/fluid/api/optimizer/ModelAverage.rst
+++ b/doc/fluid/api/optimizer/ModelAverage.rst
@@ -8,6 +8,5 @@ ModelAverage
 
 ..  autoclass:: paddle.fluid.optimizer.ModelAverage
     :members:
-    :inherited-members:
     :noindex:
 

--- a/doc/fluid/api/optimizer/MomentumOptimizer.rst
+++ b/doc/fluid/api/optimizer/MomentumOptimizer.rst
@@ -9,5 +9,6 @@ MomentumOptimizer
 ..  autoclass:: paddle.fluid.optimizer.MomentumOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 

--- a/doc/fluid/api/optimizer/RMSPropOptimizer.rst
+++ b/doc/fluid/api/optimizer/RMSPropOptimizer.rst
@@ -9,5 +9,6 @@ RMSPropOptimizer
 ..  autoclass:: paddle.fluid.optimizer.RMSPropOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 

--- a/doc/fluid/api/optimizer/SGDOptimizer.rst
+++ b/doc/fluid/api/optimizer/SGDOptimizer.rst
@@ -9,5 +9,6 @@ SGDOptimizer
 ..  autoclass:: paddle.fluid.optimizer.SGDOptimizer
     :members:
     :inherited-members:
+    :exclude-members: apply_gradients, apply_optimize, backward, load
     :noindex:
 


### PR DESCRIPTION
根据此次修改文档的如下规则

> 基础Optimizer类的中文API只保留类的介绍以及minimize接口，例如AdamOptimizer只有AdamOptimizer和minimize两段介绍，其他几个接口，apply_gradients，apply_optimizes, backward，load等的介绍暂时删除

将apply_gradients，apply_optimizes, backward，load接口暂时从API文档中移除