### PR TITLE
Optimize doc of dynamic-to-static debugging and error_handling

### DIFF
--- a/doc/paddle/guides/dygraph_to_static/debugging_cn.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_cn.md
@@ -92,8 +92,7 @@ func(np.ones([3, 2]))
 
         def false_fn_0(x):
             return x
-        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
-            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
+        x = paddle.jit.dy2static.convert_ifelse(x > 3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
 
@@ -125,8 +124,7 @@ func(np.ones([3, 2]))
 
         def false_fn_0(x):
             return x
-        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
-            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
+        x = paddle.jit.dy2static.convert_ifelse(x > 3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
     此外，如果您想将转化后的代码也输出到 ``sys.stdout``, 可以设置参数 ``also_to_stdout`` 为 True，否则将仅输出到 ``sys.stderr``。

--- a/doc/paddle/guides/dygraph_to_static/debugging_cn.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_cn.md
@@ -9,7 +9,6 @@
 ```python
 import paddle
 import numpy as np
-paddle.disable_static()
 # 关闭动转静动能
 paddle.jit.ProgramTranslator().enable(False)
 
@@ -98,7 +97,7 @@ func(np.ones([3, 2]))
         return x
     ```
 
-2. 使用 `set_code_level(level)` 或环境变量 `TRANSLATOR_CODE_LEVEL=level`
+2. 使用 [`set_code_level(level=100, also_to_stdout=False)`](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_cn.html) 或环境变量 `TRANSLATOR_CODE_LEVEL=level`
 
     通过调用 `set_code_level` 或设置环境变量 `TRANSLATOR_CODE_LEVEL`，可以在日志中查看转换后的代码：
 
@@ -116,7 +115,7 @@ func(np.ones([3, 2]))
    运行结果：
 
     ```bash
-    2020-XX-XX 00:00:00,980-INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
+    2020-XX-XX 00:00:00,980 Dynamic-to-Static INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
     def func(x):
         x = fluid.layers.assign(x)
 
@@ -130,7 +129,8 @@ func(np.ones([3, 2]))
             3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
-    `set_code_level` 函数可以设置查看不同的AST Transformer转化后的代码，详情请见 [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_cn.html)。
+    此外，如果您想将转化后的代码也输出到 ``sys.stdout``, 可以设置参数 ``also_to_stdout`` 为 True，否则将仅输出到 ``sys.stderr``。
+    `set_code_level` 函数可以设置查看不同的 AST Transformer 转化后的代码，详情请见 [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_cn.html)。
 
 ## 使用 `print`
 `print` 函数可以用来查看变量，该函数在动转静中会被转化。当仅打印 Paddle Tensor 时，实际运行时会被转换为 Paddle 算子 [Print](../../api_cn/layers_cn/Print_cn.html)，否则仍然运行 `print`。
@@ -168,7 +168,7 @@ Here call print function.
 
 ## 日志打印
 ProgramTranslator在日志中记录了额外的调试信息，以帮助您了解动转静过程中函数是否被成功转换。
-您可以调用 [`paddle.jit.set_verbosity(level)`]((../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_cn.html)) 或设置环境变量 `TRANSLATOR_VERBOSITY=level` 来设置日志详细等级，并查看不同等级的日志信息。目前，`level` 可以取值0-3：
+您可以调用 [`paddle.jit.set_verbosity(level=0, also_to_stdout=False)`]((../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_cn.html)) 或设置环境变量 `TRANSLATOR_VERBOSITY=level` 来设置日志详细等级，并查看不同等级的日志信息。目前，`level` 可以取值0-3：
 - 0: 无日志
 - 1: 包括了动转静转化流程的信息，如转换前的源码、转换的可调用对象
 - 2: 包括以上信息，还包括更详细函数转化日志
@@ -190,7 +190,7 @@ os.environ["TRANSLATOR_VERBOSITY"] = '3'
 
 运行结果：
 ```bash
-2020-XX-XX 00:00:00,123-Level 1:    Source code:
+2020-XX-XX 00:00:00,123 Dynamic-to-Static INFO: (Level 1) Source code:
 @paddle.jit.to_static
 def func(x):
     x = paddle.to_tensor(x)
@@ -200,5 +200,6 @@ def func(x):
         x = paddle.ones(shape=[1])
     return x
 
-2020-XX-XX 00:00:00,152-Level 1: Convert callable object: convert <built-in function len>.
+2020-XX-XX 00:00:00,152 Dynamic-to-Static INFO: (Level 1) Convert callable object: convert <built-in function len>.
 ```
+此外，如果您想将日志也输出到 ``sys.stdout``, 可以设置参数 ``also_to_stdout`` 为 True，否则将仅输出到 ``sys.stderr``，详情请见 [set_verbosity](../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_cn.html)。

--- a/doc/paddle/guides/dygraph_to_static/debugging_cn.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_cn.md
@@ -84,7 +84,7 @@ func(np.ones([3, 2]))
     ```bash
 
     def func(x):
-        x = fluid.layers.assign(x)
+        x = paddle.nn.functional.assign(x)
 
         def true_fn_0(x):
             x = x - 1
@@ -116,7 +116,7 @@ func(np.ones([3, 2]))
     ```bash
     2020-XX-XX 00:00:00,980 Dynamic-to-Static INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
     def func(x):
-        x = fluid.layers.assign(x)
+        x = paddle.nn.functional.assign(x)
 
         def true_fn_0(x):
             x = x - 1

--- a/doc/paddle/guides/dygraph_to_static/debugging_en.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_en.md
@@ -94,8 +94,7 @@ There are two ways to print the transformed static graph code:
 
         def false_fn_0(x):
             return x
-        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
-            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
+        x = paddle.jit.dy2static.convert_ifelse(x > 3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
 2. Call [`set_code_level(level=100, also_to_stdout=False)`](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_en.html) or set environment variable `TRANSLATOR_CODE_LEVEL=level`
@@ -125,8 +124,7 @@ There are two ways to print the transformed static graph code:
 
         def false_fn_0(x):
             return x
-        x = fluid.dygraph.dygraph_to_static.convert_operators.convert_ifelse(x >
-            3, true_fn_0, false_fn_0, (x,), (x,), (x,))
+        x = paddle.jit.dy2static.convert_ifelse(x > 3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
     In addition, if you want to output the transformed code to ``sys.stdout``, you can set the argument ``also_to_stdout`` to True, otherwise the transformed code is only output to ``sys.stderr``.

--- a/doc/paddle/guides/dygraph_to_static/debugging_en.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_en.md
@@ -10,7 +10,6 @@ This section will introduce several debugging methods recommended by Dynamic Gra
 ```python
 import paddle
 import numpy as np
-paddle.disable_static()
 
 # Disable Dynamic-to-Static
 paddle.jit.ProgramTranslator().enable(False)
@@ -99,7 +98,7 @@ There are two ways to print the transformed static graph code:
             3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
-2. Call `set_code_level(level)` or set environment variable `TRANSLATOR_CODE_LEVEL=level`
+2. Call [`set_code_level(level=100, also_to_stdout=False)`](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_en.html) or set environment variable `TRANSLATOR_CODE_LEVEL=level`
 
     You can view the transformed code in the log by calling `set_code_level` or set environment variable `TRANSLATOR_CODE_LEVEL`.
 
@@ -116,7 +115,7 @@ There are two ways to print the transformed static graph code:
     ```
 
     ```bash
-    2020-XX-XX 00:00:00,980-INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
+    2020-XX-XX 00:00:00,980 Dynamic-to-Static INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
     def func(x):
         x = fluid.layers.assign(x)
 
@@ -130,7 +129,8 @@ There are two ways to print the transformed static graph code:
             3, true_fn_0, false_fn_0, (x,), (x,), (x,))
         return x
     ```
-    `set_code_level` can set different levels to view the code transformed by different ast transformers. For details, please refer to [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_en.html)。
+    In addition, if you want to output the transformed code to ``sys.stdout``, you can set the argument ``also_to_stdout`` to True, otherwise the transformed code is only output to ``sys.stderr``.
+    `set_code_level` can set different levels to view the code transformed by different ast transformers. For details, please refer to [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_en.html).
 
 ## `print`
 You can call `print` to view variables. `print` will be transformed when using Dynamic-to-Static. When only Paddle Tensor is printed, `print` will be transformed and call Paddle operator [Print](../../api/layers/Print.html) in runtime. Otherwise, call python `print`.
@@ -168,7 +168,7 @@ Here call print function.
 ## Log Printing
 ProgramTranslator can log additional debugging information to help you know whether the function was successfully transformed or not.
 
-You can call [`paddle.jit.set_verbosity(level)`](../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_en.html) or set environment variable `TRANSLATOR_VERBOSITY=level` to enable logging and view logs of different levels. The argument `level` varies from 0 to 3:
+You can call [`paddle.jit.set_verbosity(level=0, also_to_stdout=False)`](../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_en.html) or set environment variable `TRANSLATOR_VERBOSITY=level` to enable logging and view logs of different levels. The argument `level` varies from 0 to 3:
 - 0: no logging
 - 1: includes the information in Dynamic-to-Static tranformation process, such as the source code not transformed, the callable object to transform and so on
 - 2: includes above and more detailed function transformation logs
@@ -189,7 +189,7 @@ os.environ["TRANSLATOR_VERBOSITY"] = '3'
 ```
 
 ```bash
-2020-XX-XX 00:00:00,123-Level 1:    Source code:
+2020-XX-XX 00:00:00,123 Dynamic-to-Static INFO: (Level 1) Source code:
 @paddle.jit.to_static
 def func(x):
     x = paddle.to_tensor(x)
@@ -199,4 +199,7 @@ def func(x):
         x = paddle.ones(shape=[1])
     return x
 
-2020-XX-XX 00:00:00,152-Level 1: Convert callable object: convert <built-in function len>.
+2020-XX-XX 00:00:00,152 Dynamic-to-Static INFO: (Level 1) Convert callable object: convert <built-in function len>.
+```
+
+In addition, if you want to output the logs to ``sys.stdout``, you can set the argument ``also_to_stdout`` to True, otherwise the logs are only output to ``sys.stderr``. For details, please refer to [set_verbosity](../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_en.html)

--- a/doc/paddle/guides/dygraph_to_static/debugging_en.md
+++ b/doc/paddle/guides/dygraph_to_static/debugging_en.md
@@ -86,7 +86,7 @@ There are two ways to print the transformed static graph code:
     ```bash
 
     def func(x):
-        x = fluid.layers.assign(x)
+        x = paddle.nn.functional.assign(x)
 
         def true_fn_0(x):
             x = x - 1
@@ -116,7 +116,7 @@ There are two ways to print the transformed static graph code:
     ```bash
     2020-XX-XX 00:00:00,980 Dynamic-to-Static INFO: After the level 100 ast transformer: 'All Transformers', the transformed code:
     def func(x):
-        x = fluid.layers.assign(x)
+        x = paddle.nn.functional.assign(x)
 
         def true_fn_0(x):
             x = x - 1
@@ -200,4 +200,4 @@ def func(x):
 2020-XX-XX 00:00:00,152 Dynamic-to-Static INFO: (Level 1) Convert callable object: convert <built-in function len>.
 ```
 
-In addition, if you want to output the logs to ``sys.stdout``, you can set the argument ``also_to_stdout`` to True, otherwise the logs are only output to ``sys.stderr``. For details, please refer to [set_verbosity](../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_en.html)
+In addition, if you want to output the logs to ``sys.stdout``, you can set the argument ``also_to_stdout`` to True, otherwise the logs are only output to ``sys.stderr``. For details, please refer to [set_verbosity](../../../paddle/api/paddle/fluid/dygraph/jit/set_verbosity_en.html).

--- a/doc/paddle/guides/dygraph_to_static/error_handling_cn.md
+++ b/doc/paddle/guides/dygraph_to_static/error_handling_cn.md
@@ -42,8 +42,6 @@ ProgramTranslator打印的警告信息如下：
 import paddle
 import numpy as np
 
-paddle.disable_static()
-
 @paddle.jit.to_static
 def func(x):
     x = paddle.to_tensor(x)

--- a/doc/paddle/guides/dygraph_to_static/error_handling_cn.md
+++ b/doc/paddle/guides/dygraph_to_static/error_handling_cn.md
@@ -1,16 +1,14 @@
 # 报错信息处理
 
-本节内容将介绍使用动态图转静态图（下文简称：动转静）功能发生异常时，[ProgramTranslator](./program_translator_cn.html)对报错信息做的处理，以帮助您更好地理解动转静报错信息。使用动转静功能运行动态图代码时，内部可以分为2个步骤：动态图代码转换成静态图代码，运行静态图代码。接下来将分别介绍这2个步骤中的异常报错情况。
+本节内容将介绍使用动态图转静态图（下文简称：动转静）功能发生异常时，[ProgramTranslator](./program_translator_cn.html)的动转静报错模块对报错信息做的处理，以帮助您更好地理解动转静报错信息。使用动转静功能运行动态图代码时，内部可以分为2个步骤：动态图代码转换成静态图代码，运行静态图代码。接下来将分别介绍这2个步骤中的异常报错情况。
 
 ## 动转静过程中的异常
-在动态图代码转换成静态图代码的过程中，如果ProgramTranslator无法转换一个函数时，将会显示警告信息，并尝试直接运行该函数。
+在动态图代码转换成静态图代码的过程中，如果 ProgramTranslator 无法转换一个函数时，将会显示警告信息，并尝试直接运行该函数。
 如下代码中，函数 `inner_func` 在调用前被转换成静态图代码，当 `x = inner_func(data)` 调用该函数时，不能重复转换，会给出警告信息：
 
 ```python
 import paddle
 import numpy as np
-
-paddle.disable_static()
 
 @paddle.jit.to_static
 def func():
@@ -26,7 +24,7 @@ func()
 ProgramTranslator打印的警告信息如下：
 
 ```bash
-WARNING: <function inner_func at 0x7fa9bcaacf50> doesn't have to be transformed to static function because it has been transformed before, it will be run as-is.
+2020-01-01 00:00:00,104-WARNING: <function inner_func at 0x125b3a550> doesn't have to be transformed to static function because it has been transformed before, it will be run as-is.
 ```
 
 ## 运行转换后的代码报错
@@ -77,7 +75,7 @@ AssertionError: In user code:
 
 1. 报错栈中，涉及代码转换过程的信息栈默认会被隐藏，不进行展示，以减少干扰信息。
 
-2. ProgramTranslator处理后的报错信息中，会包含提示"In user code:"，表示之后的报错栈中，包含动转静前的动态图代码，即用户写的代码：
+2. ProgramTranslator 处理后的报错信息中，会包含提示 "In user code:"，表示之后的报错栈中，包含动转静前的动态图代码，即用户写的代码：
 	```bash
 	AssertionError: In user code:
 
@@ -95,7 +93,11 @@ AssertionError: In user code:
 	AssertionError: Only one dimension value of 'shape' in reshape can be -1. But received shape[1] is also -1.
 	```
 
-运行以下代码，在静态图运行时，即运行期会抛出异常：
+> **注解:**
+>
+> 如果您想查看 Paddle 原生报错信息栈，即未被动转静模块处理过的报错信息栈，可以设置环境变量 ``TRANSLATOR_DISABLE_NEW_ERROR=1`` 关闭动转静报错模块。该环境变量默认值为0，表示默认开启动转静报错模块。
+
+运行以下代码，在静态图运行期会抛出异常：
 
 ```Python
 @paddle.jit.to_static
@@ -158,3 +160,7 @@ InvalidArgumentError: The 'shape' in ReshapeOp is invalid. The input tensor X'si
 ```
 
 上述异常中，除了隐藏部分报错栈、报错定位到转换前的动态图代码外，报错信息中包含了C++报错栈 `C++ Traceback` 和 `Error Message Summary`，这是 Paddle 的 C++ 端异常信息，经处理后在 Python 的异常信息中显示。
+
+> **注解:**
+>
+> 如果您想查看被隐藏的信息栈，可以设置环境变量 ``TRANSLATOR_SIMPLIFY_NEW_ERROR=0``。该环境变量默认值为1，表示隐藏冗余的报错信息栈。

--- a/doc/paddle/guides/dygraph_to_static/error_handling_en.md
+++ b/doc/paddle/guides/dygraph_to_static/error_handling_en.md
@@ -13,8 +13,6 @@ In the following code, the function `inner_func` is transformed before calling. 
 import paddle
 import numpy as np
 
-paddle.disable_static()
-
 @paddle.jit.to_static
 def func():
     def inner_func(x):
@@ -28,7 +26,7 @@ func()
 
 The warning message is as follows:
 ```bash
-WARNING: <function inner_func at 0x7fa9bcaacf50> doesn't have to be transformed to static function because it has been transformed before, it will be run as-is.
+2020-01-01 00:00:00,104-WARNING: <function inner_func at 0x125b3a550> doesn't have to be transformed to static function because it has been transformed before, it will be run as-is.
 ```
 ## Exceptions in Running Transformed Code
 
@@ -97,6 +95,10 @@ The above error information can be divided into three points:
     AssertionError: Only one dimension value of 'shape' in reshape can be -1. But received shape[1] is also -1.
     ```  
 
+> **NOTE:**
+>
+> If you want to view Paddle native error stack, that is, the error stack that has not been processed by Dynamic-to-Static, you can set the environment variable ``TRANSLATOR_DISABLE_NEW_ERROR=1`` to disable the Dynamic-to-Static error handling module. The default value of this environment variable is 0, which means to enable Dynamic-to-Static error handling module.
+
 If execute the following code, an exception is raised when the static graph is executed at runtime:
 
 ```Python
@@ -158,3 +160,9 @@ InvalidArgumentError: The 'shape' in ReshapeOp is invalid. The input tensor X'si
 ```
 
 In the above exception, in addition to hiding part of the error stack and locating the error to the un-transformed dynamic graph code, the error information includes the c++ error stack `C++ Traceback` and `Error Message Summary`, which are the exception from C++ and are displayed in Python exception after processing.
+
+> **NOTE:**
+>
+> If you want to view the hidden part of the error stack, you can set the environment variable ``TRANSLATOR_SIMPLIFY_NEW_ERROR=0``. The default value of this environment variable is 1, which means to hide redundant error stack.
+
+.

--- a/doc/paddle/guides/dygraph_to_static/error_handling_en.md
+++ b/doc/paddle/guides/dygraph_to_static/error_handling_en.md
@@ -44,7 +44,6 @@ For example, if executing the following code, an exception is raised when the st
 import paddle
 import numpy as np
 
-paddle.disable_static()
 
 @paddle.jit.to_static
 def func(x):

--- a/doc/paddle/guides/dygraph_to_static/error_handling_en.md
+++ b/doc/paddle/guides/dygraph_to_static/error_handling_en.md
@@ -163,5 +163,3 @@ In the above exception, in addition to hiding part of the error stack and locati
 > **NOTE:**
 >
 > If you want to view the hidden part of the error stack, you can set the environment variable ``TRANSLATOR_SIMPLIFY_NEW_ERROR=0``. The default value of this environment variable is 1, which means to hide redundant error stack.
-
-.


### PR DESCRIPTION
1. 在教程中同步更新 set_verbosity，set_code_level 接口的also_to_stdout参数的使用，以及优化后的 log 信息。（代码更新可见[Paddle PR27285](https://github.com/PaddlePaddle/Paddle/pull/27285)）
2. 在教程中同步补充 控制报错信息栈的2个环境变量（代码 [Paddle PR27225](https://github.com/PaddlePaddle/Paddle/pull/27225)）
    - TRANSLATOR_DISABLE_NEW_ERROR: 默认为0。为1时可关闭动转静报错模块，仅使用Python原生报错
    - TRANSLATOR_SIMPLIFY_NEW_ERROR: 默认为1。为0时，可看到未被简化的报错。
3. 根据2.0 RC 接口情况，更新代码中的接口使用
    - 默认开启动态图：删掉`paddle.disable_static()`
    - 转化后的代码更新到2.0rc (参考[Paddle PR27430](https://github.com/PaddlePaddle/Paddle/pull/27430)，和[PR27650](https://github.com/PaddlePaddle/Paddle/pull/27650))

---

### 中文
![image](https://user-images.githubusercontent.com/33742067/94384331-e97c3e80-0174-11eb-8697-18119beef5d1.png)

![image](https://user-images.githubusercontent.com/33742067/94384377-0a449400-0175-11eb-8fa9-5ed26fcd687b.png)

### 英文
![image](https://user-images.githubusercontent.com/33742067/94384437-28aa8f80-0175-11eb-93cc-a9a29494f4aa.png)

![image](https://user-images.githubusercontent.com/33742067/94384483-3eb85000-0175-11eb-8774-d6b41d583ea9.png)
