### PR TITLE
Add numpy bridge zero_copy cn doc

### DIFF
--- a/doc/fluid/api_cn/dygraph_cn/to_variable_cn.rst
+++ b/doc/fluid/api_cn/dygraph_cn/to_variable_cn.rst
@@ -3,7 +3,7 @@
 to_variable
 -------------------------------
 
-.. py:function:: paddle.fluid.dygraph_to_variable(value, block=None, name=None)
+.. py:function:: paddle.fluid.dygraph_to_variable(value, block=None, name=None, zero_copy=None)
 
 该函数实现从numpy\.ndarray对象或者Variable对象创建一个 ``Variable`` 类型的对象。
 
@@ -11,6 +11,7 @@ to_variable
     - **value** (ndarray) – 需要转换的numpy\.ndarray对象，维度可以为多维，数据类型为numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}中的一种。
     - **block** (fluid.Block, 可选) – Variable所在的Block，默认值为None。
     - **name**  (str, 可选) – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
+    - **zero_copy**  (bool, 可选) – 是否与输入的numpy数组共享内存。此参数仅适用于CPUPlace，当它为None时将设置为True。默认值为None。
 
 
 返回：从指定numpy\.ndarray对象创建的 ``Tensor`` ，数据类型和 ``value`` 一致，返回值维度和 ``value`` 一致
@@ -24,7 +25,12 @@ to_variable
     import numpy as np
     import paddle.fluid as fluid
 
-    with fluid.dygraph.guard():
+    with fluid.dygraph.guard(fluid.CPUPlace()):
         x = np.ones([2, 2], np.float32)
+        y = fluid.dygraph.to_variable(x, zero_copy=False)
+        x[0][0] = -1
+        y[0][0].numpy()  # array([1.], dtype=float32)
         y = fluid.dygraph.to_variable(x)
+        x[0][0] = 0
+        y[0][0].numpy()  # array([0.], dtype=float32)
 

--- a/doc/fluid/api_cn/fluid_cn/Tensor_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/Tensor_cn.rst
@@ -15,63 +15,14 @@ Tensor用于表示多维张量，可以通过 ``np.array(tensor)`` 方法转换�
 
       t = fluid.Tensor()
 
-.. py:method::  set(*args, **kwargs)
+.. py:method::  set(array, place, zero_copy=False)
 
 该接口根据输入的numpy array和设备place，设置Tensor的数据。
-
-重载函数：
-
-1. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[float32], place: paddle::platform::CPUPlace) -> None
-
-2. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int32], place: paddle::platform::CPUPlace) -> None
-
-3. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[float64], place: paddle::platform::CPUPlace) -> None
-
-4. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int64], place: paddle::platform::CPUPlace) -> None
-
-5. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[bool], place: paddle::platform::CPUPlace) -> None
-
-6. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[uint16], place: paddle::platform::CPUPlace) -> None
-
-7. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[uint8], place: paddle::platform::CPUPlace) -> None
-
-8. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int8], place: paddle::platform::CPUPlace) -> None
-
-9. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[float32], place: paddle::platform::CUDAPlace) -> None
-
-10. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int32], place: paddle::platform::CUDAPlace) -> None
-
-11. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[float64], place: paddle::platform::CUDAPlace) -> None
-
-12. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int64], place: paddle::platform::CUDAPlace) -> None
-
-13. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[bool], place: paddle::platform::CUDAPlace) -> None
-
-14. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[uint16], place: paddle::platform::CUDAPlace) -> None
-
-15. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[uint8], place: paddle::platform::CUDAPlace) -> None
-
-16. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int8], place: paddle::platform::CUDAPlace) -> None
-
-17. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[float32], place: paddle::platform::CUDAPinnedPlace) -> None
-
-18. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int32], place: paddle::platform::CUDAPinnedPlace) -> None
-
-19. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[float64], place: paddle::platform::CUDAPinnedPlace) -> None
-
-20. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int64], place: paddle::platform::CUDAPinnedPlace) -> None
-
-21. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[bool], place: paddle::platform::CUDAPinnedPlace) -> None
-
-22. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[uint16], place: paddle::platform::CUDAPinnedPlace) -> None
-
-23. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[uint8], place: paddle::platform::CUDAPinnedPlace) -> None
-
-24. set(self: paddle.fluid.core_avx.Tensor, array: numpy.ndarray[int8], place: paddle::platform::CUDAPinnedPlace) -> None
 
 参数：
     - **array** (numpy.ndarray) - 要设置的numpy array，支持的数据类型为bool, float32, float64, int8, int32, int64, uint8, uint16。
     - **place** (CPUPlace|CUDAPlace|CUDAPinnedPlace) - 要设置的Tensor所在的设备。
+    - **zero_copy** (bool，可选) - 是否与输入的numpy数组共享内存。此参数仅适用于CPUPlace。默认值为False。
 
 返回：无。
 


### PR DESCRIPTION
add an optional `zero_copy` parameter for numpy bridge [[PR](https://github.com/PaddlePaddle/Paddle/pull/20983)]:

- dygraph `to_variable` 
- Tensor `set`

![10 88 157 35_8080_documentation_docs_zh_api_cn_fluid_cn_Tensor_cn html](https://user-images.githubusercontent.com/2573291/69703474-6fca8d00-112c-11ea-9c44-ec5c41b07161.png)

![10 88 157 35_8080_documentation_docs_zh_api_cn_dygraph_cn_to_variable_cn html](https://user-images.githubusercontent.com/2573291/69704116-d0a69500-112d-11ea-8cc2-94dc0d911897.png)
