### PR TITLE
Remove benchmark from index and refine the format

### DIFF
--- a/doc/fluid/advanced_usage/development/profiling/index_cn.rst
+++ b/doc/fluid/advanced_usage/development/profiling/index_cn.rst
@@ -5,15 +5,12 @@
 ..  toctree::
 	:hidden:
 
-
-	benchmark_cn.md
 	cpu_profiling_cn.md
 	host_memory_profiling_cn.md
 	timeline_cn.md
 
 本模块介绍 Fluid 使用过程中的调优方法，包括：
 
-- `如何进行基准测试 <benchmark_cn.html>`_：介绍如何选择基准模型，从而验证模型的精度和性能
 - `CPU性能调优 <cpu_profiling_cn.html>`_：介绍如何使用 cProfile 包、yep库、Google perftools 进行性能分析与调优
 - `堆内存分析和优化 <host_memory_profiling_cn.html>`_：介绍如何使用 gperftool 进行堆内存分析和优化，以解决内存泄漏的问题
 - `Timeline工具简介 <timeline_cn.html>`_ ：介绍如何使用 Timeline 工具进行性能分析和调优

--- a/doc/fluid/beginners_guide/index_cn.rst
+++ b/doc/fluid/beginners_guide/index_cn.rst
@@ -8,17 +8,17 @@ PaddlePaddle (PArallel Distributed Deep LEarning)是一个易用、高效、灵�
 
 让我们从这里开始：
 
-    - `快速开始 <../beginners_guide/quick_start_cn.html>`_
+- `快速开始 <../beginners_guide/quick_start_cn.html>`_
 
 当您第一次来到PaddlePaddle，请您首先阅读以下文档，了解安装方法：
 
-    - `安装说明 <../beginners_guide/install/index_cn.html>`_：我们支持在Ubuntu/CentOS/Windows/MacOS环境上的安装
+- `安装说明 <../beginners_guide/install/index_cn.html>`_：我们支持在Ubuntu/CentOS/Windows/MacOS环境上的安装
 
 这里为您提供了更多学习资料:
 
-    - `深度学习基础 <../beginners_guide/basics/index_cn.html>`_：覆盖图像分类、个性化推荐、机器翻译等多个深度领域的基础知识，提供 Fluid 实现案例
+- `深度学习基础 <../beginners_guide/basics/index_cn.html>`_：覆盖图像分类、个性化推荐、机器翻译等多个深度领域的基础知识，提供 Fluid 实现案例
 
-    - `Fluid编程指南 <../beginners_guide/programming_guide/programming_guide.html>`_：介绍 Fluid 的基本概念和使用方法
+- `Fluid编程指南 <../beginners_guide/programming_guide/programming_guide.html>`_：介绍 Fluid 的基本概念和使用方法
 
 ..  toctree::
     :hidden:

--- a/doc/fluid/beginners_guide/index_en.rst
+++ b/doc/fluid/beginners_guide/index_en.rst
@@ -9,13 +9,12 @@ Please refer to  `PaddlePaddle Github <https://github.com/PaddlePaddle/Paddle>`_
 
 For beginners of PaddlePaddle, the following documentation will tutor you about installing PaddlePaddle:
 
-    - `Installation Manuals <../beginners_guide/install/index_en.html>`_ ：Installation on Ubuntu/CentOS/Windows/MacOS is supported.
+- `Installation Manuals <../beginners_guide/install/index_en.html>`_ ：Installation on Ubuntu/CentOS/Windows/MacOS is supported.
 
 If you have been armed with certain level of deep learning knowledge, and it happens to be the first time to try PaddlePaddle, the following cases of model building will expedite your learning process:
 
-    - `Programming with Fluid <../beginners_guide/programming_guide/programming_guide_en.html>`_ ： Core concepts and basic usage of Fluid
-
-    - `Deep Learning  Basics <../beginners_guide/basics/index_en.html>`_： This section encompasses various fields of fundamental deep learning knowledge, such as image classification, customized recommendation, machine translation, and examples implemented by Fluid are provided.
+- `Programming with Fluid <../beginners_guide/programming_guide/programming_guide_en.html>`_ ： Core concepts and basic usage of Fluid
+- `Deep Learning  Basics <../beginners_guide/basics/index_en.html>`_： This section encompasses various fields of fundamental deep learning knowledge, such as image classification, customized recommendation, machine translation, and examples implemented by Fluid are provided.
 
 
 ..  toctree::


### PR DESCRIPTION
- benchmark的目录显示有问题，且内容也不准确，当时只是从1.5分支里面删除了，没有从develop分支删除，见[develop文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/advanced_usage/development/profiling/index_cn.html)

![image](https://user-images.githubusercontent.com/12538138/66696349-da02ac00-ecfd-11e9-96d6-72b7e71cc582.png)


- 新手入门有些格式不对，[develop中文文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/beginners_guide/index_cn.html)，[develop英文文档](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/beginners_guide/index_en.html)，改完之后如下

中文文档：
![image](https://user-images.githubusercontent.com/12538138/66695716-868d5f80-ecf7-11e9-87e2-c083e2a8ed99.png)

英文文档：
![image](https://user-images.githubusercontent.com/12538138/66696288-387b5a80-ecfd-11e9-9200-ecbaf8cd1ed2.png)
