### PR TITLE
Fix StaticRNN Doc Example Code Chinese Comma Bug

### DIFF
--- a/doc/fluid/api_cn/layers_cn/StaticRNN_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/StaticRNN_cn.rst
@@ -248,7 +248,7 @@ StaticRNN
           # 用处理完的hidden变量更新prev变量。
           rnn.update_memory(prev, hidden)
           # 把每一步的hidden和word标记为输出。
-          rnn.output(hidden，word)
+          rnn.output(hidden, word)
 
       result = rnn()
 


### PR DESCRIPTION
As the title.

Key field screenshot:
![image](https://user-images.githubusercontent.com/7913861/75216200-2db5f380-57ce-11ea-8400-33121038a498.png)


Whole screenshot:

![image](https://user-images.githubusercontent.com/7913861/75216094-d7e14b80-57cd-11ea-92c4-34ab62f85872.png)
