### PR TITLE
refine name_scope doc

### DIFF
--- a/doc/paddle/api/paddle/fluid/framework/name_scope_cn.rst
+++ b/doc/paddle/api/paddle/fluid/framework/name_scope_cn.rst
@@ -10,7 +10,7 @@ name_scope
 
 
 
-该函数为operators生成不同的命名空间。该函数只用于调试和可视化，不建议用在其它方面。
+该函数为静态图下的operators生成不同的命名空间。该函数只用于静态图下的调试和可视化，不建议用在其它方面。
 
 
 参数：
@@ -20,33 +20,35 @@ name_scope
 
 .. code-block:: python
           
-     import paddle.fluid as fluid
-     with fluid.name_scope("s1"):
-        a = fluid.data(name='data', shape=[None, 1], dtype='int32')
-        b = a + 1
-        with fluid.name_scope("s2"):
-           c = b * 1
-        with fluid.name_scope("s3"):
-           d = c / 1
-     with fluid.name_scope("s1"):
-           f = fluid.layers.pow(d, 2.0)
-     with fluid.name_scope("s4"):
-           g = f - 1
+      import paddle
+      paddle.enable_static()
+      with paddle.static.name_scope("s1"):
+         a = paddle.data(name='data', shape=[None, 1], dtype='int32')
+         b = a + 1
+         with paddle.static.name_scope("s2"):
+            c = b * 1
+         with paddle.static.name_scope("s3"):
+            d = c / 1
+      with paddle.static.name_scope("s1"):
+            f = paddle.tensor.pow(d, 2.0)
+            print(f)
+      with paddle.static.name_scope("s4"):
+            g = f - 1
 
-     # 没有指定的话默认OP在default main program中。
-     for op in fluid.default_main_program().block(0).ops:
-         # elementwise_add在/s1/中创建
-         if op.type == 'elementwise_add':
-             assert op.desc.attr("op_namescope") == '/s1/'
-         # elementwise_mul在/s1/s2中创建
-         elif op.type == 'elementwise_mul':
-             assert op.desc.attr("op_namescope") == '/s1/s2/'
-         # elementwise_div在/s1/s3中创建
-         elif op.type == 'elementwise_div':
-             assert op.desc.attr("op_namescope") == '/s1/s3/'
-         # elementwise_sum在/s4/中创建
-         elif op.type == 'elementwise_sub':
-             assert op.desc.attr("op_namescope") == '/s4/'
-         # pow在/s1_1/中创建
-         elif op.type == 'pow':
-             assert op.desc.attr("op_namescope") == '/s1_1/'
+      # Op are created in the default main program.  
+      for op in paddle.static.default_main_program().block(0).ops:
+          # elementwise_add is created in /s1/
+          if op.type == 'elementwise_add':
+              assert op.desc.attr("op_namescope") == '/s1/'
+          # elementwise_mul is created in '/s1/s2'
+          elif op.type == 'elementwise_mul':
+              assert op.desc.attr("op_namescope") == '/s1/s2/'
+          # elementwise_div is created in '/s1/s3'
+          elif op.type == 'elementwise_div':
+              assert op.desc.attr("op_namescope") == '/s1/s3/'
+          # elementwise_sum is created in '/s4'
+          elif op.type == 'elementwise_sub':
+              assert op.desc.attr("op_namescope") == '/s4/'
+          # pow is created in /s1_1/
+          elif op.type == 'pow':
+              assert op.desc.attr("op_namescope") == '/s1_1/'


### PR DESCRIPTION
modify docs of name_scope

(1)1.8API list：paddle.fluid.name_scope
(2)2.0_main_alias：paddle.static.name_scope
(3) 组长建议：新API名称：暂无,文档和示例待更新

![image](https://user-images.githubusercontent.com/6836917/94367386-f6674680-0110-11eb-9b88-6af9c4f54113.png)
