### PR TITLE
修改 API属性 描述

### DIFF
--- a/doc/fluid/api_cn/backward_cn/append_backward_cn.rst
+++ b/doc/fluid/api_cn/backward_cn/append_backward_cn.rst
@@ -6,7 +6,7 @@ append_backward
 
 .. py:function:: paddle.fluid.backward.append_backward(loss, parameter_list=None, no_grad_set=None, callbacks=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/backward_cn/gradients_cn.rst
+++ b/doc/fluid/api_cn/backward_cn/gradients_cn.rst
@@ -6,7 +6,7 @@ gradients
 
 .. py:function:: paddle.fluid.backward.gradients(targets, inputs, target_gradients=None, no_grad_set=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/clip_cn/set_gradient_clip_cn.rst
+++ b/doc/fluid/api_cn/clip_cn/set_gradient_clip_cn.rst
@@ -6,7 +6,7 @@ set_gradient_clip
 
 .. py:function:: paddle.fluid.clip.set_gradient_clip(clip, param_list=None, program=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/executor_cn/Executor_cn.rst
+++ b/doc/fluid/api_cn/executor_cn/Executor_cn.rst
@@ -6,7 +6,7 @@ Executor
 
 .. py:class:: paddle.fluid.executor.Executor (place=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/executor_cn/global_scope_cn.rst
+++ b/doc/fluid/api_cn/executor_cn/global_scope_cn.rst
@@ -6,7 +6,7 @@ global_scope
 
 .. py:function:: paddle.fluid.global_scope()
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/executor_cn/scope_guard_cn.rst
+++ b/doc/fluid/api_cn/executor_cn/scope_guard_cn.rst
@@ -6,7 +6,7 @@ scope_guard
 
 .. py:function:: paddle.fluid.executor.scope_guard (scope)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/BuildStrategy_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/BuildStrategy_cn.rst
@@ -6,7 +6,7 @@ BuildStrategy
 
 .. py:class:: paddle.fluid.BuildStrategy
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/CompiledProgram_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/CompiledProgram_cn.rst
@@ -6,7 +6,7 @@ CompiledProgram
 
 .. py:class:: paddle.fluid.CompiledProgram(program_or_graph, build_strategy=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/DataFeedDesc_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/DataFeedDesc_cn.rst
@@ -6,7 +6,7 @@ DataFeedDesc
 
 .. py:class:: paddle.fluid.DataFeedDesc(proto_file)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/DataFeeder_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/DataFeeder_cn.rst
@@ -6,7 +6,7 @@ DataFeeder
 
 .. py:class:: paddle.fluid.DataFeeder(feed_list, place, program=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/ExecutionStrategy_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/ExecutionStrategy_cn.rst
@@ -6,7 +6,7 @@ ExecutionStrategy
 
 .. py:class:: paddle.fluid.ExecutionStrategy
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/Executor_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/Executor_cn.rst
@@ -7,7 +7,7 @@ Executor
 
 .. py:class:: paddle.fluid.Executor (place=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/ParallelExecutor_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/ParallelExecutor_cn.rst
@@ -6,7 +6,7 @@ ParallelExecutor
 
 .. py:class:: paddle.fluid.ParallelExecutor(use_cuda, loss_name=None, main_program=None, share_vars_from=None, exec_strategy=None, build_strategy=None, num_trainers=1, trainer_id=0, scope=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/WeightNormParamAttr_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/WeightNormParamAttr_cn.rst
@@ -6,7 +6,7 @@ WeightNormParamAttr
 
 .. py:class:: paddle.fluid.WeightNormParamAttr(dim=None, name=None, initializer=None, learning_rate=1.0, regularizer=None, trainable=True, do_model_average=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/create_random_int_lodtensor_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/create_random_int_lodtensor_cn.rst
@@ -7,7 +7,7 @@ create_random_int_lodtensor
 
 .. py:function:: paddle.fluid.create_random_int_lodtensor(recursive_seq_lens, base_shape, place, low, high)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/data_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/data_cn.rst
@@ -6,7 +6,7 @@ data
 
 .. py:function:: paddle.fluid.data(name, shape, dtype='float32', lod_level=0)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.nn.data
 :alias: paddle.nn.data,paddle.nn.input.data
 :old_api: paddle.fluid.data

--- a/doc/fluid/api_cn/fluid_cn/embedding_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/embedding_cn.rst
@@ -6,7 +6,7 @@ embedding
 
 .. py:function:: paddle.fluid.embedding(input, size, is_sparse=False, is_distributed=False, padding_idx=None, param_attr=None, dtype='float32')
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/global_scope_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/global_scope_cn.rst
@@ -6,7 +6,7 @@ global_scope
 
 .. py:function:: paddle.fluid.global_scope()
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/gradients_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/gradients_cn.rst
@@ -6,7 +6,7 @@ gradients
 
 .. py:function:: paddle.fluid.gradients(targets, inputs, target_gradients=None, no_grad_set=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/load_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/load_cn.rst
@@ -5,7 +5,7 @@ load
 
 .. py:function:: paddle.fluid.load(program, model_path, executor=None, var_list=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/load_op_library_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/load_op_library_cn.rst
@@ -5,7 +5,7 @@ load_op_library
 
 .. py:class:: paddle.fluid.load_op_library
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/memory_optimize_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/memory_optimize_cn.rst
@@ -6,7 +6,7 @@ memory_optimize
 
 .. py:function:: paddle.fluid.memory_optimize(input_program, skip_opt_set=None, print_log=False, level=0, skip_grads=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/name_scope_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/name_scope_cn.rst
@@ -6,7 +6,7 @@ name_scope
 
 .. py:function:: paddle.fluid.name_scope(prefix=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/program_guard_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/program_guard_cn.rst
@@ -6,7 +6,7 @@ program_guard
 
 .. py:function:: paddle.fluid.program_guard(main_program, startup_program=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/release_memory_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/release_memory_cn.rst
@@ -6,7 +6,7 @@ release_memory
 
 .. py:function:: paddle.fluid.release_memory(input_program, skip_opt_set=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/fluid_cn/save_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/save_cn.rst
@@ -6,7 +6,7 @@ save
 
 .. py:function:: paddle.fluid.save(program, model_path)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.save
 :alias: paddle.save,paddle.tensor.save,paddle.tensor.io.save
 :old_api: paddle.fluid.save

--- a/doc/fluid/api_cn/fluid_cn/scope_guard_cn.rst
+++ b/doc/fluid/api_cn/fluid_cn/scope_guard_cn.rst
@@ -6,7 +6,7 @@ scope_guard
 
 .. py:function:: paddle.fluid.scope_guard(scope)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/get_program_parameter_cn.rst
+++ b/doc/fluid/api_cn/io_cn/get_program_parameter_cn.rst
@@ -5,7 +5,7 @@ get_program_parameter
 
 .. py:function:: paddle.fluid.io.get_program_parameter(program)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/get_program_persistable_vars_cn.rst
+++ b/doc/fluid/api_cn/io_cn/get_program_persistable_vars_cn.rst
@@ -5,7 +5,7 @@ get_program_persistable_vars
 
 .. py:function:: paddle.fluid.io.get_program_persistable_vars(program)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/load_cn.rst
+++ b/doc/fluid/api_cn/io_cn/load_cn.rst
@@ -5,7 +5,7 @@ load
 
 .. py:function:: paddle.fluid.io.load(program, model_path, executor=None, var_list=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.load
 :alias: paddle.load,paddle.tensor.load,paddle.tensor.io.load
 :old_api: paddle.fluid.io.load

--- a/doc/fluid/api_cn/io_cn/load_inference_model_cn.rst
+++ b/doc/fluid/api_cn/io_cn/load_inference_model_cn.rst
@@ -6,7 +6,7 @@ load_inference_model
 
 .. py:function:: paddle.fluid.io.load_inference_model(dirname, executor, model_filename=None, params_filename=None, pserver_endpoints=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/load_params_cn.rst
+++ b/doc/fluid/api_cn/io_cn/load_params_cn.rst
@@ -6,7 +6,7 @@ load_params
 
 .. py:function:: paddle.fluid.io.load_params(executor, dirname, main_program=None, filename=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/load_persistables_cn.rst
+++ b/doc/fluid/api_cn/io_cn/load_persistables_cn.rst
@@ -6,7 +6,7 @@ load_persistables
 
 .. py:function:: paddle.fluid.io.load_persistables(executor, dirname, main_program=None, filename=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/load_program_state_cn.rst
+++ b/doc/fluid/api_cn/io_cn/load_program_state_cn.rst
@@ -5,7 +5,7 @@ load_program_state
 
 .. py:function:: paddle.fluid.io.load_program_state(model_path, var_list=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/load_vars_cn.rst
+++ b/doc/fluid/api_cn/io_cn/load_vars_cn.rst
@@ -5,7 +5,7 @@ load_vars
 
 .. py:function:: paddle.fluid.io.load_vars(executor, dirname, main_program=None, vars=None, predicate=None, filename=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/save_cn.rst
+++ b/doc/fluid/api_cn/io_cn/save_cn.rst
@@ -6,7 +6,7 @@ save
 
 .. py:function:: paddle.fluid.io.save(program, model_path)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/save_inference_model_cn.rst
+++ b/doc/fluid/api_cn/io_cn/save_inference_model_cn.rst
@@ -6,7 +6,7 @@ save_inference_model
 
 .. py:function:: paddle.fluid.io.save_inference_model(dirname, feeded_var_names, target_vars, executor, main_program=None, model_filename=None, params_filename=None, export_for_deployment=True,  program_only=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/save_params_cn.rst
+++ b/doc/fluid/api_cn/io_cn/save_params_cn.rst
@@ -6,7 +6,7 @@ save_params
 
 .. py:function:: paddle.fluid.io.save_params(executor, dirname, main_program=None, filename=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/save_persistables_cn.rst
+++ b/doc/fluid/api_cn/io_cn/save_persistables_cn.rst
@@ -6,7 +6,7 @@ save_persistables
 
 .. py:function:: paddle.fluid.io.save_persistables(executor, dirname, main_program=None, filename=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/save_vars_cn.rst
+++ b/doc/fluid/api_cn/io_cn/save_vars_cn.rst
@@ -6,7 +6,7 @@ save_vars
 
 .. py:function:: paddle.fluid.io.save_vars(executor, dirname, main_program=None, vars=None, predicate=None, filename=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/io_cn/set_program_state_cn.rst
+++ b/doc/fluid/api_cn/io_cn/set_program_state_cn.rst
@@ -5,7 +5,7 @@ set_program_state
 
 .. py:function:: paddle.fluid.io.set_program_state(program, state_dict)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/BeamSearchDecoder_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/BeamSearchDecoder_cn.rst
@@ -7,7 +7,7 @@ BeamSearchDecoder
 
 .. py:class:: paddle.fluid.layers.BeamSearchDecoder(cell, start_token, end_token, beam_size, embedding_fn=None, output_fn=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
     

--- a/doc/fluid/api_cn/layers_cn/Decoder_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/Decoder_cn.rst
@@ -7,7 +7,7 @@ Decoder
 
 .. py:class:: paddle.fluid.layers.Decoder()
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/DynamicRNN_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/DynamicRNN_cn.rst
@@ -6,7 +6,7 @@ DynamicRNN
 
 .. py:class:: paddle.fluid.layers.DynamicRNN(name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/GRUCell_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/GRUCell_cn.rst
@@ -6,7 +6,7 @@ GRUCell
 
 .. py:class:: paddle.fluid.layers.GRUCell(hidden_size, param_attr=None, bias_attr=None, gate_activation=None, activation=None, dtype="float32", name="GRUCell")
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
     

--- a/doc/fluid/api_cn/layers_cn/IfElse_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/IfElse_cn.rst
@@ -6,7 +6,7 @@ IfElse
 
 .. py:class:: paddle.fluid.layers.IfElse(cond, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/LSTMCell_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/LSTMCell_cn.rst
@@ -7,7 +7,7 @@ LSTMCell
 
 .. py:class:: paddle.fluid.layers.LSTMCell(hidden_size, param_attr=None, bias_attr=None, gate_activation=None, activation=None, forget_bias=1.0, dtype="float32", name="LSTMCell")
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
     

--- a/doc/fluid/api_cn/layers_cn/Print_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/Print_cn.rst
@@ -6,7 +6,7 @@ Print
 
 .. py:function:: paddle.fluid.layers.Print(input, first_n=-1, message=None, summarize=20, print_tensor_name=True, print_tensor_type=True, print_tensor_shape=True, print_tensor_lod=True, print_phase='both')
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/RNNCell_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/RNNCell_cn.rst
@@ -7,7 +7,7 @@ RNNCell
 
 .. py:class:: paddle.fluid.layers.RNNCell(name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 RNNCell是抽象的基类，代表将输入和状态映射到输出和新状态的计算，主要用于RNN。

--- a/doc/fluid/api_cn/layers_cn/StaticRNN_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/StaticRNN_cn.rst
@@ -6,7 +6,7 @@ StaticRNN
 
 .. py:class:: paddle.fluid.layers.StaticRNN(name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/Switch_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/Switch_cn.rst
@@ -6,7 +6,7 @@ Switch
 
 .. py:class:: paddle.fluid.layers.Switch (name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/While_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/While_cn.rst
@@ -6,7 +6,7 @@ While
 
 .. py:class:: paddle.fluid.layers.While (cond, is_test=False, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/autoincreased_step_counter_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/autoincreased_step_counter_cn.rst
@@ -6,7 +6,7 @@ autoincreased_step_counter
 
 .. py:function:: paddle.fluid.layers.autoincreased_step_counter(counter_name=None, begin=1, step=1)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/batch_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/batch_norm_cn.rst
@@ -6,7 +6,7 @@ batch_norm
 
 .. py:function:: paddle.fluid.layers.batch_norm(input, act=None, is_test=False, momentum=0.9, epsilon=1e-05, param_attr=None, bias_attr=None, data_layout='NCHW', in_place=False, name=None, moving_mean_name=None, moving_variance_name=None, do_model_average_for_mean_and_var=False, use_global_stats=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/bilinear_tensor_product_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/bilinear_tensor_product_cn.rst
@@ -6,7 +6,7 @@ bilinear_tensor_product
 
 .. py:function:: paddle.fluid.layers.bilinear_tensor_product(x, y, size, act=None, name=None, param_attr=None, bias_attr=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/case_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/case_cn.rst
@@ -6,7 +6,7 @@ case
 
 .. py:function:: paddle.fluid.layers.case(pred_fn_pairs, default=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.nn.case
 :alias: paddle.nn.case,paddle.nn.control_flow.case
 :old_api: paddle.fluid.layers.case

--- a/doc/fluid/api_cn/layers_cn/center_loss_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/center_loss_cn.rst
@@ -6,7 +6,7 @@ center_loss
 
 .. py:function:: paddle.fluid.layers.center_loss(input, label, num_classes, alpha, param_attr, update_center=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.nn.functional.center_loss
 :alias: paddle.nn.functional.center_loss,paddle.nn.functional.loss.center_loss
 :old_api: paddle.fluid.layers.center_loss

--- a/doc/fluid/api_cn/layers_cn/cond_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/cond_cn.rst
@@ -6,7 +6,7 @@ cond
 
 .. py:function:: paddle.fluid.layers.cond(pred, true_fn=None, false_fn=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.nn.cond
 :alias: paddle.nn.cond,paddle.nn.control_flow.cond
 :old_api: paddle.fluid.layers.cond

--- a/doc/fluid/api_cn/layers_cn/conv2d_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/conv2d_cn.rst
@@ -6,7 +6,7 @@ conv2d
 
 .. py:function:: paddle.fluid.layers.conv2d(input, num_filters, filter_size, stride=1, padding=0, dilation=1, groups=None, param_attr=None, bias_attr=None, use_cudnn=True, act=None, name=None, data_format="NCHW")
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/conv2d_transpose_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/conv2d_transpose_cn.rst
@@ -6,7 +6,7 @@ conv2d_transpose
 
 .. py:function:: paddle.fluid.layers.conv2d_transpose(input, num_filters, output_size=None, filter_size=None, padding=0, stride=1, dilation=1, groups=None, param_attr=None, bias_attr=None, use_cudnn=True, act=None, name=None, data_format='NCHW')
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/conv3d_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/conv3d_cn.rst
@@ -6,7 +6,7 @@ conv3d
 
 .. py:function:: paddle.fluid.layers.conv3d(input, num_filters, filter_size, stride=1, padding=0, dilation=1, groups=None, param_attr=None, bias_attr=None, use_cudnn=True, act=None, name=None, data_format="NCDHW")
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/conv3d_transpose_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/conv3d_transpose_cn.rst
@@ -6,7 +6,7 @@ conv3d_transpose
 
 .. py:function:: paddle.fluid.layers.conv3d_transpose(input, num_filters, output_size=None, filter_size=None, padding=0, stride=1, dilation=1, groups=None, param_attr=None, bias_attr=None, use_cudnn=True, act=None, name=None, data_format='NCDHW')
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/create_parameter_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/create_parameter_cn.rst
@@ -6,7 +6,7 @@ create_parameter
 
 .. py:function:: paddle.fluid.layers.create_parameter(shape,dtype,name=None,attr=None,is_bias=False,default_initializer=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/create_py_reader_by_data_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/create_py_reader_by_data_cn.rst
@@ -6,7 +6,7 @@ create_py_reader_by_data
 
 .. py:function:: paddle.fluid.layers.create_py_reader_by_data(capacity,feed_list,name=None,use_double_buffer=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/crf_decoding_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/crf_decoding_cn.rst
@@ -6,7 +6,7 @@ crf_decoding
 
 .. py:function::  paddle.fluid.layers.crf_decoding(input, param_attr, label=None, length=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/data_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/data_norm_cn.rst
@@ -6,7 +6,7 @@ data_norm
 
 .. py:function:: paddle.fluid.layers.data_norm(input, act=None, epsilon=1e-05, param_attr=None, data_layout='NCHW', in_place=False, name=None, moving_mean_name=None, moving_variance_name=None, do_model_average_for_mean_and_var=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/deformable_conv_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/deformable_conv_cn.rst
@@ -6,7 +6,7 @@ deformable_conv
 
 .. py:function:: paddle.fluid.layers.deformable_conv(input, offset, mask, num_filters, filter_size, stride=1, padding=0, dilation=1, groups=None, deformable_groups=None, im2col_step=None, param_attr=None, bias_attr=None, modulated=True, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/dynamic_decode_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/dynamic_decode_cn.rst
@@ -7,7 +7,7 @@ dynamic_decode
 
 .. py:method:: dynamic_decode(decoder, inits=None, max_step_num=None, output_time_major=False, **kwargs):
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
     

--- a/doc/fluid/api_cn/layers_cn/dynamic_gru_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/dynamic_gru_cn.rst
@@ -6,7 +6,7 @@ dynamic_gru
 
 .. py:function::  paddle.fluid.layers.dynamic_gru(input, size, param_attr=None, bias_attr=None, is_reverse=False, gate_activation='sigmoid', candidate_activation='tanh', h_0=None, origin_mode=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/dynamic_lstm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/dynamic_lstm_cn.rst
@@ -6,7 +6,7 @@ dynamic_lstm
 
 .. py:function::  paddle.fluid.layers.dynamic_lstm(input, size, h_0=None, c_0=None, param_attr=None, bias_attr=None, use_peepholes=True, is_reverse=False, gate_activation='sigmoid', cell_activation='tanh', candidate_activation='tanh', dtype='float32', name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/dynamic_lstmp_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/dynamic_lstmp_cn.rst
@@ -5,7 +5,7 @@ dynamic_lstmp
 
 .. py:function:: paddle.fluid.layers.dynamic_lstmp(input, size, proj_size, param_attr=None, bias_attr=None, use_peepholes=True, is_reverse=False, gate_activation='sigmoid', cell_activation='tanh', candidate_activation='tanh', proj_activation='tanh', dtype='float32', name=None, h_0=None, c_0=None, cell_clip=None, proj_clip=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/embedding_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/embedding_cn.rst
@@ -6,7 +6,7 @@ embedding
 
 .. py:function:: paddle.fluid.layers.embedding(input, size, is_sparse=False, is_distributed=False, padding_idx=None, param_attr=None, dtype='float32')
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/fc_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/fc_cn.rst
@@ -6,7 +6,7 @@ fc
 
 .. py:function::  paddle.fluid.layers.fc(input, size, num_flatten_dims=1, param_attr=None, bias_attr=None, act=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/group_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/group_norm_cn.rst
@@ -6,7 +6,7 @@ group_norm
 
 .. py:function::  paddle.fluid.layers.group_norm(input, groups, epsilon=1e-05, param_attr=None, bias_attr=None, act=None, data_layout='NCHW', name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/gru_unit_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/gru_unit_cn.rst
@@ -6,7 +6,7 @@ gru_unit
 
 .. py:function:: paddle.fluid.layers.gru_unit(input, hidden, size, param_attr=None, bias_attr=None, activation='tanh', gate_activation='sigmoid', origin_mode=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/hsigmoid_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/hsigmoid_cn.rst
@@ -6,7 +6,7 @@ hsigmoid
 
 .. py:function:: paddle.fluid.layers.hsigmoid(input, label, num_classes, param_attr=None, bias_attr=None, name=None, path_table=None, path_code=None, is_custom=False, is_sparse=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/im2sequence_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/im2sequence_cn.rst
@@ -6,7 +6,7 @@ im2sequence
 
 .. py:function:: paddle.fluid.layers.im2sequence(input, filter_size=1, stride=1, padding=0, input_image_size=None, out_stride=1, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/instance_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/instance_norm_cn.rst
@@ -6,7 +6,7 @@ instance_norm
 
 .. py:function:: paddle.fluid.layers.instance_norm(input, epsilon=1e-05, param_attr=None, bias_attr=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/layer_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/layer_norm_cn.rst
@@ -6,7 +6,7 @@ layer_norm
 
 .. py:function:: paddle.fluid.layers.layer_norm(input, scale=True, shift=True, begin_norm_axis=1, epsilon=1e-05, param_attr=None, bias_attr=None, act=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/linear_chain_crf_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/linear_chain_crf_cn.rst
@@ -6,7 +6,7 @@ linear_chain_crf
 
 .. py:function:: paddle.fluid.layers.linear_chain_crf(input, label, param_attr=None, length=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/lstm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/lstm_cn.rst
@@ -6,7 +6,7 @@ lstm
 
 .. py:function::  paddle.fluid.layers.lstm(input, init_h, init_c, max_len, hidden_size, num_layers, dropout_prob=0.0, is_bidirec=False, is_test=False, name=None, default_initializer=None, seed=-1)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/lstm_unit_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/lstm_unit_cn.rst
@@ -6,7 +6,7 @@ lstm_unit
 
 .. py:function:: paddle.fluid.layers.lstm_unit(x_t, hidden_t_prev, cell_t_prev, forget_bias=0.0, param_attr=None, bias_attr=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/multi_box_head_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/multi_box_head_cn.rst
@@ -6,7 +6,7 @@ multi_box_head
 
 .. py:function:: paddle.fluid.layers.multi_box_head(inputs, image, base_size, num_classes, aspect_ratios, min_ratio=None, max_ratio=None, min_sizes=None, max_sizes=None, steps=None, step_w=None, step_h=None, offset=0.5, variance=[0.1, 0.1, 0.2, 0.2], flip=True, clip=False, kernel_size=1, pad=0, stride=1, name=None, min_max_aspect_ratios_order=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/nce_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/nce_cn.rst
@@ -6,7 +6,7 @@ nce
 
 .. py:function:: paddle.fluid.layers.nce(input, label, num_total_classes, sample_weight=None, param_attr=None, bias_attr=None, num_neg_samples=None, name=None, sampler='uniform', custom_dist=None, seed=0, is_sparse=False)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/prelu_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/prelu_cn.rst
@@ -6,7 +6,7 @@ prelu
 
 .. py:function:: paddle.fluid.layers.prelu(x, mode, param_attr=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/py_func_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/py_func_cn.rst
@@ -6,7 +6,7 @@ py_func
 
 .. py:function:: paddle.fluid.layers.py_func(func, x, out, backward_func=None, skip_vars_in_backward_input=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/py_reader_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/py_reader_cn.rst
@@ -6,7 +6,7 @@ py_reader
 
 .. py:function:: paddle.fluid.layers.py_reader(capacity, shapes, dtypes, lod_levels=None, name=None, use_double_buffer=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/read_file_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/read_file_cn.rst
@@ -6,7 +6,7 @@ read_file
 
 .. py:function:: paddle.fluid.layers.read_file(reader)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/rnn_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/rnn_cn.rst
@@ -7,7 +7,7 @@ rnn
 
 .. py:method:: paddle.fluid.layers.rnn(cell, inputs, initial_states=None, sequence_length=None, time_major=False, is_reverse=False, **kwargs)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
     

--- a/doc/fluid/api_cn/layers_cn/row_conv_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/row_conv_cn.rst
@@ -6,7 +6,7 @@ row_conv
 
 .. py:function:: paddle.fluid.layers.row_conv(input, future_context_size, param_attr=None, act=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_concat_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_concat_cn.rst
@@ -6,7 +6,7 @@ sequence_concat
 
 .. py:function:: paddle.fluid.layers.sequence_concat(input, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_conv_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_conv_cn.rst
@@ -6,7 +6,7 @@ sequence_conv
 
 .. py:function:: paddle.fluid.layers.sequence_conv(input, num_filters, filter_size=3, filter_stride=1, padding=True, padding_start=None, bias_attr=None, param_attr=None, act=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_enumerate_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_enumerate_cn.rst
@@ -6,7 +6,7 @@ sequence_enumerate
 
 .. py:function:: paddle.fluid.layers.sequence_enumerate(input, win_size, pad_value=0, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_expand_as_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_expand_as_cn.rst
@@ -6,7 +6,7 @@ sequence_expand_as
 
 .. py:function:: paddle.fluid.layers.sequence_expand_as(x, y, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_expand_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_expand_cn.rst
@@ -6,7 +6,7 @@ sequence_expand
 
 .. py:function:: paddle.fluid.layers.sequence_expand(x, y, ref_level=-1, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_first_step_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_first_step_cn.rst
@@ -6,7 +6,7 @@ sequence_first_step
 
 .. py:function:: paddle.fluid.layers.sequence_first_step(input)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_last_step_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_last_step_cn.rst
@@ -6,7 +6,7 @@ sequence_last_step
 
 .. py:function:: paddle.fluid.layers.sequence_last_step(input)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_pad_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_pad_cn.rst
@@ -6,7 +6,7 @@ sequence_pad
 
 .. py:function:: paddle.fluid.layers.sequence_pad(x,pad_value,maxlen=None,name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_pool_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_pool_cn.rst
@@ -6,7 +6,7 @@ sequence_pool
 
 .. py:function:: paddle.fluid.layers.sequence_pool(input, pool_type, is_test=False, pad_value=0.0)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_reshape_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_reshape_cn.rst
@@ -6,7 +6,7 @@ sequence_reshape
 
 .. py:function:: paddle.fluid.layers.sequence_reshape(input, new_dim)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_scatter_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_scatter_cn.rst
@@ -6,7 +6,7 @@ sequence_scatter
 
 .. py:function:: paddle.fluid.layers.sequence_scatter(input, index, updates, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_slice_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_slice_cn.rst
@@ -6,7 +6,7 @@ sequence_slice
 
 .. py:function:: paddle.fluid.layers.sequence_slice(input, offset, length, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_softmax_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_softmax_cn.rst
@@ -6,7 +6,7 @@ sequence_softmax
 
 .. py:function:: paddle.fluid.layers.sequence_softmax(input, use_cudnn=False, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/sequence_unpad_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/sequence_unpad_cn.rst
@@ -6,7 +6,7 @@ sequence_unpad
 
 .. py:function:: paddle.fluid.layers.sequence_unpad(x, length, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/spectral_norm_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/spectral_norm_cn.rst
@@ -6,7 +6,7 @@ spectral_norm
 
 .. py:function:: paddle.fluid.layers.spectral_norm(weight, dim=0, power_iters=1, eps=1e-12, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/layers_cn/switch_case_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/switch_case_cn.rst
@@ -6,7 +6,7 @@ switch_case
 
 .. py:function:: paddle.fluid.layers.switch_case(branch_index, branch_fns, default=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.nn.switch_case
 :alias: paddle.nn.switch_case,paddle.nn.control_flow.switch_case
 :old_api: paddle.fluid.layers.switch_case

--- a/doc/fluid/api_cn/layers_cn/while_loop_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/while_loop_cn.rst
@@ -7,7 +7,7 @@ ____________________________________
 
 .. py:function:: paddle.fluid.layers.while_loop(cond, body, loop_vars, is_test=False, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 :alias_main: paddle.nn.while_loop
 :alias: paddle.nn.while_loop,paddle.nn.control_flow.while_loop
 :old_api: paddle.fluid.layers.while_loop

--- a/doc/fluid/api_cn/nets_cn/glu_cn.rst
+++ b/doc/fluid/api_cn/nets_cn/glu_cn.rst
@@ -5,7 +5,7 @@ glu
 
 .. py:function:: paddle.fluid.nets.glu(input, dim=-1)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/nets_cn/img_conv_group_cn.rst
+++ b/doc/fluid/api_cn/nets_cn/img_conv_group_cn.rst
@@ -6,7 +6,7 @@ img_conv_group
 
 .. py:function:: paddle.fluid.nets.img_conv_group(input, conv_num_filter, pool_size, conv_padding=1, conv_filter_size=3, conv_act=None, param_attr=None, conv_with_batchnorm=False, conv_batchnorm_drop_rate=0.0, pool_stride=1, pool_type='max', use_cudnn=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/nets_cn/scaled_dot_product_attention_cn.rst
+++ b/doc/fluid/api_cn/nets_cn/scaled_dot_product_attention_cn.rst
@@ -6,7 +6,7 @@ scaled_dot_product_attention
 
 .. py:function:: paddle.fluid.nets.scaled_dot_product_attention(queries, keys, values, num_heads=1, dropout_rate=0.0)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/nets_cn/sequence_conv_pool_cn.rst
+++ b/doc/fluid/api_cn/nets_cn/sequence_conv_pool_cn.rst
@@ -6,7 +6,7 @@ sequence_conv_pool
 
 .. py:function:: paddle.fluid.nets.sequence_conv_pool(input, num_filters, filter_size, param_attr=None, act='sigmoid', pool_type='max', bias_attr=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/nets_cn/simple_img_conv_pool_cn.rst
+++ b/doc/fluid/api_cn/nets_cn/simple_img_conv_pool_cn.rst
@@ -6,7 +6,7 @@ simple_img_conv_pool
 
 .. py:function:: paddle.fluid.nets.simple_img_conv_pool(input, num_filters, filter_size, pool_size, pool_stride, pool_padding=0, pool_type='max', global_pooling=False, conv_stride=1, conv_padding=0, conv_dilation=1, conv_groups=1, param_attr=None, bias_attr=None, act=None, use_cudnn=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/optimizer_cn/DGCMomentumOptimizer_cn.rst
+++ b/doc/fluid/api_cn/optimizer_cn/DGCMomentumOptimizer_cn.rst
@@ -6,7 +6,7 @@ DGCMomentumOptimizer
 
 .. py:class:: paddle.fluid.optimizer.DGCMomentumOptimizer(learning_rate, momentum, rampup_begin_step, rampup_step=1, sparsity=[0.999], use_nesterov=False, local_grad_clip_norm=None, num_trainers=None, regularization=None, grad_clip=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/optimizer_cn/ExponentialMovingAverage_cn.rst
+++ b/doc/fluid/api_cn/optimizer_cn/ExponentialMovingAverage_cn.rst
@@ -6,7 +6,7 @@ ExponentialMovingAverage
 
 .. py:class:: paddle.fluid.optimizer.ExponentialMovingAverage(decay=0.999, thres_steps=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/optimizer_cn/LookaheadOptimizer_cn.rst
+++ b/doc/fluid/api_cn/optimizer_cn/LookaheadOptimizer_cn.rst
@@ -6,7 +6,7 @@ LookaheadOptimizer
 
 .. py:class:: paddle.fluid.optimizer.LookaheadOptimizer(inner_optimizer, alpha=0.5, k=5)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/optimizer_cn/ModelAverage_cn.rst
+++ b/doc/fluid/api_cn/optimizer_cn/ModelAverage_cn.rst
@@ -6,7 +6,7 @@ ModelAverage
 
 .. py:class:: paddle.fluid.optimizer.ModelAverage(average_window_rate, min_average_window=10000, max_average_window=10000, regularization=None, name=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/optimizer_cn/PipelineOptimizer_cn.rst
+++ b/doc/fluid/api_cn/optimizer_cn/PipelineOptimizer_cn.rst
@@ -6,7 +6,7 @@ PipelineOptimizer
 
 .. py:class:: paddle.fluid.optimizer.PipelineOptimizer(optimizer, cut_list=None, place_list=None, concurrency_list=None, queue_size=30, sync_steps=1, start_cpu_core_id=0)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/optimizer_cn/RecomputeOptimizer_cn.rst
+++ b/doc/fluid/api_cn/optimizer_cn/RecomputeOptimizer_cn.rst
@@ -6,7 +6,7 @@ RecomputeOptimizer
 
 .. py:class:: paddle.fluid.optimizer.RecomputeOptimizer(optimizer)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/transpiler_cn/DistributeTranspilerConfig_cn.rst
+++ b/doc/fluid/api_cn/transpiler_cn/DistributeTranspilerConfig_cn.rst
@@ -6,7 +6,7 @@ DistributeTranspilerConfig
 
 .. py:class:: paddle.fluid.transpiler.DistributeTranspilerConfig
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/transpiler_cn/DistributeTranspiler_cn.rst
+++ b/doc/fluid/api_cn/transpiler_cn/DistributeTranspiler_cn.rst
@@ -6,7 +6,7 @@ DistributeTranspiler
 
 .. py:class:: paddle.fluid.transpiler.DistributeTranspiler (config=None)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/transpiler_cn/HashName_cn.rst
+++ b/doc/fluid/api_cn/transpiler_cn/HashName_cn.rst
@@ -6,7 +6,7 @@ HashName
 
 .. py:class:: paddle.fluid.transpiler.HashName(pserver_endpoints)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/transpiler_cn/RoundRobin_cn.rst
+++ b/doc/fluid/api_cn/transpiler_cn/RoundRobin_cn.rst
@@ -6,7 +6,7 @@ RoundRobin
 
 .. py:class:: paddle.fluid.transpiler.RoundRobin(pserver_endpoints)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/transpiler_cn/memory_optimize_cn.rst
+++ b/doc/fluid/api_cn/transpiler_cn/memory_optimize_cn.rst
@@ -6,7 +6,7 @@ memory_optimize
 
 .. py:function:: paddle.fluid.transpiler.memory_optimize(input_program, skip_opt_set=None, print_log=False, level=0, skip_grads=True)
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 

--- a/doc/fluid/api_cn/transpiler_cn/release_memory_cn.rst
+++ b/doc/fluid/api_cn/transpiler_cn/release_memory_cn.rst
@@ -6,7 +6,7 @@ release_memory
 
 .. py:function:: paddle.fluid.transpiler.release_memory(input_program, skip_opt_set=None) 
 
-:api_attr: 声明式编程模式（静态图)
+:api_attr: 声明式编程(静态图)专用API
 
 
 


### PR DESCRIPTION
修改2.0-alpha版本 API属性描述：声明式编程模式(静态图) -> 声明式编程(静态图)专用API' 共124处
预览url：http://180.76.141.178/documentation/docs/zh/2.0-alpha/api_cn/paddle_cn/append_backward_cn.html
预览图：
![image](https://user-images.githubusercontent.com/11935832/84467037-77f3af80-acad-11ea-9390-44c57a38cf25.png)

