### PR TITLE
update PRelu doc

### DIFF
--- a/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
+++ b/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
@@ -16,11 +16,11 @@ PRelu
 参数：
     - **mode** (str) - 权重共享模式。共提供三种激活方式：
 
-        .. code-block:: text
-            
-            all：所有元素使用同一个 :math:`[\alpha]` 值
-            channel：在同一个通道中的元素使用同一个 :math:`[\alpha]` 值
-            element：每一个元素有一个独立的 :math:`[\alpha]` 值
+    .. code-block:: text
+
+        all：所有元素使用同一个 :math:`[\alpha]` 值
+        channel：在同一个通道中的元素使用同一个 :math:`[\alpha]` 值
+        element：每一个元素有一个独立的 :math:`[\alpha]` 值
 
     - **channel_or_input_shape** (int 或 list 或 tuple，可选) - 通道数或输入的维度。该参数仅在mode参数为"channel"或"element"时有用。当mode为“channel”时参数为int，当mode为“element”时参数为list或tuple。默认为None。
     - **param_attr** (ParamAttr, 可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。

--- a/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
+++ b/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
@@ -18,9 +18,9 @@ PRelu
 
     .. code-block:: text
 
-        all：所有元素使用同一个 :math:`[\alpha]` 值
-        channel：在同一个通道中的元素使用同一个 :math:`[\alpha]` 值
-        element：每一个元素有一个独立的 :math:`[\alpha]` 值
+        all：所有元素使用同一个alpha值
+        channel：在同一个通道中的元素使用同一个alpha值
+        element：每一个元素有一个独立的alpha值
 
     - **channel** (int，可选) - 通道数。该参数在mode参数为"channel"时是必须的。默认为None。
     - **input_shape** (int 或 list 或 tuple，可选) - 输入的维度。该参数在mode参数为"element"时是必须的。默认为None。

--- a/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
+++ b/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
@@ -22,7 +22,8 @@ PRelu
         channel：在同一个通道中的元素使用同一个 :math:`[\alpha]` 值
         element：每一个元素有一个独立的 :math:`[\alpha]` 值
 
-    - **channel_or_input_shape** (int 或 list 或 tuple，可选) - 通道数或输入的维度。该参数仅在mode参数为"channel"或"element"时有用。当mode为“channel”时参数为int，当mode为“element”时参数为list或tuple。默认为None。
+    - **channel** (int，可选) - 通道数。该参数在mode参数为"channel"时是必须的。默认为None。
+    - **input_shape** (int 或 list 或 tuple，可选) - 输入的维度。该参数在mode参数为"element"时是必须的。默认为None。
     - **param_attr** (ParamAttr, 可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **dtype** (str, 可选) - 数据类型，可以为"float32"或"float64"。默认值："float32"。
 
@@ -45,12 +46,12 @@ PRelu
         dy_rlt0 = prelu0(inp_np)
         prelu1 = fluid.PRelu(
            mode='channel',
-           channel_or_input_shape=200,
+           channel=200,
            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
         dy_rlt1 = prelu1(inp_np)
         prelu2 = fluid.PRelu(
            mode='element',
-           channel_or_input_shape=inp_np.shape,
+           input_shape=inp_np.shape,
            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
         dy_rlt2 = prelu2(inp_np)
 

--- a/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
+++ b/doc/fluid/api_cn/dygraph_cn/PRelu_cn.rst
@@ -22,7 +22,7 @@ PRelu
             channel：在同一个通道中的元素使用同一个 :math:`[\alpha]` 值
             element：每一个元素有一个独立的 :math:`[\alpha]` 值
 
-    - **input_shape** (list 或 tuple，可选) - 输入的维度，该参数仅在mode参数为"all"时需要设置。默认为None。
+    - **channel_or_input_shape** (int 或 list 或 tuple，可选) - 通道数或输入的维度。该参数仅在mode参数为"channel"或"element"时有用。当mode为“channel”时参数为int，当mode为“element”时参数为list或tuple。默认为None。
     - **param_attr** (ParamAttr, 可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **dtype** (str, 可选) - 数据类型，可以为"float32"或"float64"。默认值："float32"。
 
@@ -39,9 +39,20 @@ PRelu
     inp_np = np.ones([5, 200, 100, 100]).astype('float32')
     with fluid.dygraph.guard():
         inp_np = to_variable(inp_np)
-        mode = 'channel'
-        prelu = fluid.PRelu('prelu', mode=mode, param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
-        dy_rlt = prelu(inp_np)
+        prelu0 = fluid.PRelu(
+           mode='all',
+           param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
+        dy_rlt0 = prelu0(inp_np)
+        prelu1 = fluid.PRelu(
+           mode='channel',
+           channel_or_input_shape=200,
+           param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
+        dy_rlt1 = prelu1(inp_np)
+        prelu2 = fluid.PRelu(
+           mode='element',
+           channel_or_input_shape=inp_np.shape,
+           param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
+        dy_rlt2 = prelu2(inp_np)
 
 属性
 ::::::::::::


### PR DESCRIPTION
修改PRelu的input_shape参数为channel_or_input_shape，并补充示例。
对应PR：https://github.com/PaddlePaddle/Paddle/pull/21946

![10 88 157 35_8080_documentation_docs_zh_api_cn_dygraph_cn_PRelu_cn html (3)](https://user-images.githubusercontent.com/2573291/71892755-be843180-3184-11ea-80cd-db012fa178b3.png)
