### PR TITLE
rm update_api of norm api

### DIFF
--- a/doc/fluid/api_cn/tensor_cn/norm_cn.rst
+++ b/doc/fluid/api_cn/tensor_cn/norm_cn.rst
@@ -7,7 +7,6 @@ norm
 
 :alias_main: paddle.norm
 :alias: paddle.norm,paddle.tensor.norm,paddle.tensor.linalg.norm
-:update_api: paddle.fluid.layers.l2_normalize
 
 
 


### PR DESCRIPTION
rm update_api of norm api.

The norm api is not the same as l2_normalize.