### PR TITLE
fix python example

### DIFF
--- a/doc/fluid/api_cn/layers_cn/grid_sampler_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/grid_sampler_cn.rst
@@ -62,6 +62,8 @@ step 2：
 
 .. code-block:: python
 
+    import paddle.fluid as fluid
+
     # 一般与 affine_grid 组合使用
     x = fluid.data(name='x', shape=[None, 10, 32, 32], dtype='float32')
     theta = fluid.layers.data(name='theta', shape=[2, 3], dtype='float32')

--- a/doc/fluid/api_cn/layers_cn/kldiv_loss_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/kldiv_loss_cn.rst
@@ -34,9 +34,11 @@ kL发散损失计算如下：
 
 返回类型：变量(Variable)，数据类型与输入 ``x`` 一致。
 
-**代码示例**：
+**代码示例：**
 
 .. code-block:: python
+
+    import paddle.fluid as fluid
 
     # 'batchmean' reduction, loss shape 为[N]
     x = fluid.data(name='x', shape=[None,4,2,2], dtype='float32') # shape=[-1, 4, 2, 2]

--- a/doc/fluid/api_cn/layers_cn/spectral_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/spectral_norm_cn.rst
@@ -37,12 +37,14 @@ spectral_norm
 
 返回类型：变量(Variable)，数据类型与输入 ``weight`` 一致。
 
-**代码示例**：
+**代码示例：**
 
 .. code-block:: python
 
-   weight = fluid.data(name='weight', shape=[2, 8, 32, 32], dtype='float32')
-   x = fluid.layers.spectral_norm(weight=weight, dim=1, power_iters=2)
+    import paddle.fluid as fluid
+
+    weight = fluid.data(name='weight', shape=[2, 8, 32, 32], dtype='float32')
+    x = fluid.layers.spectral_norm(weight=weight, dim=1, power_iters=2)
 
 
 


### PR DESCRIPTION
**fix python example** 
fluid is not imported in following OP python example in cn docs(already imprted in en docs)
- grid_sampler
- kldiv_loss
- spectral_norm
<img width="1088" alt="spectral_norm" src="https://user-images.githubusercontent.com/12605721/73742970-8292bb00-4788-11ea-8195-6920f9bf0918.png">
<img width="1105" alt="kldiv_loss" src="https://user-images.githubusercontent.com/12605721/73742973-8292bb00-4788-11ea-89fc-1743cbe92fd4.png">
<img width="1101" alt="grid_sampler" src="https://user-images.githubusercontent.com/12605721/73742974-832b5180-4788-11ea-8857-529be0c69918.png">
