### PR TITLE
add a check code script

### DIFF
--- a/scripts/check_code.sh
+++ b/scripts/check_code.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#=================================================
+#                   Utils
+#=================================================
+
+set -ex
+
+if [ -z ${BRANCH} ]; then
+    BRANCH="develop"
+fi
+
+BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/.." && pwd )"
+echo ${BENCHMARK_ROOT}
+
+function prepare_env(){
+    # Update pip
+    easy_install --upgrade pip
+    # Install tensorflow and other packages
+    pip install pre-commit==1.21 pylint==1.9.5 pytest==4.6.9
+    #apt-get update
+    #apt-get install -y git
+}
+
+function abort(){
+    echo "Your change doesn't follow benchmark's code style." 1>&2
+    echo "Please use pre-commit to check what is wrong." 1>&2
+    exit 1
+}
+
+
+function check_style(){
+	trap 'abort' 0
+	pre-commit install
+	commit_files=on
+    	for file_name in `git diff --numstat | awk '{print $NF}'`;do
+        	if [[ ! `pre-commit run --files $file_name` ]]; then
+            		git diff
+            		commit_files=off
+        	fi
+    	#done
+    	if [ $commit_files == 'off' ];then
+        	echo "code format error"
+        	exit 1
+    	fi
+    	trap 0
+}
+
+prepare_env
+check_style

--- a/scripts/check_code.sh
+++ b/scripts/check_code.sh
@@ -28,12 +28,8 @@ BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 echo ${BENCHMARK_ROOT}
 
 function prepare_env(){
-    # Update pip
-    easy_install --upgrade pip
     # Install tensorflow and other packages
     pip install pre-commit==1.21 pylint==1.9.5 pytest==4.6.9
-    #apt-get update
-    #apt-get install -y git
 }
 
 function abort(){
@@ -52,7 +48,7 @@ function check_style(){
             		git diff
             		commit_files=off
         	fi
-    	#done
+    	done
     	if [ $commit_files == 'off' ];then
         	echo "code format error"
         	exit 1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,6 +2,7 @@
 
 DIR_PATH="/FluidDoc"
 
+/bin/bash  ${DIR_PATH}/scripts/check_code.sh
 /bin/bash  ${DIR_PATH}/scripts/check_api_cn.sh
 if [ $? -ne 0 ];then
   exit 1


### PR DESCRIPTION
FluidDoc本身是在Travis-CI上进行代码风格检测的
但是Travis-Ci存在不稳定的现象，一旦触发不了，Paddle管理员没有办法
因此需要travis-ci和TeamCity合并
此PR是添加一个代码检测的脚本，用于可以在teamcity上检测代码风格