### PR TITLE
Remove "TypeError" from some files as required

### DIFF
--- a/doc/paddle/api/paddle/fluid/layers/fill_constant_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/fill_constant_cn.rst
@@ -27,10 +27,6 @@ fill_constant
 
 返回类型：变量（Variable）
 
-抛出异常：
-    - :code:`TypeError`: dtype必须是bool，float16，float32，float64，int32和int64之一，输出Tensor的数据类型必须与dtype相同。
-    - :code:`TypeError`: 当 `shape` 的数据类型不是list、tuple、Variable。
-
 **代码示例**：
 
 .. code-block:: python

--- a/doc/paddle/api/paddle/fluid/layers/ones_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/ones_cn.rst
@@ -14,10 +14,6 @@ ones
 
 返回：值全为1的Tensor，数据类型和 ``dtype`` 定义的类型一致。
 
-抛出异常：
-    - ``TypeError`` - 当 ``dtype`` 不是bool、 float16、float32、float64、int32、int64和None时。
-    - ``TypeError`` - 当 ``shape`` 不是tuple、list、或者Tensor时， 当 ``shape`` 为Tensor，其数据类型不是int32或者int64时。
-
 **代码示例**：
 
 .. code-block:: python

--- a/doc/paddle/api/paddle/fluid/layers/zeros_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/zeros_cn.rst
@@ -14,10 +14,6 @@ zeros
 
 返回：值全为0的Tensor，数据类型和 ``dtype`` 定义的类型一致。
 
-抛出异常：
-    - ``TypeError`` - 当 ``dtype`` 不是bool、 float16、float32、float64、int32、int64和None时。
-    - ``TypeError`` - 当 ``shape`` 不是tuple、list、或者Tensor时。 当 ``shape`` 为Tensor，其数据类型不是int32或者int64时。
-
 **代码示例**：
 
 .. code-block:: python


### PR DESCRIPTION
In order to avoid the confusion of error reporting, "TypeError" have been removed  from the document.