### PR TITLE
update name_scope document

### DIFF
--- a/doc/fluid/api_cn/fluid_cn/name_scope_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/name_scope_cn.rst
@@ -6,7 +6,7 @@ name_scope
 .. py:function:: paddle.fluid.name_scope(prefix=None)
 
 
-该OP为operators生成不同的命名空间。此OP用于调试和可视化，不建议用在其它方面。
+该函数为operators生成不同的命名空间。该函数只用于调试和可视化，不建议用在其它方面。
 
 
 参数：
@@ -18,7 +18,7 @@ name_scope
           
      import paddle.fluid as fluid
      with fluid.name_scope("s1"):
-        a = fluid.layers.data(name='data', shape=[1], dtype='int32')
+        a = fluid.data(name='data', shape=[None, 1], dtype='int32')
         b = a + 1
         with fluid.name_scope("s2"):
            c = b * 1
@@ -33,18 +33,16 @@ name_scope
      for op in fluid.default_main_program().block(0).ops:
          # elementwise_add在/s1/中创建
          if op.type == 'elementwise_add':
-             self.assertEqual(op.desc.attr("op_namescope"), '/s1/')
+             assert op.desc.attr("op_namescope") == '/s1/'
          # elementwise_mul在/s1/s2中创建
          elif op.type == 'elementwise_mul':
-             self.assertEqual(op.desc.attr("op_namescope"), '/s1/s2/')
+             assert op.desc.attr("op_namescope") == '/s1/s2/'
          # elementwise_div在/s1/s3中创建
          elif op.type == 'elementwise_div':
-             self.assertEqual(op.desc.attr("op_namescope"), '/s1/s3/')
+             assert op.desc.attr("op_namescope") == '/s1/s3/'
          # elementwise_sum在/s4/中创建
          elif op.type == 'elementwise_sub':
-             self.assertEqual(op.desc.attr("op_namescope"), '/s4/')
+             assert op.desc.attr("op_namescope") == '/s4/'
          # pow在/s1_1/中创建
          elif op.type == 'pow':
-             self.assertEqual(op.desc.attr("op_namescope"), '/s1_1/')
-
-
+             assert op.desc.attr("op_namescope") == '/s1_1/'


### PR DESCRIPTION
修复name_scope注释：
1. 之前的示例用了`self.assertEqual`，这是在单测里用的，但直接运行示例会出错。
![image](https://user-images.githubusercontent.com/6836917/66543772-e0abea80-eb68-11e9-8e99-e519940ae3db.png)
因此将其改成assert。对应英文PR在https://github.com/PaddlePaddle/Paddle/pull/20373
2. 将“该Op”改成“该函数”，因为这个API不是OP。
![image](https://user-images.githubusercontent.com/6836917/66543930-4e581680-eb69-11e9-929e-04ec7554b00f.png)
![image](https://user-images.githubusercontent.com/6836917/66543944-57e17e80-eb69-11e9-9ebb-db92a79f5fd3.png)

