### PR TITLE
【API DOC FIX】Fix default value of `summarize` in  API `Print` from -1 to 20 

### DIFF
--- a/doc/fluid/api_cn/layers_cn/Print_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/Print_cn.rst
@@ -3,7 +3,7 @@
 Print
 -------------------------------
 
-.. py:function:: paddle.fluid.layers.Print(input, first_n=-1, message=None, summarize=-1, print_tensor_name=True, print_tensor_type=True, print_tensor_shape=True, print_tensor_lod=True, print_phase='both')
+.. py:function:: paddle.fluid.layers.Print(input, first_n=-1, message=None, summarize=20, print_tensor_name=True, print_tensor_type=True, print_tensor_shape=True, print_tensor_lod=True, print_phase='both')
 
 **Print操作命令**
 
@@ -13,7 +13,7 @@ Print
 
 参数：
     - **input** (Variable)-将要打印的Tensor
-    - **summarize** (int)-打印Tensor中的元素数目，如果值为-1则打印所有元素
+    - **summarize** (int)-打印Tensor中的元素数目，如果值为-1则打印所有元素，默认值为20
     - **message** (str)-打印Tensor信息前自定义的字符串类型消息，作为前缀打印
     - **first_n** (int)-打印Tensor的次数
     - **print_tensor_name** (bool)-可选，指明是否打印Tensor名称，默认为True


### PR DESCRIPTION
【问题描述】： `Print` API中summarize参数的默认值为20，中文文档写成默认值为-1了。（英文文档是正确值20）   之前已有[PR](https://github.com/PaddlePaddle/FluidDoc/pull/1599)将develop分支的中文文档修改正确，但当前文档界面链接的是Paddle release/1.6，该版本的中文文档需要修改
【问题来源】： [P0卡片](http://newicafe.baidu.com/issue/84541279/show?cid=5&spaceId=23205&from=email&noticeStatistics=31539741)
【本PR工作】：修改release/1.6的中文API文档中的`Print`中summarize的默认值，从错误值-1修正为20.

【效果展示】：
<img width="1072" alt="屏幕快照 2020-01-17 下午8 02 53" src="https://user-images.githubusercontent.com/45189361/72611216-77582680-3964-11ea-872f-cdf9574ab190.png">
