### PR TITLE
Fix doc for chunk_eval and BeamSearchDecoder

### DIFF
--- a/doc/fluid/api_cn/layers_cn/BeamSearchDecoder_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/BeamSearchDecoder_cn.rst
@@ -82,8 +82,7 @@ BeamSearchDecoder
 此函数输入形状为 :math:`[batch\_size,s_0，s_1，...]` 的tensor t，由minibatch中的样本 :math:`t[0]，...，t[batch\_size-1]` 组成。将其扩展为形状 :math:`[ batch\_size,beam\_size,s_0，s_1，...]` 的tensor，由 :math:`t[0]，t[0]，...，t[1]，t[1]，...` 组成，其中每个minibatch中的样本重复 :math:`beam\_size` 次。
 
 参数：
-  - **probs** (Variable) - 形状为 :math:`[batch\_size,beam\_size,vocab\_size]` 的tensor，表示对数概率。其数据类型应为float32。
-  - **finish** (Variable) - 形状为 :math:`[batch\_size,beam\_size]` 的tensor，表示所有beam的完成状态。其数据类型应为bool。
+  - **x** (Variable) - 形状为 :math:`[batch\_size, ...]` 的tenosr。数据类型应为float32，float64，int32，int64或bool。
 
 返回：具有与 :code:`x` 相同的形状和数据类型的tensor，其中未完成的beam保持不变，而已完成的beam被替换成特殊的tensor(tensor中所有概率质量被分配给EOS标记)。
 

--- a/doc/fluid/api_cn/layers_cn/chunk_eval_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/chunk_eval_cn.rst
@@ -79,13 +79,13 @@ chunk_eval
      
     dict_size = 10000
     label_dict_len = 7
-    sequence = fluid.layers.data(
-        name='id', shape=[1], lod_level=1, dtype='int64')
-    embedding = fluid.layers.embedding(
+    sequence = fluid.data(
+        name='id', shape=[None, 1], lod_level=1, dtype='int64')
+    embedding = fluid.embedding(
         input=sequence, size=[dict_size, 512])
     hidden = fluid.layers.fc(input=embedding, size=512)
-    label = fluid.layers.data(
-        name='label', shape=[1], lod_level=1, dtype='int32')
+    label = fluid.data(
+        name='label', shape=[None, 1], lod_level=1, dtype='int64')
     crf = fluid.layers.linear_chain_crf(
         input=hidden, label=label, param_attr=fluid.ParamAttr(name="crfw"))
     crf_decode = fluid.layers.crf_decoding(
@@ -94,7 +94,7 @@ chunk_eval
         input=crf_decode,
         label=label,
         chunk_scheme="IOB",
-        num_chunk_types=(label_dict_len - 1) / 2)
+        num_chunk_types=int((label_dict_len - 1) / 2))
 
 
 


### PR DESCRIPTION
Fix doc for chunk_eval and BeamSearchDecoder. 
* chunk_eval: fix sample code. 
![image](https://user-images.githubusercontent.com/7160927/81887123-0d2d5680-95d1-11ea-8f76-38ab1659683f.png)

* BeamSearchDecoder: fix parameters description for _expand_to_beam_size. 
![image](https://user-images.githubusercontent.com/7160927/81887063-f0911e80-95d0-11ea-88d7-8bb2141cc392.png)
