### PR TITLE
Fix SyntaxError in examples in retinanet_target_assign Chinese API

### DIFF
--- a/doc/fluid/api_cn/layers_cn/retinanet_target_assign_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/retinanet_target_assign_cn.rst
@@ -68,6 +68,6 @@ retinanet_target_assign
                       dtype='float32')
     im_info = fluid.data(name='im_info', shape=[1, 3],
                       dtype='float32')
-    score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num =
+    score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num = \
           fluid.layers.retinanet_target_assign(bbox_pred, cls_logits, anchor_box,
           anchor_var, gt_boxes, gt_labels, is_crowd, im_info, 10)


### PR DESCRIPTION
There is a SyntaxError in the example for retinanet_target_assign chinese API, so we fix this error.
test=develop