### PR TITLE
fix ci grep error

### DIFF
--- a/scripts/check_api_cn.sh
+++ b/scripts/check_api_cn.sh
@@ -13,7 +13,9 @@ else
    pip install -U python/dist/paddlepaddle_gpu-0.0.0-cp27-cp27mu-linux_x86_64.whl 
 fi
 
+
 for files in `echo $git_files`;do
+  cd /FluidDoc
   grep "code-block" $files
   if [ $? -eq 0 ] ;then 
     echo $files|grep 'doc/fluid/api_cn/.*/.*.rst'


### PR DESCRIPTION
解决CI在编译完paddle，当前目录不对导致grep 失败
![image](https://user-images.githubusercontent.com/29832297/89891018-ea7a0080-dc06-11ea-84a5-9b5beeda2ded.png)
