### PR TITLE
fix python3 installation problem on Windows, test=develop

### DIFF
--- a/doc/fluid/install/compile/compile_Windows.md
+++ b/doc/fluid/install/compile/compile_Windows.md
@@ -4,7 +4,7 @@
 
 * **Windows 7/8/10 专业版/企业版 (64bit) (GPU版本支持CUDA 9.0/10.0, 且仅支持单卡)**
 * **Python 版本 2.7/3.5.1+/3.6/3.7 (64 bit)**
-* **pip 或 pip3 版本 9.0.1+ (64 bit)**
+* **pip 版本 9.0.1+ (64 bit)**
 * **Visual Studio 2015 Update3**
 
 ## 选择CPU/GPU

--- a/doc/fluid/install/install_Conda.md
+++ b/doc/fluid/install/install_Conda.md
@@ -32,45 +32,49 @@
 
 2. 确认您的conda虚拟环境和需要安装PaddlePaddle的Python是您预期的位置，因为您计算机可能有多个Python。进入Anaconda的命令行终端，输入以下指令确认Python位置。
 
-    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+    在 Windows 环境下，输出 Python 路径的命令为
 
-        在 Windows 环境下，输出 Python 路径的命令为：
+        where python
 
-            where python
+    在 MacOS/Linux 环境下，输出 Python 路径的命令为
 
-        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
+        如果您使用 Python 2:   which python
 
-            which python
-
-    如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
-
-        在 Windows 环境下，输出 Python 路径的命令为：
-
-            where python3
-
-        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
-
-            which python3
+        如果您使用 Python 3:   which python3
+    
+    根据您的环境，您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
 
 3. 检查Python的版本
 
-    如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+    在 Windows 环境下，使用以下命令确认版本(Python2 应对应 2.7.15+，Python3 应对应 3.5.1+/3.6/3.7)
 
         python --version
 
-    如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+    在 MacOS/Linux 环境下
+    
+        如果您是使用 Python 2，使用以下命令确认是 2.7.15+:
+    
+            python --version
 
-        python3 --version
+        如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7:
+
+            python3 --version
 
 4. 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64（或x64、AMD64）"即可：
 
-    如果您是使用 Python 2
+    在 Windows 环境下
 
         python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
-    如果您是使用 Python 3
+    在 MacOS/Linux 环境下
 
-        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+        如果您使用Python2:
+
+            python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
+
+        如果您使用Python3:
+
+            python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
 5. 安装PaddlePaddle
 
@@ -80,11 +84,11 @@
 
     (2). **GPU版本**：如果您想使用GPU版本请参考如下命令安装
 
-        如果您是使用 CUDA 9，cuDNN 7.3+，安装GPU版本的命令为：
+        如果您是使用 CUDA 9，cuDNN 7.3+，安装GPU版本的命令为:
 
             conda install paddlepaddle-gpu cudatoolkit=9.0
 
-        如果您是使用 CUDA 10.0，cuDNN 7.3+，安装GPU版本的命令为：
+        如果您是使用 CUDA 10.0，cuDNN 7.3+，安装GPU版本的命令为:
 
             conda install paddlepaddle-gpu cudatoolkit=10.0
 

--- a/doc/fluid/install/install_Windows.md
+++ b/doc/fluid/install/install_Windows.md
@@ -4,53 +4,41 @@
 
 * **Windows 7/8/10 专业版/企业版 (64bit) (GPU版本支持CUDA 9.0/10.0，且仅支持单卡)**
 * **Python 版本 2.7.15+/3.5.1+/3.6/3.7 (64 bit)**
-* **pip 或 pip3 版本 9.0.1+ (64 bit)**
+* **pip 版本 9.0.1+ (64 bit)**
 
 ### 注意事项
 
-* 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
+* 确认您安装PaddlePaddle的 Python是您预期的版本，因为您计算机可能有多个 Python，使用以下命令
 
-    * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+    python --version
 
-        where python
+    * 如果您是使用 Python 2，输出应是 2.7.15+
 
-    * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+    * 如果您是使用 Python 3，输出应是 3.5.1+/3.6+/3.7+
 
-        where python3
+* 如果不符合您预期的版本，使用以下命令查看python的路径是否是您预期的位置
 
-* 需要确认python的版本是否满足要求
+    where python
 
-    * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+    * 如果您是使用 Python 2, python2.7的安装目录应位于第一行
 
-        python --version
+    * 如果您是使用 Python 3, python3.5.1+/3.6+/3.7+的安装目录应位于第一行
 
-    * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7
+    * 您可以通过以下任意方法进行调整：
 
-        python3 --version
+        * 使用具体的Python路径来执行命令（例如C:\Python36\python.exe对应 Python 3，C:\Python27\python.exe对应 Python 2)     
+        * 在环境变量中，将您预期的安装路径设置在第一顺序位（请在控制面板->系统属性->环境变量->PATH中修改)
 
 * 需要确认pip的版本是否满足要求，要求pip版本为9.0.1+
 
-    * 如果您是使用 Python 2
+    python -m ensurepip
 
-        python -m ensurepip
-
-        python -m pip --version
-
-    * 如果您是使用 Python 3
-
-        python3 -m ensurepip
-
-        python3 -m pip --version
+    python -m pip --version
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
-    * 如果您是使用 Python 2
+    python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
-        python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-
-    * 如果您是使用 Python 3
-
-        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
 * 默认提供的安装包需要计算机支持MKL，如果您的环境不支持，请在[这里](./Tables.html#ciwhls-release)下载`openblas`版本的安装包
 * 当前版本暂不支持NCCL，分布式等相关功能
@@ -80,32 +68,27 @@ Windows系统下有3种安装方式：
 ## 安装步骤
 
 * CPU版PaddlePaddle：
-  * 对于Python 2： `python -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple` 或 `python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
-  * 对于Python 3： `python3 -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple` 或 `python3 -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
+  * `python -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple`（推荐使用百度源） 或 `python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 * GPU版PaddlePaddle：
-  * 对于Python 2： `python -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple` 或 `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple`
-  * 对于Python 3： `python3 -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple` 或 `python3 -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple`
+  * `python -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple` 或 `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple`
 
 您可[验证是否安装成功](#check)，如有问题请查看[FAQ](./FAQ.html)
 
 注：
 
-* 如果是python2.7, 建议使用`python`命令; 如果是python3.x, 则建议使用`python3`命令
-
-
-* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 10.0(配合cuDNN v7.3+)的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`或 `python3 -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html#whls)
+* `python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple` 此命令将安装支持CUDA 10.0(配合cuDNN v7.3+)的PaddlePaddle，如您对CUDA或cuDNN版本有不同要求，可用`python -m pip install paddlepaddle-gpu==[版本号] -i https://pypi.tuna.tsinghua.edu.cn/simple`命令来安装，版本号请见[这里](https://pypi.org/project/paddlepaddle-gpu#history), 关于paddlepaddle与CUDA, cuDNN版本的对应关系请见[安装包列表](./Tables.html#whls)
 
 
 <a name="check"></a>
 ## 验证安装
-安装完成后您可以使用 `python` 或 `python3` 进入python解释器，输入`import paddle.fluid as fluid` ，再输入
+安装完成后您可以使用 `python` 进入python解释器，输入`import paddle.fluid as fluid` ，再输入
  `fluid.install_check.run_check()`
 
 如果出现`Your Paddle Fluid is installed succesfully!`，说明您已成功安装。
 
 ## 如何卸载
 
-* **CPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`
+* **CPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle`
 
-* **GPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle-gpu` 或 `python3 -m pip uninstall paddlepaddle-gpu`
+* **GPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle-gpu`


### PR DESCRIPTION
修改了 `Windows上安装`、`Windows上conda安装`、`Windows上源码编译` 三篇文档。

修复了Windows上python3的安装说明问题，Windows上在anaconda、cmd上，都不建议使用python3或pip3来执行命令，先python --version验证版本，并做调整。然后直接使用python和pip即可。目前对用户存在一定困扰和出错概率。

![image](https://user-images.githubusercontent.com/52485244/75950659-c3dfcd00-5ee4-11ea-8b9e-9e180ff8eb7a.png)

![image](https://user-images.githubusercontent.com/52485244/76080546-19e66a80-5fe2-11ea-8f65-faee35cb6389.png)
![image](https://user-images.githubusercontent.com/52485244/76080549-1c48c480-5fe2-11ea-9b0c-893def214f57.png)

![image](https://user-images.githubusercontent.com/52485244/76080857-d17b7c80-5fe2-11ea-806a-183f6a47e949.png)
