### PR TITLE
remove high level api

### DIFF
--- a/doc/fluid/user_guides/nlp_case/machine_translation/README.md
+++ b/doc/fluid/user_guides/nlp_case/machine_translation/README.md
@@ -155,15 +155,6 @@ import paddle.fluid.layers as pd
 from paddle.fluid.executor import Executor
 from functools import partial
 import os
-try:
-    from paddle.fluid.contrib.trainer import *
-    from paddle.fluid.contrib.inferencer import *
-except ImportError:
-    print(
-        "In the fluid 1.0, the trainer and inferencer are moving to paddle.fluid.contrib",
-        file=sys.stderr)
-    from paddle.fluid.trainer import *
-    from paddle.fluid.inferencer import *
 
 dict_size = 30000 # dictionary dimension
 source_dict_dim = target_dict_dim = dict_size # source/target language dictionary dimension

--- a/doc/fluid/user_guides/nlp_case/machine_translation/index.html
+++ b/doc/fluid/user_guides/nlp_case/machine_translation/index.html
@@ -197,15 +197,6 @@ import paddle.fluid.layers as pd
 from paddle.fluid.executor import Executor
 from functools import partial
 import os
-try:
-    from paddle.fluid.contrib.trainer import *
-    from paddle.fluid.contrib.inferencer import *
-except ImportError:
-    print(
-        "In the fluid 1.0, the trainer and inferencer are moving to paddle.fluid.contrib",
-        file=sys.stderr)
-    from paddle.fluid.trainer import *
-    from paddle.fluid.inferencer import *
 
 dict_size = 30000 # dictionary dimension
 source_dict_dim = target_dict_dim = dict_size # source/target language dictionary dimension


### PR DESCRIPTION
因Paddle中high level api已经不再使用，因此删除paddle.fluid.contrib.trainer与paddle.fluid.contrib.inferencer