### PR TITLE
add formula for entropy and kl-divergence in Uniform and Normal classes

### DIFF
--- a/doc/paddle/api/paddle/distribution/Normal_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Normal_cn.rst
@@ -128,9 +128,9 @@ Normal
 
 .. math::
 
-    KL\_divergence(\mu_0, \sigma_0; \mu_1, \sigma_1) = 0.5 (ratio^2 + (\\frac{diff}{\sigma_1})^2 - 1 - 2 \\ln {ratio})
+    KL\_divergence(\mu_0, \sigma_0; \mu_1, \sigma_1) = 0.5 (ratio^2 + (\frac{diff}{\sigma_1})^2 - 1 - 2 \ln {ratio})
 
-    ratio = \\frac{\sigma_0}{\sigma_1}
+    ratio = \frac{\sigma_0}{\sigma_1}
 
     diff = \mu_1 - \mu_0
 

--- a/doc/paddle/api/paddle/distribution/Normal_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Normal_cn.rst
@@ -88,7 +88,7 @@ Normal
 
 .. math::
 
-    entropy(\sigma) = 0.5 \\log (2 \pi e \sigma^2)
+    entropy(\sigma) = 0.5 \log (2 \pi e \sigma^2)
 
 上面的数学公式中：
 

--- a/doc/paddle/api/paddle/distribution/Normal_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Normal_cn.rst
@@ -25,8 +25,8 @@ Normal
 :math:`Z`: 正态分布常量。
 
 参数：
-    - **loc** (int|float|list|numpy.ndarray|Tensor) - 正态分布平均值。数据类型为int、float32、list、numpy.ndarray或Tensor。
-    - **scale** (int|float|list|numpy.ndarray|Tensor) - 正态分布标准差。数据类型为int、float32、list、numpy.ndarray或Tensor。
+    - **loc** (int|float|list|numpy.ndarray|Tensor) - 正态分布平均值。数据类型为int、float、list、numpy.ndarray或Tensor。
+    - **scale** (int|float|list|numpy.ndarray|Tensor) - 正态分布标准差。数据类型为int、float、list、numpy.ndarray或Tensor。
     - **name** (str，可选） - 操作的名称(可选，默认值为None）。更多信息请参见 :ref:`api_guide_Name`。
 
 **代码示例**：
@@ -75,7 +75,7 @@ Normal
 参数：
     - **shape** (list) - 1维列表，指定生成样本的维度。数据类型为int32。
     - **seed** (int) - 长整型数。
-    
+
 返回：预先设计好维度的张量, 数据类型为float32
 
 返回类型：Tensor
@@ -83,7 +83,17 @@ Normal
 .. py:function:: entropy()
 
 信息熵
-    
+
+数学公式：
+
+.. math::
+
+    entropy(\sigma) = 0.5 \\log (2 \pi e \sigma^2)
+
+上面的数学公式中：
+
+:math:`scale = \sigma` : 标准差。
+
 返回：正态分布的信息熵, 数据类型为float32
 
 返回类型：Tensor
@@ -94,7 +104,7 @@ Normal
 
 参数：
     - **value** (Tensor) - 输入张量。数据类型为float32或float64。
-    
+
 返回：对数概率, 数据类型与value相同
 
 返回类型：Tensor
@@ -105,7 +115,7 @@ Normal
 
 参数：
     - **value** (Tensor) - 输入张量。数据类型为float32或float64。
-    
+
 返回：概率, 数据类型与value相同
 
 返回类型：Tensor
@@ -114,13 +124,31 @@ Normal
 
 两个正态分布之间的KL散度。
 
+数学公式：
+
+.. math::
+
+    KL\_divergence(\mu_0, \sigma_0; \mu_1, \sigma_1) = 0.5 (ratio^2 + (\\frac{diff}{\sigma_1})^2 - 1 - 2 \\ln {ratio})
+
+    ratio = \\frac{\sigma_0}{\sigma_1}
+
+    diff = \mu_1 - \mu_0
+
+上面的数学公式中：
+
+:math:`loc = \mu_0`: 当前正态分布的平均值。
+:math:`scale = \sigma_0`: 当前正态分布的标准差。
+:math:`loc = \mu_1`: 另一个正态分布的平均值。
+:math:`scale = \sigma_1`: 另一个正态分布的标准差。
+:math:`ratio`: 两个标准差之间的比例。
+:math:`diff`: 两个平均值之间的差值。
+
 参数：
     - **other** (Normal) - Normal的实例。
-    
+
 返回：两个正态分布之间的KL散度, 数据类型为float32
 
 返回类型：Tensor
-
 
 
 

--- a/doc/paddle/api/paddle/distribution/Uniform_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Uniform_cn.rst
@@ -85,7 +85,7 @@ Uniform
 
 .. math::
 
-    entropy(low, high) = \\log (high - low)
+    entropy(low, high) = \log (high - low)
 
 返回：均匀分布的信息熵, 数据类型为float32
 

--- a/doc/paddle/api/paddle/distribution/Uniform_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Uniform_cn.rst
@@ -27,8 +27,8 @@ Uniform
 参数low和high的维度必须能够支持广播。
 
 参数：
-    - **low** (int|float|list|numpy.ndarray|Tensor) - 均匀分布的下边界。数据类型为int、float32、list、numpy.ndarray或Tensor。
-    - **high** (int|float|list|numpy.ndarray|Tensor) - 均匀分布的上边界。数据类型为int、float32、list、numpy.ndarray或Tensor。
+    - **low** (int|float|list|numpy.ndarray|Tensor) - 均匀分布的下边界。数据类型为int、float、list、numpy.ndarray或Tensor。
+    - **high** (int|float|list|numpy.ndarray|Tensor) - 均匀分布的上边界。数据类型为int、float、list、numpy.ndarray或Tensor。
     - **name** (str，可选） - 操作的名称(可选，默认值为None）。更多信息请参见 :ref:`api_guide_Name`。
 
 **代码示例**：
@@ -82,7 +82,11 @@ Uniform
 .. py:function:: entropy()
 
 信息熵
-    
+
+.. math::
+
+    entropy(low, high) = \\log (high - low)
+
 返回：均匀分布的信息熵, 数据类型为float32
 
 返回类型：Tensor


### PR DESCRIPTION
Documents of distribution related classes have been implemented in PR #2417.
This PR adds formula for entropy and kl-divergence in `Uniform` and `Normal` classes.


# Uniform_cn
## entropy formula
![图片](https://user-images.githubusercontent.com/26408901/92223048-7adbf600-eed2-11ea-9909-9ad413008b2b.png)

# Uniform_en
## entropy_formula
![图片](https://user-images.githubusercontent.com/26408901/92224659-b1b30b80-eed4-11ea-8d57-039525844e03.png)


# Normal_cn
## entropy formula
![图片](https://user-images.githubusercontent.com/26408901/92224480-73b5e780-eed4-11ea-93f4-78ac1487c814.png)

## kl-divergence formula
![图片](https://user-images.githubusercontent.com/26408901/92224522-7dd7e600-eed4-11ea-9797-e78995f4d3ac.png)

# Normal_en
## entropy formula
![图片](https://user-images.githubusercontent.com/26408901/92224736-cc858000-eed4-11ea-9662-58c7adb24b2a.png)

## kl-divergence formula
![图片](https://user-images.githubusercontent.com/26408901/92224782-e030e680-eed4-11ea-8a36-32dae635ea88.png)


