### PR TITLE
add example for reshape op

### DIFF
--- a/doc/fluid/api_cn/layers_cn/reshape_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/reshape_cn.rst
@@ -67,7 +67,11 @@ reshape
   reshaped_2 = fluid.layers.reshape(data_2, shape=[dim, 10])
   # the shape of reshaped_2 is [5,10].
 
-
+  # example 3:
+  data_3 = fluid.data(
+      name="data_3", shape=[2,4,6], dtype='float32')
+  reshaped_3 = fluid.layers.reshape(x=data_3, shape=[6,8])
+  # the shape of reshaped_3 is [6,8].
 
 
 


### PR DESCRIPTION
用户问：请问一下，怎么reshape一个lodtensor，特别地，是将3维的降低成2维

经查，文档中有说明，但没有对应的示例

https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/layers_cn/reshape_cn.html

给定一个形状为[2,4,6]的三维张量x，目标形状为[6,8]，则将x变换为形状为[6,8]的2-D张量，且x的数据保持不变。
补充示例:
![image](https://user-images.githubusercontent.com/23031310/71883870-3eed6700-3172-11ea-93a0-745107078677.png)
