### PR TITLE
remove np.dtype in param dtype of embedding

### DIFF
--- a/doc/fluid/api_cn/fluid_cn/embedding_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/embedding_cn.rst
@@ -57,7 +57,7 @@ embedding
     - **is_distributed** (bool) - 是否使用分布式的方式存储embedding矩阵，仅在多机分布式cpu训练中使用。默认为False。
     - **padding_idx** (int|long|None) - padding_idx需在区间[-vocab_size, vocab_size)，否则不生效，padding_idx<0时，padding_idx 会被改成 vocab_size + padding_idx，input中等于padding_index的id对应的embedding信息会被设置为0，且这部分填充数据在训练时将不会被更新。如果为none，不作处理，默认为None。
     - **param_attr** (ParamAttr) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。此外，可以通过 ``param_attr`` 参数加载用户自定义或预训练的词向量。只需将本地词向量转为numpy数据格式，且保证本地词向量的shape和embedding的 ``size`` 参数一致，然后使用 :ref:`cn_api_fluid_initializer_NumpyArrayInitializer` 进行初始化，即可实现加载自定义或预训练的词向量。详细使用方法见代码示例2。
-    - **dtype** (str|np.dtype|core.VarDesc.VarType) - 输出Tensor或LoDTensor的数据类型，数据类型必须为：float32，float64，默认为float32。
+    - **dtype** (str|core.VarDesc.VarType) - 输出Tensor或LoDTensor的数据类型，数据类型必须为：float32，float64，默认为float32。
 
 返回：input映射后embedding Tensor或LoDTensor，数据类型和dtype定义的类型一致。
 

--- a/doc/fluid/api_cn/layers_cn/embedding_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/embedding_cn.rst
@@ -61,7 +61,7 @@ embedding
     - **is_distributed** (bool) - 是否使用分布式的方式存储embedding矩阵，仅在多机分布式cpu训练中使用。默认为False。
     - **padding_idx** (int|long|None) - padding_idx需在区间[-vocab_size, vocab_size)，否则不生效，padding_idx<0时，padding_idx会被改成vocab_size + padding_idx，input中等于padding_index的id对应的embedding信息会被设置为0，且这部分填充数据在训练时将不会被更新。如果为None，不作处理，默认为None。
     - **param_attr** (ParamAttr) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。此外，可以通过 ``param_attr`` 参数加载用户自定义或预训练的词向量。只需将本地词向量转为numpy数据格式，且保证本地词向量的shape和embedding的 ``size`` 参数一致，然后使用 :ref:`cn_api_fluid_initializer_NumpyArrayInitializer` 进行初始化，即可实现加载自定义或预训练的词向量。详细使用方法见代码示例2。
-    - **dtype** (str|np.dtype|core.VarDesc.VarType) - 输出Tensor或LoDTensor的数据类型，数据类型必须为：float32或float64，默认为float32。
+    - **dtype** (str|core.VarDesc.VarType) - 输出Tensor或LoDTensor的数据类型，数据类型必须为：float32或float64，默认为float32。
 
 返回：input映射后得到的Embedding Tensor或LoDTensor，数据类型和dtype定义的类型一致。
 


### PR DESCRIPTION
+ embedding don't support `np.dype` in `dtype`

Test Code:
```python
import paddle.fluid as fluid
import numpy as np
x = fluid.layers.data(name='x', shape=[1], dtype='int64', lod_level=1)
emb = fluid.layers.embedding(input=x, size=(128, 100), dtype=np.float32)
```

It will exit with error:
```
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    input=x, size=(128, 100), dtype=np.float32)
  File "/Users/XXX/Documents/project/ENV2.7/lib/python2.7/site-packages/paddle/fluid/layers/nn.py", line 400, in embedding
    attr=helper.param_attr, shape=size, dtype=dtype, is_bias=False)
  File "/Users/XXX/Documents/project/ENV2.7/lib/python2.7/site-packages/paddle/fluid/layer_helper_base.py", line 288, in create_parameter
    if not (dtype.startswith("float") or dtype == "double"):
AttributeError: type object 'numpy.float32' has no attribute 'startswith'
```