### PR TITLE
Refine the example code in doc

### DIFF
--- a/doc/fluid/api_cn/layers_cn/create_global_var_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/create_global_var_cn.rst
@@ -26,7 +26,7 @@ create_global_var
     import paddle.fluid as fluid
     import paddle.fluid.layers as layers
     var = layers.create_global_var(shape=[2,3], value=1.0, dtype='float32',
-                     persistable=True, force_cpu=True, name='new_var')
+                                   persistable=True, force_cpu=True, name='new_var')
 
 
 

--- a/doc/fluid/api_cn/layers_cn/pad2d_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/pad2d_cn.rst
@@ -19,36 +19,34 @@ pad2d
 
 返回类型：Variable
 
-示例：
+**示例**：
 
 .. code-block:: text
 
-  假设X是输入图像:
+      Input = [[[[1., 2., 3.],
+                 [4., 5., 6.]]]]
 
-      X = [[1, 2, 3],
-           [4, 5, 6]]
+      Case 0:
+          paddings = [0, 1, 2, 3],
+          mode = 'constant'
+          pad_value = 0
+          Out = [[[[0., 0., 1., 2., 3., 0., 0., 0.],
+                   [0., 0., 4., 5., 6., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0.]]]]
 
-     Case 0:
-        paddings = [0, 1, 2, 3],
-        mode = 'constant'
-        pad_value = 0
-        Out = [[0, 0, 1, 2, 3, 0, 0, 0]
-               [0, 0, 4, 5, 6, 0, 0, 0]
-               [0, 0, 0, 0, 0, 0, 0, 0]]
+      Case 1:
+          paddings = [0, 1, 2, 1],
+          mode = 'reflect'
+          Out = [[[[3., 2., 1., 2., 3., 2.],
+                   [6., 5., 4., 5., 6., 5.],
+                   [3., 2., 1., 2., 3., 2.]]]]
 
-     Case 1:
-        paddings = [0, 1, 2, 1],
-        mode = 'reflect'
-        Out = [[3, 2, 1, 2, 3, 2]
-               [6, 5, 4, 5, 6, 5]
-               [3, 2, 1, 2, 3, 2]]
-
-     Case 2:
-        paddings = [0, 1, 2, 1],
-        mode = 'edge'
-        Out = [[1, 1, 1, 2, 3, 3]
-               [4, 4, 4, 5, 6, 6]
-               [4, 4, 4, 5, 6, 6]]
+      Case 2:
+          paddings = [0, 1, 2, 1],
+          mode = 'edge'
+          Out = [[[[1., 1., 1., 2., 3., 3.],
+                   [4., 4., 4., 5., 6., 6.],
+                   [4., 4., 4., 5., 6., 6.]]]]
 
 
 
@@ -56,8 +54,6 @@ pad2d
 
 .. code-block:: python
 
-  import paddle.fluid as fluid
-  data = fluid.layers.data(name='data', shape=[3, 32, 32], dtype='float32')
-  result = fluid.layers.pad2d(input=data, paddings=[1,2,3,4], mode='reflect')
-
-
+    import paddle.fluid as fluid
+    data = fluid.data(name='data', shape=[1, 1, 2, 3], dtype='float32')
+    result = fluid.layers.pad2d(input=data, paddings=[0, 1, 2, 3], mode='reflect')

--- a/doc/fluid/api_cn/layers_cn/pad_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/pad_cn.rst
@@ -8,23 +8,21 @@ pad
 该OP在Tensor上填充一个由 ``pad_value`` 给出的常数值，填充宽度由 ``paddings`` 指定。
 其中，维度 ``i`` 中 ``x`` 内容前填充的值个数用 ``paddings[2*i]`` 表示，维度 ``i`` 中 ``x`` 内容后填充的值个数用 ``paddings[2*i+1]`` 表示。
 
-**样例**：
+**示例**：
 
-::
+.. code-block:: text
 
         Given:
+            x = [[1, 2], [3, 4]]
 
-         x = [[1, 2], [3, 4]]
+            paddings = [0, 1, 1, 2]
 
-        paddings = [0, 1, 1, 2]
-
-        pad_value = 0
+            pad_value = 0
 
         Return:
-
-        out = [[0, 1, 2, 0, 0]
-               [0, 3, 4, 0, 0]
-               [0, 0, 0, 0, 0]]
+            out = [[0, 1, 2, 0, 0]
+                   [0, 3, 4, 0, 0]
+                   [0, 0, 0, 0, 0]]
 
 
 参数:
@@ -44,15 +42,7 @@ pad
 
     # x 为一个秩为2的张量
     import paddle.fluid as fluid
-    x = fluid.layers.data(name='data', shape=[224], dtype='float32')
+    x = fluid.data(name='data', shape=[2, 2], dtype='float32')
     out = fluid.layers.pad(x=x, paddings=[0, 1, 1, 2], pad_value=0.)
-
-
-
-
-
-
-
-
 
 

--- a/doc/fluid/api_cn/layers_cn/pad_constant_like_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/pad_constant_like_cn.rst
@@ -7,9 +7,9 @@ pad_constant_like
 
 该OP使用 ``pad_value`` 填充 ``y`` ，填充到每个维度值的数量由x和y的形状而指定，((0，x.shape[0] - y.shape[0]), ..., (0, x.shape[i] - y.shape[i]), ..., (0, x.shape[n] - y.shape[n]))是每个维度填充的宽度，对于维度i，填充宽度 ``(0, x.shape[i] - y.shape[i])`` ，表示在y的第i维开头不填充，而在末尾填充 ``x.shape[i] - y.shape[i]`` 个位置。该OP要求y与x具有相同的秩，并且对每个维度i， ``y.shape[i] <= x.shape[i]`` 。
 
-**样例**
+**示例**：
 
-::
+.. code-block:: text
 
     Given:
         X = [[[[ 0,  1,  2],
@@ -24,30 +24,34 @@ pad_constant_like
                [27, 28, 29]],
               [[30, 31, 32],
                [33, 34, 35]]]]
+
         X.shape = (2, 3, 2, 3)
 
         Y = [[[[35, 36, 37]],
               [[38, 39, 40]],
               [[41, 42, 43]]]]
+
         Y.shape = (1, 3, 1, 3)
 
-    and
+    And
         pad_value = 0.
 
-    Output is:
-        out = [[[[35, 36, 37],
-                 [0, 0, 0]],
+    Return:
+        Out = [[[[35, 36, 37],
+                 [ 0,  0,  0]],
                 [[38, 39, 40],
-                 [0, 0, 0]],
+                 [ 0,  0,  0]],
                 [[41, 42, 43],
-                 [0, 0, 0]]],
-               [[[0, 0, 0], 
-                 [0, 0, 0]],
-                [[0, 0, 0], 
-                 [0, 0, 0]],
-                [[0, 0, 0], 
-                 [0, 0, 0]]]]
-        out.shape = [2, 3, 2, 3]
+                 [ 0,  0,  0]]],
+               [[[ 0,  0,  0], 
+                 [ 0,  0,  0]],
+                [[ 0,  0,  0], 
+                 [ 0,  0,  0]],
+                [[ 0,  0,  0], 
+                 [ 0,  0,  0]]]]
+
+        Out.shape = [2, 3, 2, 3]
+
 
 参数：
           - **x** （Variable）- 多维Tensor
@@ -66,8 +70,8 @@ pad_constant_like
     # x是秩为4的tensor, x.shape = (2, 3, 2, 3)
     # y是秩为4的tensor, y.shape = (1, 3, 1, 3)
     import paddle.fluid as fluid
-    x = fluid.layers.data(name='x', shape=[2,3,2,3], dtype='float32')
-    y = fluid.layers.data(name='y', shape=[1,3,1,3], dtype='float32')
+    x = fluid.data(name='x', shape=[2,3,2,3], dtype='float32')
+    y = fluid.data(name='y', shape=[1,3,1,3], dtype='float32')
     out = fluid.layers.pad_constant_like(x=x, y=y, pad_value=0.)
     # out是秩为4的tensor, out.shape = [2, 3 ,2 , 3]
 


### PR DESCRIPTION
Refine the doc of create_global_var, pad, pad_constant_like and pad2d to make it consistent with en doc.
Related to [Paddle #23549](https://github.com/PaddlePaddle/Paddle/pull/23549)