### PR TITLE
Docker compile git fix

### DIFF
--- a/doc/fluid/install/compile/compile_CentOS.md
+++ b/doc/fluid/install/compile/compile_CentOS.md
@@ -153,7 +153,7 @@
 
 恭喜，至此您已完成PaddlePaddle的编译安装。您只需要进入Docker容器后运行PaddlePaddle，即可开始使用。更多Docker使用请参见[Docker官方文档](https://docs.docker.com)
 
-> 注：PaddlePaddle Docker镜像为了减小体积，默认没有安装`vim`，您可以在容器中执行 `apt-get install -y vim` 来安装
+> 注：PaddlePaddle Docker镜像为了减小体积，默认没有安装`vim`，您可以在容器中执行 `apt-get update && apt-get install -y vim` 来安装
 
 <a name="ct_source"></a>
 ### **本机编译**

--- a/doc/fluid/install/compile/compile_CentOS.md
+++ b/doc/fluid/install/compile/compile_CentOS.md
@@ -94,7 +94,7 @@
 
 4. 进入Docker后进入paddle目录下：
 
-    `cd paddle`
+    `cd ../paddle`
 
 5. 切换到较稳定版本下进行编译：
 

--- a/doc/fluid/install/compile/compile_CentOS_en.md
+++ b/doc/fluid/install/compile/compile_CentOS_en.md
@@ -109,7 +109,7 @@ Please follow the steps below to install:
 
     `mkdir -p /paddle/build && cd /paddle/build`
 
-7. Use the following command to install the dependencies: 
+7. Use the following command to install the dependencies:
 
 
         For Python2: pip install protobuf
@@ -143,9 +143,15 @@ Please follow the steps below to install:
 
     > Use multicore compilation
 
+    Note: if compile fail, normally because you did config git properly,  read the following blog: [stackoverflow](hhttps://stackoverflow.com/questions/35821245/github-server-certificate-verification-failed).
+
+    Or you can just disable SSL verification, (if the project does not require a high level of security other than login/password) by typing:
+
+    `git config --global http.sslverify false`
+
 10. After compiling successfully, go to the `/paddle/build/python/dist` directory and find the generated `.whl` package: `cd /paddle/build/python/dist`
 
-11. Install the compiled `.whl` package on the current machine or target machine: 
+11. Install the compiled `.whl` package on the current machine or target machine:
 
         For Python2: pip install -U (whl package name)
         For Python3: pip3.5 install -U (whl package name)

--- a/doc/fluid/install/compile/compile_CentOS_en.md
+++ b/doc/fluid/install/compile/compile_CentOS_en.md
@@ -154,7 +154,7 @@ Please follow the steps below to install:
 
 Congratulations, now that you have successfully installed PaddlePaddle using Docker, you only need to run PaddlePaddle after entering the Docker container. For more Docker usage, please refer to the [official Docker documentation](https://docs.docker.com/).
 
-> Note: In order to reduce the size, `vim` is not installed in PaddlePaddle Docker image by default. You can edit the code in the container after executing `apt-get install -y vim` in the container.
+> Note: In order to reduce the size, `vim` is not installed in PaddlePaddle Docker image by default. You can edit the code in the container after executing `apt-get update && apt-get install -y vim` in the container.
 
 <a name="ct_source"></a>
 ### **Local compilation**

--- a/doc/fluid/install/compile/compile_MacOS.md
+++ b/doc/fluid/install/compile/compile_MacOS.md
@@ -45,7 +45,7 @@
 
 5. 进入Docker后进入paddle目录下：
 
-	`cd paddle`
+	`cd ../paddle`
 
 6. 切换到较稳定版本下进行编译：
 

--- a/doc/fluid/install/compile/compile_MacOS_en.md
+++ b/doc/fluid/install/compile/compile_MacOS_en.md
@@ -49,7 +49,7 @@ Please follow the steps below to install:
 
 5. After entering Docker, go to the paddle directory: 
 
-	`cd paddle`
+	`cd ../paddle`
 
 6. Switch to a more stable version to compile:
 

--- a/doc/fluid/install/compile/compile_Ubuntu.md
+++ b/doc/fluid/install/compile/compile_Ubuntu.md
@@ -91,7 +91,7 @@
 
 4. 进入Docker后进入paddle目录下：
 
-    `cd paddle`
+    `cd ../paddle`
 
 5. 切换到较稳定release分支下进行编译：
 

--- a/doc/fluid/install/compile/compile_Ubuntu.md
+++ b/doc/fluid/install/compile/compile_Ubuntu.md
@@ -152,7 +152,7 @@
 
 恭喜，至此您已完成PaddlePaddle的编译安装。您只需要进入Docker容器后运行PaddlePaddle，即可开始使用。更多Docker使用请参见[Docker官方文档](https://docs.docker.com)
 
-> 注：PaddlePaddle Docker镜像为了减小体积，默认没有安装`vim`，您可以在容器中执行 `apt-get install -y vim` 来安装。
+> 注：PaddlePaddle Docker镜像为了减小体积，默认没有安装`vim`，您可以在容器中执行 `apt-get update && apt-get install -y vim` 来安装。
 
 <a name="ubt_source"></a>
 ### **本机编译**

--- a/doc/fluid/install/compile/compile_Ubuntu_en.md
+++ b/doc/fluid/install/compile/compile_Ubuntu_en.md
@@ -151,7 +151,7 @@ Please follow the steps below to install:
 
 Congratulations, now you have completed the compilation and installation of PaddlePaddle. You only need to enter the Docker container and run PaddlePaddle to start using. For more Docker usage, please refer to [official docker documentation](https://docs.docker.com)
 
-> Note: In order to reduce the size, `vim` is not installed in PaddlePaddle Docker image by default. You can edit the code in the container after executing `apt-get install -y vim` in the container.
+> Note: In order to reduce the size, `vim` is not installed in PaddlePaddle Docker image by default. You can edit the code in the container after executing `apt-get update && apt-get install -y vim` in the container.
 
 <a name="ubt_source"></a>
 ### ***Local compilation***

--- a/doc/fluid/install/compile/compile_Ubuntu_en.md
+++ b/doc/fluid/install/compile/compile_Ubuntu_en.md
@@ -90,7 +90,7 @@ Please follow the steps below to install:
 
 4. After entering Docker, enter the Paddle Directory:
 
-    `cd paddle`
+    `cd ../paddle`
 
 5. Switch to a more stable release branch for compilation:
 


### PR DESCRIPTION
This change is because when we compile in the docker we need to change the git config to let git to download staff we need during make process.

Note: if compile fail, normally because you did config git properly,  read the following blog: [stackoverflow](hhttps://stackoverflow.com/questions/35821245/github-server-certificate-verification-failed).

    Or you can just disable SSL verification, (if the project does not require a high level of security other than login/password) by typing:

    `git config --global http.sslverify false`