### PR TITLE
Fix SyntaxError in examples in retinanet_target_assign Chinese API

### DIFF
--- a/doc/fluid/api_cn/layers_cn/retinanet_target_assign_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/retinanet_target_assign_cn.rst
@@ -68,6 +68,6 @@ retinanet_target_assign
                       dtype='float32')
     im_info = fluid.data(name='im_info', shape=[1, 3],
                       dtype='float32')
-    score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num =
+    score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num = \
           fluid.layers.retinanet_target_assign(bbox_pred, cls_logits, anchor_box,
           anchor_var, gt_boxes, gt_labels, is_crowd, im_info, 10)


### PR DESCRIPTION
There is a SyntaxError in the example for retinanet_target_assign chinese API, so we fix this error.
test=develop
PR for fixing syntaxerror in examples in retinanet_target_assign English API:
https://github.com/PaddlePaddle/Paddle/pull/22774
![image](https://user-images.githubusercontent.com/22235422/75343427-6ab7de00-58d3-11ea-8920-8672d6283b88.png)
![image](https://user-images.githubusercontent.com/22235422/75343512-9935b900-58d3-11ea-995e-438ef87329a7.png)
![image](https://user-images.githubusercontent.com/22235422/75346832-81156800-58da-11ea-9ff1-7699f5a8e78f.png)
![image](https://user-images.githubusercontent.com/22235422/75346894-98545580-58da-11ea-85c7-c5c037ddfe9d.png)
![image](https://user-images.githubusercontent.com/22235422/75346909-9f7b6380-58da-11ea-8060-887a4fd503b2.png)