### PR TITLE
fix code example

### DIFF
--- a/doc/fluid/api_cn/fluid_cn/default_main_program_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/default_main_program_cn.rst
@@ -28,8 +28,8 @@ default_main_program
         import paddle.fluid as fluid
      
         #示例网络:
-        data = fluid.layers.data(name='image', shape=[3, 224, 224], dtype='float32')
-        label = fluid.layers.data(name='label', shape=[1], dtype='int64')
+        data = fluid.data(name='image', shape=[None, 3, 224, 224], dtype='float32')
+        label = fluid.data(name='label', shape=[None, 1], dtype='int64')
     
         conv1 = fluid.layers.conv2d(data, 4, 5, 1, act=None)
         bn1 = fluid.layers.batch_norm(conv1, act='relu')


### PR DESCRIPTION
修复中英文文档示例代码的diff。下图左面是中文的，有面是英文的。
![image](https://user-images.githubusercontent.com/26615455/80195397-5af81400-864e-11ea-99c4-f5907d0134ad.png)
目前推荐使用的是fluid.data。因此应该修复中文文档，修复后预览如下

![image](https://user-images.githubusercontent.com/26615455/80195863-11f48f80-864f-11ea-90d9-411f31b728c3.png)
