### PR TITLE
refine some reader API

### DIFF
--- a/doc/fluid/api_cn/io_cn/PipeReader_cn.rst
+++ b/doc/fluid/api_cn/io_cn/PipeReader_cn.rst
@@ -30,7 +30,7 @@ PipeReader从命令的输出流中读取数据，把数据存在一个pipe缓存
            import paddle
            def example_reader(filelist):
                for f in filelist:
-                   pr = paddle.reader.PipeReader("cat %s"%f)
+                   pr = paddle.fluid.io.PipeReader("cat %s"%f)
                    for l in pr.get_line():
                        sample = l.split(" ")
                        yield sample

--- a/doc/fluid/api_cn/io_cn/PipeReader_cn.rst
+++ b/doc/fluid/api_cn/io_cn/PipeReader_cn.rst
@@ -31,7 +31,7 @@ PipeReader从命令的输出流中读取数据，把数据存在一个pipe缓存
            
            def example_reader(filelist):
                for f in filelist:
-                   pr = luid.io.PipeReader("cat %s"%f)
+                   pr = fluid.io.PipeReader("cat %s"%f)
                    for l in pr.get_line():
                        sample = l.split(" ")
                        yield sample

--- a/doc/fluid/api_cn/io_cn/PipeReader_cn.rst
+++ b/doc/fluid/api_cn/io_cn/PipeReader_cn.rst
@@ -27,10 +27,11 @@ PipeReader从命令的输出流中读取数据，把数据存在一个pipe缓存
 
 ..  code-block:: python
 
-           import paddle
+           import paddle.fluid as fluid
+           
            def example_reader(filelist):
                for f in filelist:
-                   pr = paddle.fluid.io.PipeReader("cat %s"%f)
+                   pr = luid.io.PipeReader("cat %s"%f)
                    for l in pr.get_line():
                        sample = l.split(" ")
                        yield sample

--- a/doc/fluid/api_cn/io_cn/chain_cn.rst
+++ b/doc/fluid/api_cn/io_cn/chain_cn.rst
@@ -20,7 +20,7 @@ chain
 
 ..  code-block:: python
 
-    import paddle
+    import paddle.fluid as fluid
 
     def reader_creator_3(start):
         def reader():
@@ -28,7 +28,7 @@ chain
                 yield [i, i, i]
         return reader
 
-    c = paddle.fluid.io.chain(reader_creator_3(0), reader_creator_3(10), reader_creator_3(20))
+    c = fluid.io.chain(reader_creator_3(0), reader_creator_3(10), reader_creator_3(20))
     for e in c():
         print(e)
     # 输出结果如下：

--- a/doc/fluid/api_cn/io_cn/chain_cn.rst
+++ b/doc/fluid/api_cn/io_cn/chain_cn.rst
@@ -28,7 +28,7 @@ chain
                 yield [i, i, i]
         return reader
 
-    c = paddle.reader.chain(reader_creator_3(0), reader_creator_3(10), reader_creator_3(20))
+    c = paddle.fluid.io.chain(reader_creator_3(0), reader_creator_3(10), reader_creator_3(20))
     for e in c():
         print(e)
     # 输出结果如下：

--- a/doc/fluid/api_cn/io_cn/xmap_readers_cn.rst
+++ b/doc/fluid/api_cn/io_cn/xmap_readers_cn.rst
@@ -22,7 +22,7 @@ xmap_readers
 
 .. code-block:: python
 
-    import paddle.reader as reader
+    import paddle
     import time
 
     def reader_creator_10(dur):
@@ -41,7 +41,7 @@ xmap_readers
     for order in orders:
         for t_num in thread_num:
             for size in buffer_size:
-                user_reader = reader.xmap_readers(mapper,
+                user_reader = paddle.fluid.io.xmap_readers(mapper,
                                                   reader_creator_10(0),
                                                   t_num, size, order)
                 for n in range(3):

--- a/doc/fluid/api_cn/io_cn/xmap_readers_cn.rst
+++ b/doc/fluid/api_cn/io_cn/xmap_readers_cn.rst
@@ -22,7 +22,7 @@ xmap_readers
 
 .. code-block:: python
 
-    import paddle
+    import paddle.fluid as fluid
     import time
 
     def reader_creator_10(dur):
@@ -41,7 +41,7 @@ xmap_readers
     for order in orders:
         for t_num in thread_num:
             for size in buffer_size:
-                user_reader = paddle.fluid.io.xmap_readers(mapper,
+                user_reader = fluid.io.xmap_readers(mapper,
                                                   reader_creator_10(0),
                                                   t_num, size, order)
                 for n in range(3):


### PR DESCRIPTION
Polish sample code, use `fluid.io.xx` instead of `paddle.reader.xx `.

`paddle.fluid.io.xmap_readers`
![image](https://user-images.githubusercontent.com/6888866/72237336-0ab3f380-3615-11ea-99c8-ec8537fbd290.png)

`paddle.fluid.io.chain`
![image](https://user-images.githubusercontent.com/6888866/72237613-0dfbaf00-3616-11ea-99fd-cea809187784.png)

`paddle.fluid.io.PipeReader`
No preview image, since this API is not presented on website.