### PR TITLE
add if to start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,6 +3,10 @@
 DIR_PATH="/FluidDoc"
 
 /bin/bash  ${DIR_PATH}/scripts/check_code.sh
+if [ $? -ne 0 ];then
+  echo "code format error"
+  exit 1
+fi
 /bin/bash  ${DIR_PATH}/scripts/check_api_cn.sh
 if [ $? -ne 0 ];then
   exit 1


### PR DESCRIPTION
#2236 存在代码风格已经检查出错误，并在日志有错误输出，但github上显示流水线通过。
#2240 是解决上述问题的，发现并没有解决。
此PR依旧是解决同样问题的，个人排查后，应该是start.sh脚本的问题。
这个脚本是
![image](https://user-images.githubusercontent.com/45056973/85966297-e2b52280-b9f1-11ea-8227-26a4e5d9af3e.png)
这条流水线执行的脚本，他是将几个需要提PR时需要运行的脚本，汇聚到一起，接连运行，每个脚本执行前会有if判断上一个脚本的执行结果$?，是否等于0，不是0则exit1。
所以个人排查后得出的结果是，我把代码检测的脚本也加到这个里面，但是没有加if判断，虽然代码检测的脚本里有set -e，但是他报错与停止，只是代码检测的脚本而已，start.sh这个脚本还会继续向下运行，导致日志里有错误输出，但是整个流水线没停止没报错。