### PR TITLE
Synchronize Chinese and English DOC of API:layers.sum

### DIFF
--- a/doc/fluid/api_cn/layers_cn/sum_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sum_cn.rst
@@ -48,13 +48,28 @@ sum
 **代码示例：**
 
 .. code-block:: python
+	
+	import paddle.fluid as fluid
+	input0 = fluid.layers.fill_constant(shape=[2, 3], dtype='int64', value=5)
+	input1 = fluid.layers.fill_constant(shape=[2, 3], dtype='int64', value=3)
+	sum = fluid.layers.sum([input0, input1])
 
-    import paddle.fluid as fluid
-    import paddle.fluid.layers as layers
-    input0 = layers.data(name="input0", shape=[13, 11], dtype='float32')
-    input1 = layers.data(name="input1", shape=[13, 11], dtype='float32')
-    out = layers.sum([input0,input1])
+	#用户可以通过executor打印出求和的结果
+	out = fluid.layers.Print(sum, message="the sum of input0 and input1: ")
+	exe = fluid.Executor(fluid.CPUPlace())
+	exe.run(fluid.default_main_program())
 
+	#打印出的数据为：
+	1570701754	the sum of input0 and input1: 	The place is:CPUPlace
+	Tensor[sum_0.tmp_0]
+		shape: [2,3,]
+		dtype: l
+		data: 8,8,8,8,8,8,
+
+	#输出了shape为[2,3]的Tensor，与输入的shape一致
+	#dtype为对应C++数据类型，在不同环境下可能显示值不同，但本质相同
+	#例如：如果Tensor中数据类型是int64，则对应的C++数据类型为int64_t，所以dtype值为typeid(int64_t).name()，
+	#      其在MacOS下为'x'，linux下为'l'，Windows下为'__int64'，都表示64位整型变量
 
 
 


### PR DESCRIPTION
Fix fluid.layers.data of example code, Synchronize Chinese and English DOC of API:layers.sum.

The English Doc PR is [20329](https://github.com/PaddlePaddle/Paddle/pull/20329), which has benn merged.

Chinese Doc:
<img width="971" alt="MacHi 2019-10-12 21-11-54" src="https://user-images.githubusercontent.com/52485244/66702029-90ce4e80-ed35-11e9-8673-fd4600687a68.png">

English Doc:
<img width="958" alt="MacHi 2019-10-10 20-24-46" src="https://user-images.githubusercontent.com/52485244/66702044-ac395980-ed35-11e9-9d06-d38fdf92514f.png">


