### PR TITLE
fix save_dygraph API doc

### DIFF
--- a/doc/fluid/api_cn/dygraph_cn/save_dygraph_cn.rst
+++ b/doc/fluid/api_cn/dygraph_cn/save_dygraph_cn.rst
@@ -27,15 +27,11 @@ save_dygraph
     import paddle.fluid as fluid
 
     with fluid.dygraph.guard():
-        emb = fluid.dygraph.Embedding(
-            size=[10, 32],
-            param_attr='emb.w',
-            is_sparse=False)
+        emb = fluid.dygraph.Embedding([10, 32])
         state_dict = emb.state_dict()
         fluid.save_dygraph(state_dict, "paddle_dy")  # 会保存为 paddle_dy.pdparams
 
-        adam = fluid.optimizer.Adam(
-            learning_rate=fluid.layers.noam_decay(100, 10000),
-            parameter_list = emb.parameters())
+        adam = fluid.optimizer.Adam(learning_rate=fluid.layers.noam_decay(100, 10000),
+                                    parameter_list = emb.parameters())
         state_dict = adam.state_dict()
         fluid.save_dygraph(state_dict, "paddle_dy")  # 会保存为 paddle_dy.pdopt


### PR DESCRIPTION
fix save_dygraph API doc, Keep pace with English doc.

预览截图：
![image](https://user-images.githubusercontent.com/52485244/74900336-64f56080-53da-11ea-89e6-e067c8a0d106.png)
