### PR TITLE
Fix the elementwise_min doc api bug, correct the api used

### DIFF
--- a/doc/fluid/api_cn/layers_cn/elementwise_min_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/elementwise_min_cn.rst
@@ -60,7 +60,7 @@ elementwise_min
 
     x = fluid.layers.data(name="x", shape=[3], dtype='float32')
     y = fluid.layers.data(name="y", shape=[3], dtype='float32')
-    z = fluid.layers.elementwise_max(x, y)
+    z = fluid.layers.elementwise_min(x, y)
 
     place = fluid.CPUPlace()
     exe = fluid.Executor(place)
@@ -84,7 +84,7 @@ elementwise_min
 
     x = fluid.layers.data(name="x", shape=[2,3,4,5], dtype='float32')
     y = fluid.layers.data(name="y", shape=[3,4], dtype='float32')
-    z = fluid.layers.elementwise_max(x, y, axis=1)
+    z = fluid.layers.elementwise_min(x, y, axis=1)
 
     place = fluid.CPUPlace()
     exe = fluid.Executor(place)


### PR DESCRIPTION
In elementwise_min api doc has the error, all the api just use the elementwise_max op, we just correct the doc.