### PR TITLE
[cherry-pick 1.7]fix example bug of sampled_softmax_with_cross_entropy in cn_doc

### DIFF
--- a/doc/fluid/api_cn/layers_cn/sampled_softmax_with_cross_entropy_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sampled_softmax_with_cross_entropy_cn.rst
@@ -37,7 +37,7 @@ sampled_softmax_with_cross_entropy
     import paddle.fluid as fluid
 
     input = fluid.layers.data(name='data', shape=[256], dtype='float32')
-    label = fluid.layers.data(name='label', shape=[5], dtype='int64')
+    label = fluid.layers.data(name='label', shape=[1], dtype='int64')
     fc = fluid.layers.fc(input=input, size=100)
     out = fluid.layers.sampled_softmax_with_cross_entropy(
               logits=fc, label=label, num_samples=25)


### PR DESCRIPTION
cherry pick from #1893