### PR TITLE
migrate en doc from old dir

### DIFF
--- a/doc/paddle/guides/dygraph_to_static/debugging_cn.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_cn.md
@@ -1,8 +1,11 @@
 # 调试方法
 
-本节内容将介绍动态图转静态图（下文简称动转静）推荐的几种调试方法。
+本节内容将介绍动态图转静态图（下文简称：动转静）推荐的几种调试方法。
 
-注意：请确保转换前的动态图代码能够成功运行，建议使用[paddle.jit.ProgramTranslator().enable(False)](../../api_cn/dygraph_cn/ProgramTranslator_cn.html#enable)关闭动转静功能，直接运行动态图，如下：
+> **注解:**
+>
+> 请确保转换前的动态图代码能够成功运行，建议使用[paddle.jit.ProgramTranslator().enable(False)](../../api_cn/dygraph_cn/ProgramTranslator_cn.html#enable)关闭动转静功能，直接运行动态图，如下：
+
 ```python
 import paddle
 import numpy as np
@@ -96,35 +99,36 @@ func(np.ones([3, 2]))
 
 2. 使用`set_code_level(level)`或环境变量`TRANSLATOR_CODE_LEVEL=level`
 
-    通过调用`set_code_level`或设置环境变量`TRANSLATOR_CODE_LEVEL`，可以在log中查看转换后的代码
-```python
-@paddle.jit.to_static
-def func(x):
-    x = paddle.to_tensor(x)
-    if x > 3:
-        x = x - 1
-    return x
+    通过调用`set_code_level`或设置环境变量`TRANSLATOR_CODE_LEVEL`，可以在log中查看转换后的代码：
 
-paddle.jit.set_code_level() # 也可设置 os.environ["TRANSLATOR_CODE_LEVEL"] = '100'，效果相同
-func(np.ones([1]))
-```
-    运行结果：
+    ```python
+    @paddle.jit.to_static
+       def func(x):
+       x = paddle.to_tensor(x)
+       if x > 3:
+           x = x - 1
+       return x
 
-```bash
-2020-XX-XX 00:00:00,980-INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
-def func(x):
-    x = fluid.layers.assign(x)
+    paddle.jit.set_code_level() # 也可设置 os.environ["TRANSLATOR_CODE_LEVEL"] = '100'，效果相同
+    func(np.ones([1]))
+    ```
+   运行结果：
 
-    def true_fn_0(x):
-        x = x - 1
+    ```bash
+    2020-XX-XX 00:00:00,980-INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
+    def func(x):
+        x = fluid.layers.assign(x)
+
+        def true_fn_0(x):
+            x = x - 1
+            return x
+
+        def false_fn_0(x):
+            return x
+        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
+            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
-
-    def false_fn_0(x):
-        return x
-    x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
-        3, true_fn_0, false_fn_0, (x,), (x,), (x,))
-    return x
-```
+    ```
     `set_code_level` 函数可以设置查看不同的AST Transformer转化后的代码，详情请见[set_code_level]()<!--TODO：补充set_code_level文档链接-->。
 
 ## 使用 `print`
@@ -133,15 +137,19 @@ def func(x):
 @paddle.jit.to_static
 def func(x):
     x = paddle.to_tensor(x)
+
     # 打印x，x是Paddle Tensor，实际运行时会运行Paddle Print(x)
     print(x)
+
     # 打印注释，非Paddle Tensor，实际运行时仍运行print
     print("Here call print function.")
+
     if len(x) > 3:
         x = x - 1
     else:
         x = paddle.ones(shape=[1])
     return x
+
 func(np.ones([1]))
 ```
 
@@ -165,8 +173,11 @@ ProgramTranslator在日志中记录了额外的调试信息，以帮助您了解
 - 2: 包括以上信息，还包括更详细函数转化日志
 - 3: 包括以上信息，以及更详细的动转静日志
 
+> **注意:**
+>
+> 日志中包括了源代码等信息，请在共享日志前确保它不包含敏感信息。
 
-可以在代码运行前调用`paddle.jit.set_verbosity()`：
+可以在代码运行前调用`paddle.jit.set_verbosity`控制日志详细程度：
 ```python
 paddle.jit.set_verbosity(3)
 ```

--- a/doc/paddle/guides/dygraph_to_static/debugging_en.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_en.md
@@ -1,0 +1,200 @@
+# Debugging Methods
+
+This section will introduce several debugging methods recommended by Dynamic Graph to Static Graph (hereafter called Dynamic-to-Staic).
+
+> **NOTE:**
+>
+> Please ensure that the dynamic graph code before transformation can run successfully. It is recommended to call [paddle.jit.ProgramTranslator().enable(False)](../../api/dygraph/ProgramTranslator_en.html#enable) to disable Dynamic-to-Static, and run dynamic graph code as follows:
+
+
+```python
+import paddle
+import numpy as np
+paddle.disable_static()
+
+# Disable Dynamic-to-Static
+paddle.jit.ProgramTranslator().enable(False)
+
+@paddle.jit.to_static
+def func(x):
+    x = paddle.to_tensor(x)
+    if x > 3:
+        x = x - 1
+    return x
+
+func(np.ones([3, 2]))
+```
+
+## Breakpoint Debugging
+When using Dynamic-to-Static, you can use breakpoints to debug.
+
+For example, call `pdb.set_trace()` in your code:
+```Python
+import pdb
+
+@paddle.jit.to_static
+def func(x):
+    x = paddle.to_tensor(x)
+    pdb.set_trace()
+    if x > 3:
+        x = x - 1
+    return x
+```
+Executing the following code will land the debugger in the transformed static graph code:
+```Python
+func(np.ones([3, 2]))
+```
+
+```bash
+> /tmp/tmpR809hf.py(6)func()
+-> def true_fn_0(x):
+(Pdb) n
+> /tmp/tmpR809hf.py(6)func()
+-> def false_fn_0(x):
+...
+```
+
+Calling [`paddle.jit.ProgramTranslator().enable(False)`](../../api/dygraph/ProgramTranslator_en.html#enable) before executing the code will land the debugger in the original dynamic graph code:
+```python
+paddle.jit.ProgramTranslator().enable(False)
+func(np.ones([3, 2]))
+```
+
+```bash
+> <ipython-input-22-0bd4eab35cd5>(10)func()
+-> if x > 3:
+...
+
+```
+
+## Print Transformed Code
+
+There are two ways to print the transformed static graph code:
+
+1. Use the attribute `code` of the decorated function:
+    ```Python
+    @paddle.jit.to_static
+    def func(x):
+    x = paddle.to_tensor(x)
+        if x > 3:
+            x = x - 1
+        return x
+
+    print(func.code)
+    ```
+    ```bash
+
+    def func(x):
+        x = fluid.layers.assign(x)
+
+        def true_fn_0(x):
+            x = x - 1
+            return x
+
+        def false_fn_0(x):
+            return x
+        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
+            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
+        return x
+    ```
+2. Call `set_code_level(level)` or set environment variable `TRANSLATOR_CODE_LEVEL=level`
+
+    You can view the transformed code in the log by calling `set_code_level` or set environment variable `TRANSLATOR_CODE_LEVEL`.
+
+    ```python
+    @paddle.jit.to_static
+       def func(x):
+       x = paddle.to_tensor(x)
+       if x > 3:
+           x = x - 1
+       return x
+
+    paddle.jit.set_code_level() # the same effect to set os.environ["TRANSLATOR_CODE_LEVEL"] = '100'
+    func(np.ones([1]))
+    ```
+
+    ```bash
+    2020-XX-XX 00:00:00,980-INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
+    def func(x):
+        x = fluid.layers.assign(x)
+
+        def true_fn_0(x):
+            x = x - 1
+            return x
+
+        def false_fn_0(x):
+            return x
+        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
+            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
+        return x
+    ```
+    `set_code_level` can set different levels to view the code transformed by different ast transformers. For details, please refer to [set_code_level]()<!--TODO：补充set_code_level文档链接-->。
+
+## `print`
+You can call `print` to view variables. `print` will be transformed when using Dynamic-to-Static. When only Paddle Tensor is printed, `print` will be transformed and call Paddle operator [Print](../../api/layers/Print.html) in runtime. Otherwise, call python `print`.
+
+```python
+@paddle.jit.to_static
+def func(x):
+    x = paddle.to_tensor(x)
+    # x is a Paddle Tensor, so it will run Paddle Print(x) actually.
+    print(x)
+
+    # The string is not a Paddle Tensor, so it will run print as-is.
+    print("Here call print function.")
+
+    if len(x) > 3:
+        x = x - 1
+    else:
+        x = paddle.ones(shape=[1])
+    return x
+
+func(np.ones([1]))
+```
+
+```bash
+Variable: assign_0.tmp_0
+  - lod: {}
+  - place: CPUPlace
+  - shape: [1]
+  - layout: NCHW
+  - dtype: double
+  - data: [1]
+Here call print function.  
+```
+
+## Log Printing
+ProgramTranslator can log additional debugging information to help you know whether the function was successfully transformed or not.
+
+You can call `paddle.jit.set_verbosity(level)` or set environment variable `TRANSLATOR_VERBOSITY=level` to enable logging and view logs of different levels. The argument `level` varies from 0 to 3:
+- 0: no logging
+- 1: includes the information in Dynamic-to-Static tranformation process, such as the source code not transformed, the callable object to transform and so on
+- 2: includes above and more detailed function transformation logs
+- 3: includes above and extremely verbose logging
+
+> **WARNING:**
+>
+> The logs includes information such as source code. Please make sure logs don't contain any sensitive information before sharing them.
+
+You can call `paddle.jit.set_verbosity` to control the verbosity level of logs:
+```python
+paddle.jit.set_verbosity(3)
+```
+or use the environment variable `TRANSLATOR_VERBOSITY`：
+```python
+import os
+os.environ["TRANSLATOR_VERBOSITY"] = '3'
+```
+
+```bash
+2020-XX-XX 00:00:00,123-Level 1:    Source code:
+@paddle.jit.to_static
+def func(x):
+    x = paddle.to_tensor(x)
+    if len(x) > 3:
+        x = x - 1
+    else:
+        x = paddle.ones(shape=[1])
+    return x
+
+2020-XX-XX 00:00:00,152-Level 1: Convert callable object: convert <built-in function len>.

--- a/doc/paddle/guides/dygraph_to_static/index_cn.rst
+++ b/doc/paddle/guides/dygraph_to_static/index_cn.rst
@@ -15,9 +15,9 @@
 
 ..  toctree::
     :hidden:
-
-    grammar_list_cn.rst
+    
     program_translator_cn.rst
+    grammar_list_cn.rst
     input_spec_cn.rst
     error_handling_cn.md
     debugging_cn.md

--- a/doc/paddle/guides/dygraph_to_static/index_en.rst
+++ b/doc/paddle/guides/dygraph_to_static/index_en.rst
@@ -4,9 +4,9 @@ Dygraph to Static Graph
 
 - `Dygraph to Static Graph <program_translator_cn.html>`_ ：Introduce the basic usage for transforming dygraph code into static code and the architecture of ProgramTranslator.
 
-- `Supported Grammars <grammar_list_en.html>`_ ：Introduce the grammars supported by ProgramTranslator and list unsupport grammars.
+- `Supported Grammars <grammar_list_en.html>`_ ：Introduce the grammars supported by ProgramTranslator and list unsupported grammars.
 
-- `InputSpec Feature<input_spec_en.html>`_ ：Introduce the usage of InputSpec to specify the input signature from dygraph to static program.
+- `Usage of InputSpec <input_spec_en.html>`_ ：Introduce the usage of InputSpec to specify the input signature from dygraph to static program.
 
 - `Error Handling <error_handling_en.html>`_ ：Introduce the error handling by ProgramTranslator.
 

--- a/doc/paddle/guides/dygraph_to_static/index_en.rst
+++ b/doc/paddle/guides/dygraph_to_static/index_en.rst
@@ -6,9 +6,18 @@ Dygraph to Static Graph
 
 - `Supported Grammars <grammar_list_en.html>`_ ：Introduce the grammars supported by ProgramTranslator and list unsupport grammars.
 
+- `InputSpec Feature<input_spec_en.html>`_ ：Introduce the usage of InputSpec to specify the input signature from dygraph to static program.
+
+- `Error Handling <error_handling_en.html>`_ ：Introduce the error handling by ProgramTranslator.
+
+- `Debugging Methods <debugging_en.html>`_ ：Introduce the debugging methods when using ProgramTranslator.
+
 ..  toctree::
     :hidden:
 
     grammar_list_en.rst
     program_translator_en.rst
+    input_spec_en.rst
+    error_handling_en.md
+    debugging_en.md
 

--- a/doc/paddle/guides/dygraph_to_static/index_en.rst
+++ b/doc/paddle/guides/dygraph_to_static/index_en.rst
@@ -6,7 +6,7 @@ Dygraph to Static Graph
 
 - `Supported Grammars <grammar_list_en.html>`_ ：Introduce the grammars supported by ProgramTranslator and list unsupported grammars.
 
-- `Usage of InputSpec <input_spec_en.html>`_ ：Introduce the usage of InputSpec to specify the input signature from dygraph to static program.
+- `Introduction of InputSpec <input_spec_en.html>`_ ：Introduce the usage of InputSpec to specify the input signature from dygraph to static program.
 
 - `Error Handling <error_handling_en.html>`_ ：Introduce the error handling by ProgramTranslator.
 
@@ -15,8 +15,8 @@ Dygraph to Static Graph
 ..  toctree::
     :hidden:
 
-    grammar_list_en.rst
     program_translator_en.rst
+    grammar_list_en.rst
     input_spec_en.rst
     error_handling_en.md
     debugging_en.md

--- a/doc/paddle/guides/index_en.rst
+++ b/doc/paddle/guides/index_en.rst
@@ -16,4 +16,4 @@ Let's start with studying basic concept of PaddlePaddle:
     :hidden:
 
     migration_en.rst
-    dynamic_to_static/index_en.rst
+    dygraph_to_static/index_en.rst


### PR DESCRIPTION
Only migrating en doc from old dir `doc/advanced_guides/dygraph_to_static` to `paddle/guides/dygraph_to_static`

http://gzhxy-inf-bce36a39de.gzhxy.baidu.com:8121/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc_review-1339

+ Add `debugging_en.md`
+ Add `error_handling_en.md`
+ Update `debugging_cn.md` from old dir
+ Update `error_handling_cn.md`
+ Update `index_en.rst` in dygraph_to_static dir


![image](https://user-images.githubusercontent.com/9301846/93076893-9dcc8e00-f6ba-11ea-9d2b-7cd7a5d29d3b.png)
