### PR TITLE
fix dtype error in retinanet_target_assgin example codes

### DIFF
--- a/doc/fluid/api_cn/layers_cn/retinanet_target_assign_cn.rst
+++ b/doc/fluid/api_cn/layers_cn/retinanet_target_assign_cn.rst
@@ -68,9 +68,9 @@ retinanet_target_assign
     gt_boxes = fluid.data(name='gt_boxes', shape=[10, 4],
                       dtype='float32')
     gt_labels = fluid.data(name='gt_labels', shape=[10, 1],
-                      dtype='float32')
+                      dtype='int32')
     is_crowd = fluid.data(name='is_crowd', shape=[1],
-                      dtype='float32')
+                      dtype='int32')
     im_info = fluid.data(name='im_info', shape=[1, 3],
                       dtype='float32')
     score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num = \


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Describe
Example code of retinanet_target_assgin op raises dtype errors, input `gt_label` and `is_crowd` must be int32 variables but they are float32 variables before，so this bug need to be been fixed.

**Before**

![image](https://user-images.githubusercontent.com/22235422/84870035-5df10d00-b0b1-11ea-9f7c-d86974cf0ac5.png)
![image](https://user-images.githubusercontent.com/22235422/84870063-66494800-b0b1-11ea-8e6d-23e28172a67d.png)
![image](https://user-images.githubusercontent.com/22235422/84870085-6ea18300-b0b1-11ea-8b0d-f98d8d517351.png)

**After**

![image](https://user-images.githubusercontent.com/22235422/84869896-326e2280-b0b1-11ea-982b-77a3e6381d59.png)
![image](https://user-images.githubusercontent.com/22235422/84869944-3f8b1180-b0b1-11ea-98f8-26fbcfbe0843.png)
![image](https://user-images.githubusercontent.com/22235422/84869960-46198900-b0b1-11ea-93e5-d6af42c8f4bd.png)
