### PR TITLE
modified cn doc of crop_tensor for attr(shape) supporting -1

### DIFF
--- a/doc/fluid/api_cn/layers_cn/crop_tensor_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/crop_tensor_cn.rst
@@ -41,7 +41,7 @@ crop_tensor
                         [0, 0, 0, 0]]]
 
         参数：
-            shape = [2, 2, 3]
+            shape = [2, 2, -1]
             offsets = [0, 0, 1]
 
         输出：
@@ -52,8 +52,8 @@ crop_tensor
                          [6, 7, 8]]]
 
 参数:
-  - **x** (Variable): 1-D到6-D Tensor，数据类型为float32或float64。
-  - **shape** (list|tuple|Variable) - 输出Tensor的形状，数据类型为int32。如果是列表或元组，则其长度必须与x的维度大小相同，如果是Variable，则其应该是1-D Tensor。当它是列表时，每一个元素可以是整数或者形状为[1]的Tensor。含有Variable的方式适用于每次迭代时需要改变输出形状的情况。列表和元组中只有第一个元素可以被设置为-1，这意味着输出的第一维大小与输入相同。
+  - **x** (Variable): 1-D到6-D Tensor，数据类型为float32、float64、int32或者int64。
+  - **shape** (list|tuple|Variable) - 输出Tensor的形状，数据类型为int32。如果是列表或元组，则其长度必须与x的维度大小相同，如果是Variable，则其应该是1-D Tensor。当它是列表时，每一个元素可以是整数或者形状为[1]的Tensor。含有Variable的方式适用于每次迭代时需要改变输出形状的情况。
   - **offsets** (list|tuple|Variable，可选) - 每个维度上裁剪的偏移量，数据类型为int32。如果是列表或元组，则其长度必须与x的维度大小相同，如果是Variable，则其应是1-D Tensor。当它是列表时，每一个元素可以是整数或者形状为[1]的Variable。含有Variable的方式适用于每次迭代的偏移量（offset）都可能改变的情况。默认值：None，每个维度的偏移量为0。
   - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
 
@@ -62,39 +62,43 @@ crop_tensor
 返回类型: Variable
 
 抛出异常：
-    - :code:`ValueError` - shape 应该是列表、元组或Variable。
-    - :code:`ValueError` - offsets 应该是列表、元组、Variable或None。
+    - :code:`TypeError` - x 的数据类型应该是float32、float64、int32或者int64。
+    - :code:`TypeError` - shape 应该是列表、元组或Variable。
+    - :code:`TypeError` - shape 的数据类型应该是int32。
+    - :code:`TypeError` - offsets 应该是列表、元组、Variable或None。
+    - :code:`TypeError` - offsets 的数据类型应该是int32。
+    - :code:`TypeError` - offsets 的元素应该大于等于0。
 
 **代码示例**:
 
 ..  code-block:: python
     
     import paddle.fluid as fluid
-    x = fluid.layers.data(name="x", shape=[3, 5], dtype="float32")
+    x = fluid.data(name="x", shape=[None, 3, 5], dtype="float32")
     # x.shape = [-1, 3, 5], where -1 indicates batch size, and it will get the exact value in runtime.
 
-    # shape is a 1-D tensor variable
-    crop_shape = fluid.layers.data(name="crop_shape", shape=[3], dtype="int32", append_batch_size=False)
+    # shape is a 1-D Tensor
+    crop_shape = fluid.data(name="crop_shape", shape=[3], dtype="int32")
     crop0 = fluid.layers.crop_tensor(x, shape=crop_shape)
     # crop0.shape = [-1, -1, -1], it means crop0.shape[0] = x.shape[0] in runtime.
 
     # or shape is a list in which each element is a constant
-    crop1 = fluid.layers.crop_tensor(x, shape=[-1, 2, 3])
+    crop1 = fluid.layers.crop_tensor(x, shape=[-1, -1, 3], offsets=[0, 1, 0])
     # crop1.shape = [-1, 2, 3]
 
-    # or shape is a list in which each element is a constant or variable
-    y = fluid.layers.data(name="y", shape=[3, 8, 8], dtype="float32")
-    dim1 = fluid.layers.data(name="dim1", shape=[1], dtype="int32", append_batch_size=False)
-    crop2 = fluid.layers.crop_tensor(y, shape=[-1, 3, dim1, 4])
-    # crop2.shape = [-1, 3, -1, 4]
+    # or shape is a list in which each element is a constant or Tensor
+    y = fluid.data(name="y", shape=[3, 8, 8], dtype="float32")
+    dim1 = fluid.layers.data(name="dim1", shape=[1], dtype="int32")
+    crop2 = fluid.layers.crop_tensor(y, shape=[3, dim1, 4])
+    # crop2.shape = [3, -1, 4]
 
-    # offsets is a 1-D tensor variable
-    crop_offsets = fluid.layers.data(name="crop_offsets", shape=[3], dtype="int32", append_batch_size=False)
+    # offsets is a 1-D Tensor
+    crop_offsets = fluid.data(name="crop_offsets", shape=[3], dtype="int32")
     crop3 = fluid.layers.crop_tensor(x, shape=[-1, 2, 3], offsets=crop_offsets)
     # crop3.shape = [-1, 2, 3]
 
-    # offsets is a list in which each element is a constant or variable
-    offsets_var =  fluid.layers.data(name="dim1", shape=[1], dtype="int32", append_batch_size=False)
+    # offsets is a list in which each element is a constant or Tensor
+    offsets_var =  fluid.data(name="dim1", shape=[1], dtype="int32")
     crop4 = fluid.layers.crop_tensor(x, shape=[-1, 2, 3], offsets=[0, 1, offsets_var])
     # crop4.shape = [-1, 2, 3]
 


### PR DESCRIPTION
修改crop_tensor中文文档：
- 修改case2示例，以便于理解shape支持-1的用法及运行结果
- 修改`x`数据类型说明，`shape`的参数说明：删除"列表和元组中只有第一个元素可以被设置为-1"的限制
- 修改“抛出异常”
- 修改code example：去除fluid.layers.data；示例中给出shape支持-1的例子
![image](https://user-images.githubusercontent.com/26615455/67264850-df6eac00-f4de-11e9-82d2-b48a970994dc.png)
![image](https://user-images.githubusercontent.com/26615455/67264894-f57c6c80-f4de-11e9-8986-b5bda2da08e8.png)
![image](https://user-images.githubusercontent.com/26615455/67265030-468c6080-f4df-11e9-9f73-c25f6b5f4148.png)

