### PR TITLE
Add doc about VarBase.__setitem__

### DIFF
--- a/doc/paddle/guides/tensor_introduction_cn.md
+++ b/doc/paddle/guides/tensor_introduction_cn.md
@@ -16,8 +16,6 @@
 * [Tensor的操作](#4)
 
 
-----------
-
 ## <h2 id="1">Tensor的创建</h2>
 
 首先，让我们开始创建一个 **Tensor** :
@@ -156,7 +154,7 @@ paddle.arrange(start, end, step) # 创建从start到end，步长为step的Tenso
 paddle.linspace(start, end, num) # 创建从start到end，元素个数固定为num的Tensor
 ```
 
-----------
+
 ## <h2 id="2">Tensor的shape</h2>
 
 ### 基本概念
@@ -236,7 +234,6 @@ print("Tensor flattened to Vector:", paddle.reshape(rank_3_tensor, [-1]).numpy()
 Tensor flattened to Vector: [1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30]
 ```
 
-----------
 ## <h2 id="3">Tensor其他属性</h2>
 ### Tensor的dtype
 
@@ -319,7 +316,6 @@ print("Tensor name:", paddle.to_tensor(1).name)
 Tensor name: generated_tensor_0
 ```
 
-----------
 ## <h2 id="4">Tensor的操作</h2>
 
 Paddle提供了丰富的Tensor操作的API，包括数学运算符、逻辑运算符、线性代数相关等100+余种API，这些API调用有两种方法：

--- a/doc/paddle/guides/tensor_introduction_cn.md
+++ b/doc/paddle/guides/tensor_introduction_cn.md
@@ -190,72 +190,6 @@ Elements number along axis 0 of tensor: 2
 Elements number along the last axis of tensor: 5
 ```
 
-### 索引
-通过索引能方便地对Tensor进行“切片”操作。Paddle使用标准的 Python索引规则 与 Numpy索引规则，与[ndexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings)类似。具有以下特点：
-
-1. 如果索引为负数，则从尾部开始计算
-2. 如果索引使用 ``:`` ，则其对应格式为start: stop: step，其中start、stop、step均可缺省
-
-* 针对1-D **Tensor**，则仅有单个轴上的索引：
-```python
-rank_1_tensor = paddle.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8])
-print("Origin Tensor:", rank_1_tensor.numpy())
-
-print("First element:", rank_1_tensor[0].numpy())
-print("Last element:", rank_1_tensor[-1].numpy())
-print("All element:", rank_1_tensor[:].numpy())
-print("Before 3:", rank_1_tensor[:3].numpy())
-print("From 6 to the end:", rank_1_tensor[6:].numpy())
-print("From 3 to 6:", rank_1_tensor[3:6].numpy())
-print("Interval of 3:", rank_1_tensor[::3].numpy())
-print("Reverse:", rank_1_tensor[::-1].numpy())
-```
-```text
-Origin Tensor: array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=int64)
-First element: [0]
-Last element: [8]
-All element: [0 1 2 3 4 5 6 7 8]
-Before 3: [0 1 2]
-From 6 to the end: [6 7 8]
-From 3 to 6: [3 4 5]
-Interval of 3: [0 3 6]
-Reverse: [8 7 6 5 4 3 2 1 0]
-```
-
-* 针对2-D及以上的 **Tensor**，则会有多个轴上的索引：
-```python
-rank_2_tensor = paddle.to_tensor([[0, 1, 2, 3],
-                                  [4, 5, 6, 7],
-                                  [8, 9, 10, 11]])
-print("Origin Tensor:", rank_2_tensor.numpy())
-print("First row:", rank_2_tensor[0].numpy())
-print("First row:", rank_2_tensor[0, :].numpy())
-print("First column:", rank_2_tensor[:, 0].numpy())
-print("Last column:", rank_2_tensor[:, -1].numpy())
-print("All element:", rank_2_tensor[:].numpy())
-print("First row and second column:", rank_2_tensor[0, 1].numpy())
-```
-```text
-Origin Tensor: array([[ 0  1  2  3]
-                      [ 4  5  6  7]
-                      [ 8  9 10 11]], dtype=int64)
-First row: [0 1 2 3]
-First row: [0 1 2 3]
-First column: [0 4 8]
-Last column: [ 3  7 11]
-All element: [[ 0  1  2  3]
-              [ 4  5  6  7]
-              [ 8  9 10 11]]
-First row and second column: [1]
-```
-
-输入索引的第一个值对应axis 0，第二个值对应axis 1，以此类推，如果某个axis上未指定索引，则默认为 ``:`` 。例如：
-```
-rank_3_tensor[1]
-rank_3_tensor[1, :]
-rank_3_tensor[1, :, :]
-```
-以上三种索引的结果是完全相同的。
 
 ### 对shape进行操作
 
@@ -414,7 +348,97 @@ Tensor: eager_tmp_3
 
 可以看出，使用 **Tensor类成员函数** 和 **paddle API** 具有相同的效果，由于 **类成员函数** 操作更为方便，以下均从 **Tensor类成员函数** 的角度，对常用**Tensor**操作进行介绍。
 
-#### 数学运算符
+### 索引和切片
+您可以通过索引或切片方便地访问或修改 Tensor。Paddle 使用标准的 Python 索引规则与 Numpy 索引规则，与[ndexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings)类似。具有以下特点：
+
+1. 基于 0-n 的下标进行索引，如果下标为负数，则从尾部开始计算
+2. 通过冒号 ``:`` 分隔切片参数 ``start:stop:step`` 来进行切片操作，其中 start、stop、step 均可缺省
+
+#### 访问 Tensor
+* 针对1-D **Tensor**，则仅有单个轴上的索引或切片：
+```python
+rank_1_tensor = paddle.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8])
+print("Origin Tensor:", rank_1_tensor.numpy())
+
+print("First element:", rank_1_tensor[0].numpy())
+print("Last element:", rank_1_tensor[-1].numpy())
+print("All element:", rank_1_tensor[:].numpy())
+print("Before 3:", rank_1_tensor[:3].numpy())
+print("From 6 to the end:", rank_1_tensor[6:].numpy())
+print("From 3 to 6:", rank_1_tensor[3:6].numpy())
+print("Interval of 3:", rank_1_tensor[::3].numpy())
+print("Reverse:", rank_1_tensor[::-1].numpy())
+```
+```text
+Origin Tensor: array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=int64)
+First element: [0]
+Last element: [8]
+All element: [0 1 2 3 4 5 6 7 8]
+Before 3: [0 1 2]
+From 6 to the end: [6 7 8]
+From 3 to 6: [3 4 5]
+Interval of 3: [0 3 6]
+Reverse: [8 7 6 5 4 3 2 1 0]
+```
+
+* 针对2-D及以上的 **Tensor**，则会有多个轴上的索引或切片：
+```python
+rank_2_tensor = paddle.to_tensor([[0, 1, 2, 3],
+                                  [4, 5, 6, 7],
+                                  [8, 9, 10, 11]])
+print("Origin Tensor:", rank_2_tensor.numpy())
+print("First row:", rank_2_tensor[0].numpy())
+print("First row:", rank_2_tensor[0, :].numpy())
+print("First column:", rank_2_tensor[:, 0].numpy())
+print("Last column:", rank_2_tensor[:, -1].numpy())
+print("All element:", rank_2_tensor[:].numpy())
+print("First row and second column:", rank_2_tensor[0, 1].numpy())
+```
+```text
+Origin Tensor: array([[ 0  1  2  3]
+                      [ 4  5  6  7]
+                      [ 8  9 10 11]], dtype=int64)
+First row: [0 1 2 3]
+First row: [0 1 2 3]
+First column: [0 4 8]
+Last column: [ 3  7 11]
+All element: [[ 0  1  2  3]
+              [ 4  5  6  7]
+              [ 8  9 10 11]]
+First row and second column: [1]
+```
+
+索引或切片的第一个值对应 axis 0，第二个值对应 axis 1，以此类推，如果某个 axis 上未指定索引，则默认为 ``:`` 。例如：
+```
+rank_3_tensor[1]
+rank_3_tensor[1, :]
+rank_3_tensor[1, :, :]
+```
+以上三种操作的结果是完全相同的。
+
+#### 修改 Tensor
+
+> **注意：**
+>
+> 请慎重通过索引或切片修改 Tensor，该操作会**原地**修改该 Tensor 的数值，且原值不会被保存。如果被修改的 Tensor 参与梯度计算，将仅会使用修改后的数值，这可能会给梯度计算引入风险。Paddle 之后将会对具有风险的操作进行检测和报错。
+
+与访问 Tensor 类似，修改 Tensor 可以在单个或多个轴上通过索引或切片操作。同时，支持将多种类型的数据赋值给该 Tensor，当前支持的数据类型有：`int`, `float`, `numpy.ndarray`, `Tensor`。
+
+```python
+import paddle
+import numpy as np
+
+x = paddle.to_tensor(np.ones((2, 3)).astype(np.float32)) # [[1,1,1], [1,1,1]]
+
+x[0] = 0                      # x : [[0, 0, 0], [1 ,1, 1]]        id(x) = 4433705584
+x[0:1] = 2.1                  # x : [[2.1, 2.1, 2.1], [1 ,1, 1]]  id(x) = 4433705584
+x[...] = 3                    # x : [[3, 3, 3], [3, 3, 3]]        id(x) = 4433705584
+
+x[0:1] = np.array([1,2,3])    # x : [[1, 2, 3], [3, 3, 3]]        id(x) = 4433705584
+x[1] = paddle.ones([3])       # x : [[1, 2, 3], [1,1,1]]          id(x) = 4433705584
+```
+
+### 数学运算符
 ```python
 x.abs()                       #绝对值
 x.ceil()                      #向上取整
@@ -450,7 +474,7 @@ x % y  -> x.remainder(y)      #逐元素相除并取余
 x ** y -> x.pow(y)            #逐元素幂运算
 ```
 
-#### 逻辑运算符
+### 逻辑运算符
 ```python
 x.is_empty()                  #判断tensor是否为空
 x.isfinite()                  #判断tensor中元素是否是有限的数字，即不包括inf与nan
@@ -483,7 +507,7 @@ x.logical_xor(y)              #对两个bool型tensor逐元素进行逻辑亦或
 x.logical_not(y)              #对两个bool型tensor逐元素进行逻辑非操作
 ```
 
-#### 线性代数相关
+### 线性代数相关
 ```python
 x.cholesky()                  #矩阵的cholesky分解
 x.t()                         #矩阵转置

--- a/doc/paddle/guides/tensor_introduction_cn.md
+++ b/doc/paddle/guides/tensor_introduction_cn.md
@@ -335,7 +335,7 @@ Tensor: eager_tmp_3
 可以看出，使用 **Tensor类成员函数** 和 **paddle API** 具有相同的效果，由于 **类成员函数** 操作更为方便，以下均从 **Tensor类成员函数** 的角度，对常用**Tensor**操作进行介绍。
 
 ### 索引和切片
-您可以通过索引或切片方便地访问或修改 Tensor。Paddle 使用标准的 Python 索引规则与 Numpy 索引规则，与[ndexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings)类似。具有以下特点：
+您可以通过索引或切片方便地访问或修改 Tensor。Paddle 使用标准的 Python 索引规则与 Numpy 索引规则，与 [Indexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings)类似。具有以下特点：
 
 1. 基于 0-n 的下标进行索引，如果下标为负数，则从尾部开始计算
 2. 通过冒号 ``:`` 分隔切片参数 ``start:stop:step`` 来进行切片操作，其中 start、stop、step 均可缺省

--- a/doc/paddle/guides/tensor_introduction_cn.md
+++ b/doc/paddle/guides/tensor_introduction_cn.md
@@ -308,32 +308,6 @@ Tensor name: generated_tensor_0
 
 ## Tensor的操作
 
-Paddle提供了丰富的Tensor操作的API，包括数学运算符、逻辑运算符、线性代数相关等100+余种API，这些API调用有两种方法：
-```python
-x = paddle.to_tensor([[1.1, 2.2], [3.3, 4.4]])
-y = paddle.to_tensor([[5.5, 6.6], [7.7, 8.8]])
-
-print(paddle.add(x, y), "\n")
-print(x.add(y), "\n")
-```
-```text
-Tensor: eager_tmp_2
-  - place: CUDAPlace(0)
-  - shape: [2, 2]
-  - layout: NCHW
-  - dtype: float
-  - data: [6.6 8.8 11 13.2]
-
-Tensor: eager_tmp_3
-  - place: CUDAPlace(0)
-  - shape: [2, 2]
-  - layout: NCHW
-  - dtype: float
-  - data: [6.6 8.8 11 13.2]
-```
-
-可以看出，使用 **Tensor类成员函数** 和 **paddle API** 具有相同的效果，由于 **类成员函数** 操作更为方便，以下均从 **Tensor类成员函数** 的角度，对常用**Tensor**操作进行介绍。
-
 ### 索引和切片
 您可以通过索引或切片方便地访问或修改 Tensor。Paddle 使用标准的 Python 索引规则与 Numpy 索引规则，与 [Indexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings)类似。具有以下特点：
 
@@ -424,6 +398,34 @@ x[0:1] = np.array([1,2,3])    # x : [[1, 2, 3], [3, 3, 3]]        id(x) = 443370
 x[1] = paddle.ones([3])       # x : [[1, 2, 3], [1,1,1]]          id(x) = 4433705584
 ```
 
+---
+
+同时，Paddle 还提供了丰富的 Tensor 操作的 API，包括数学运算符、逻辑运算符、线性代数相关等100余种 API，这些 API 调用有两种方法：
+```python
+x = paddle.to_tensor([[1.1, 2.2], [3.3, 4.4]])
+y = paddle.to_tensor([[5.5, 6.6], [7.7, 8.8]])
+
+print(paddle.add(x, y), "\n")
+print(x.add(y), "\n")
+```
+```text
+Tensor: eager_tmp_2
+  - place: CUDAPlace(0)
+  - shape: [2, 2]
+  - layout: NCHW
+  - dtype: float
+  - data: [6.6 8.8 11 13.2]
+
+Tensor: eager_tmp_3
+  - place: CUDAPlace(0)
+  - shape: [2, 2]
+  - layout: NCHW
+  - dtype: float
+  - data: [6.6 8.8 11 13.2]
+```
+
+可以看出，使用 **Tensor 类成员函数** 和 **Paddle API** 具有相同的效果，由于 **类成员函数** 操作更为方便，以下均从 **Tensor 类成员函数** 的角度，对常用 **Tensor** 操作进行介绍。
+
 ### 数学运算符
 ```python
 x.abs()                       #绝对值
@@ -504,4 +506,4 @@ x.matmul(y)                   #矩阵乘法
 ```
 需要注意，Paddle中Tensor的操作符均为非inplace操作，即 ``x.add(y)`` 不会在**tensor x**上直接进行操作，而会返回一个新的**Tensor**来表示运算结果。
 
-更多Tensor操作相关的API，请参考[class paddle.Tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/creation/Tensor_cn.html)
+更多Tensor操作相关的API，请参考 [class paddle.Tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/creation/Tensor_cn.html)

--- a/doc/paddle/guides/tensor_introduction_cn.md
+++ b/doc/paddle/guides/tensor_introduction_cn.md
@@ -1,5 +1,3 @@
-
-
 # Tensor概念介绍
 
 飞桨（PaddlePaddle，以下简称Paddle）和其他深度学习框架一样，使用**Tensor**来表示数据，在神经网络中传递的数据均为**Tensor**。
@@ -8,15 +6,7 @@
 
 同一**Tensor**的中所有元素的dtype均相同。如果你对 [Numpy](https://www.paddlepaddle.org.cn/tutorials/projectdetail/590690) 熟悉，**Tensor**是类似于 **Numpy array** 的概念。
 
-### 目录
-
-* [Tensor的创建](#1)
-* [Tensor的shape](#2)
-* [Tensor其他属性](#3)
-* [Tensor的操作](#4)
-
-
-## <h2 id="1">Tensor的创建</h2>
+## Tensor的创建
 
 首先，让我们开始创建一个 **Tensor** :
 
@@ -154,8 +144,7 @@ paddle.arrange(start, end, step) # 创建从start到end，步长为step的Tenso
 paddle.linspace(start, end, num) # 创建从start到end，元素个数固定为num的Tensor
 ```
 
-
-## <h2 id="2">Tensor的shape</h2>
+## Tensor的shape
 
 ### 基本概念
 查看一个**Tensor**的形状可以通过 **Tensor.shape**，shape是 **Tensor** 的一个重要属性，以下为相关概念：
@@ -234,7 +223,7 @@ print("Tensor flattened to Vector:", paddle.reshape(rank_3_tensor, [-1]).numpy()
 Tensor flattened to Vector: [1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30]
 ```
 
-## <h2 id="3">Tensor其他属性</h2>
+## Tensor其他属性
 ### Tensor的dtype
 
 **Tensor**的数据类型，可以通过 Tensor.dtype 来查看，dtype支持：'bool'，'float16'，'float32'，'float64'，'uint8'，'int8'，'int16'，'int32'，'int64'。
@@ -300,11 +289,12 @@ Tensor: generated_tensor_0
 pin_memory_tensor = paddle.to_tensor(1, place=paddle.CUDAPinnedPlace())
 print(pin_memory_tensor)
 ```
+
 ```text
 Tensor: generated_tensor_0
   - place: CUDAPinnedPlace
-
 ```
+
 ### Tensor的name
 
 Tensor的name是其唯一的标识符，为python 字符串类型，查看一个Tensor的name可以通过Tensor.name属性。默认地，在每个Tensor创建时，Paddle会自定义一个独一无二的name。
@@ -316,7 +306,7 @@ print("Tensor name:", paddle.to_tensor(1).name)
 Tensor name: generated_tensor_0
 ```
 
-## <h2 id="4">Tensor的操作</h2>
+## Tensor的操作
 
 Paddle提供了丰富的Tensor操作的API，包括数学运算符、逻辑运算符、线性代数相关等100+余种API，这些API调用有两种方法：
 ```python

--- a/doc/paddle/guides/tensor_introduction_en.md
+++ b/doc/paddle/guides/tensor_introduction_en.md
@@ -314,34 +314,6 @@ Tensor name: generated_tensor_0
 
 ## Method of Tensor
 
-
-Paddles provide rich Tensor operating API , including mathematical operators, logical operators, linear algebra operators and so on. The total number is more than 100+ kinds. For example:
-
-```python
-x = paddle.to_tensor([[1.1, 2.2], [3.3, 4.4]])
-y = paddle.to_tensor([[5.5, 6.6], [7.7, 8.8]])
-
-print(paddle.add(x, y), "\n")
-print(x.add(y), "\n")
-```
-```text
-Tensor: eager_tmp_2
-  - place: CUDAPlace(0)
-  - shape: [2, 2]
-  - layout: NCHW
-  - dtype: float
-  - data: [6.6 8.8 11 13.2]
-
-Tensor: eager_tmp_3
-  - place: CUDAPlace(0)
-  - shape: [2, 2]
-  - layout: NCHW
-  - dtype: float
-  - data: [6.6 8.8 11 13.2]
-```
-
-It can be seen that Tensor class method has the same result with paddle API. And the Tensor class method is more convenient to invoke.
-
 ### Index and slice
 
 You can easily access or modify Tensors by indexing or slicing. Paddle follows standard Python indexing rules, similar to [Indexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. It has the following features:
@@ -434,6 +406,36 @@ x[0:1] = np.array([1,2,3])    # x : [[1, 2, 3], [3, 3, 3]]        id(x) = 443370
 x[1] = paddle.ones([3])       # x : [[1, 2, 3], [1,1,1]]          id(x) = 4433705584
 ```
 
+---
+
+In addition, Paddle provides rich Tensor operating APIs, including mathematical operators, logical operators, linear algebra operators and so on. The total number is more than 100 kinds. For example:
+
+```python
+x = paddle.to_tensor([[1.1, 2.2], [3.3, 4.4]])
+y = paddle.to_tensor([[5.5, 6.6], [7.7, 8.8]])
+
+print(paddle.add(x, y), "\n")
+print(x.add(y), "\n")
+```
+```text
+Tensor: eager_tmp_2
+  - place: CUDAPlace(0)
+  - shape: [2, 2]
+  - layout: NCHW
+  - dtype: float
+  - data: [6.6 8.8 11 13.2]
+
+Tensor: eager_tmp_3
+  - place: CUDAPlace(0)
+  - shape: [2, 2]
+  - layout: NCHW
+  - dtype: float
+  - data: [6.6 8.8 11 13.2]
+```
+
+It can be seen that Tensor class method has the same result with Paddle API. And the Tensor class method is more convenient to invoke.
+
+
 ### mathematical operators
 ```python
 x.abs()                       #absolute value
@@ -514,4 +516,4 @@ x.matmul(y)                   #Matrix multiplication
 ```
 It should be noted that the class method of Tensor are non-inplace operations. It means, ``x.And dd(y)`` will not operate directly on Tensor x, but return a new Tensor to represent the results.
 
-For more API related to Tensor operations, please refer to[class paddle.Tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/creation/Tensor_cn.html)
+For more API related to Tensor operations, please refer to [class paddle.Tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/creation/Tensor_cn.html)

--- a/doc/paddle/guides/tensor_introduction_en.md
+++ b/doc/paddle/guides/tensor_introduction_en.md
@@ -344,7 +344,7 @@ It can be seen that Tensor class method has the same result with paddle API. And
 
 ### Index and slice
 
-You can easily access or modify Tensors by indexing or slicing. Paddle follows standard Python indexing rules, similar to [Indexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. It has following characteristics:
+You can easily access or modify Tensors by indexing or slicing. Paddle follows standard Python indexing rules, similar to [Indexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. It has the following features:
 
 1. Indexing a Tensor based on the subscript 0-n. A negative subscript means counting backwards from the end.
 2. Slicing a Tensor base on separating parameters `start:stop:step` by colons `:`, and `start`, `stop` and `step` can be default.
@@ -418,7 +418,7 @@ These three are exactly the same.
 >
 > Please be careful to modify a Tensor through index or slice. It will **inplace** modify the value of Tensor, and the original value will not be saved. If the modified Tensor participates in the gradient calculation, only the modified value will be used, which may introduce risks to the gradient calculation. Paddle will detect and report errors in risky operations later.
 
-Similar to accessing a Tensor, modifying a Tensor by indexing or slicing can be on a single or multiple axes. In addition, it supports assigning multiple types of data to A Tensor. The supported data types are `int`, `float`,  `numpy.ndarray` and `Tensor`.
+Similar to accessing a Tensor, modifying a Tensor by indexing or slicing can be on a single or multiple axes. In addition, it supports assigning multiple types of data to a Tensor. The supported data types are `int`, `float`,  `numpy.ndarray` and `Tensor`.
 
 ```python
 import paddle

--- a/doc/paddle/guides/tensor_introduction_en.md
+++ b/doc/paddle/guides/tensor_introduction_en.md
@@ -14,7 +14,7 @@ The dtypes of all elements in the same Tensor are the same. If you are familiar 
 * [Other attributes of Tensor](#3)
 * [Method of Tensor](#4)
 
-----------
+
 ## <h2 id="1">Creation of Tensor</h2>
 
 Firstly, let we create a **Tensor**:
@@ -153,7 +153,7 @@ paddle.arrange(start, end, 2) # Elements: from start to end, step size is 2
 paddle.linspace(start, end, 10) # Elements: from start to end, num of elementwise is 10
 ```
 
-----------
+
 ## <h2 id="2">Shape of Tensor</h2>
 
 ### Basic Concept
@@ -233,7 +233,7 @@ print("Tensor flattened to Vector:", paddle.reshape(rank_3_tensor, [-1]).numpy()
 Tensor flattened to Vector: [1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30]
 ```
 
-----------
+
 ## <h2 id="3">Other attributes of Tensor</h2>
 
 ### dtype of Tensor
@@ -319,7 +319,7 @@ print("Tensor name:", paddle.to_tensor(1).name)
 Tensor name: generated_tensor_0
 ```
 
-----------
+
 ## <h2 id="4">Method of Tensor</h2>
 
 

--- a/doc/paddle/guides/tensor_introduction_en.md
+++ b/doc/paddle/guides/tensor_introduction_en.md
@@ -188,75 +188,6 @@ Elements number along axis 0 of tensor: 2
 Elements number along the last axis of tensor: 5
 ```
 
-### indexing
-
-Paddle follows standard Python indexing rules, similar to[ndexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. indexing is used to work on Tensor "slice". It has following characteristics:
-
-1. negative indices count backwards from the end
-2. colons, : , are used for slices: start:stop:step
-
-For **1-D Tensor**, there is only single-axis indexing:
-```python
-rank_1_tensor = paddle.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8])
-print("Origin Tensor:", rank_1_tensor.numpy())
-
-print("First element:", rank_1_tensor[0].numpy())
-print("Last element:", rank_1_tensor[-1].numpy())
-print("All element:", rank_1_tensor[:].numpy())
-print("Before 3:", rank_1_tensor[:3].numpy())
-print("From 6 to the end:", rank_1_tensor[6:].numpy())
-print("From 3 to 6:", rank_1_tensor[3:6].numpy())
-print("Interval of 3:", rank_1_tensor[::3].numpy())
-print("Reverse:", rank_1_tensor[::-1].numpy())
-```
-```text
-Origin Tensor: array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=int64)
-First element: [0]
-Last element: [8]
-All element: [0 1 2 3 4 5 6 7 8]
-Before 3: [0 1 2]
-From 6 to the end: [6 7 8]
-From 3 to 6: [3 4 5]
-Interval of 3: [0 3 6]
-Reverse: [8 7 6 5 4 3 2 1 0]
-```
-
-For 2-D **Tensor** or above, there is multi-axis indexing:
-```python
-rank_2_tensor = paddle.to_tensor([[0, 1, 2, 3],
-                                  [4, 5, 6, 7],
-                                  [8, 9, 10, 11]])
-print("Origin Tensor:", rank_2_tensor.numpy())
-
-print("First row:", rank_2_tensor[0].numpy())
-print("First row:", rank_2_tensor[0, :].numpy())
-print("First column:", rank_2_tensor[:, 0].numpy())
-print("Last column:", rank_2_tensor[:, -1].numpy())
-print("All element:", rank_2_tensor[:].numpy())
-print("First row and second column:", rank_2_tensor[0, 1].numpy())
-```
-```text
-Origin Tensor: array([[ 0  1  2  3]
-                      [ 4  5  6  7]
-                      [ 8  9 10 11]], dtype=int64)
-First row: [0 1 2 3]
-First row: [0 1 2 3]
-First column: [0 4 8]
-Last column: [ 3  7 11]
-All element: [[ 0  1  2  3]
-              [ 4  5  6  7]
-              [ 8  9 10 11]]
-First row and second column: [1]
-```
-
-The first element of index is corresponds to Axis 0, the second is corresponds to Axis 1, and so on. If no index is specified on an Axis, the default is ':' . For example:
-```
-rank_3_tensor[1]
-rank_3_tensor[1, :]
-rank_3_tensor[1, :, :]
-```
-These three are exactly the same.
-
 ### Manipulating Shape
 
 Manipulating shape of Tensor is important in programming.
@@ -418,6 +349,98 @@ Tensor: eager_tmp_3
 ```
 
 It can be seen that Tensor class method has the same result with paddle API. And the Tensor class method is more convenient to invoke.
+
+### Index and slice
+
+You can easily access or modify Tensors by indexing or slicing. Paddle follows standard Python indexing rules, similar to[ndexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. It has following characteristics:
+
+1. Indexing a Tensor based on the subscript 0-n. A negative subscript means counting backwards from the end.
+2. Slicing a Tensor base on separating parameters `start:stop:step` by colons `:`, and `start`, `stop` and `step` can be default.
+
+#### Access Tensor
+For **1-D Tensor**, there is only single-axis indexing or slicing:
+```python
+rank_1_tensor = paddle.to_tensor([0, 1, 2, 3, 4, 5, 6, 7, 8])
+print("Origin Tensor:", rank_1_tensor.numpy())
+
+print("First element:", rank_1_tensor[0].numpy())
+print("Last element:", rank_1_tensor[-1].numpy())
+print("All element:", rank_1_tensor[:].numpy())
+print("Before 3:", rank_1_tensor[:3].numpy())
+print("From 6 to the end:", rank_1_tensor[6:].numpy())
+print("From 3 to 6:", rank_1_tensor[3:6].numpy())
+print("Interval of 3:", rank_1_tensor[::3].numpy())
+print("Reverse:", rank_1_tensor[::-1].numpy())
+```
+```text
+Origin Tensor: array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=int64)
+First element: [0]
+Last element: [8]
+All element: [0 1 2 3 4 5 6 7 8]
+Before 3: [0 1 2]
+From 6 to the end: [6 7 8]
+From 3 to 6: [3 4 5]
+Interval of 3: [0 3 6]
+Reverse: [8 7 6 5 4 3 2 1 0]
+```
+
+For 2-D **Tensor** or above, there is multi-axis indexing or slicing:
+```python
+rank_2_tensor = paddle.to_tensor([[0, 1, 2, 3],
+                                  [4, 5, 6, 7],
+                                  [8, 9, 10, 11]])
+print("Origin Tensor:", rank_2_tensor.numpy())
+
+print("First row:", rank_2_tensor[0].numpy())
+print("First row:", rank_2_tensor[0, :].numpy())
+print("First column:", rank_2_tensor[:, 0].numpy())
+print("Last column:", rank_2_tensor[:, -1].numpy())
+print("All element:", rank_2_tensor[:].numpy())
+print("First row and second column:", rank_2_tensor[0, 1].numpy())
+```
+```text
+Origin Tensor: array([[ 0  1  2  3]
+                      [ 4  5  6  7]
+                      [ 8  9 10 11]], dtype=int64)
+First row: [0 1 2 3]
+First row: [0 1 2 3]
+First column: [0 4 8]
+Last column: [ 3  7 11]
+All element: [[ 0  1  2  3]
+              [ 4  5  6  7]
+              [ 8  9 10 11]]
+First row and second column: [1]
+```
+
+The first element of index or slice is corresponds to axis 0, the second is corresponds to axis 1, and so on. If no index is specified on an axis, the default is `:` . For example:
+```
+rank_3_tensor[1]
+rank_3_tensor[1, :]
+rank_3_tensor[1, :, :]
+```
+These three are exactly the same.
+
+#### Modify Tensor
+
+> **Warning:**
+>
+> Please be careful to modify a Tensor through index or slice. It will **inplace** modify the value of Tensor, and the original value will not be saved. If the modified Tensor participates in the gradient calculation, only the modified value will be used, which may introduce risks to the gradient calculation. Paddle will detect and report errors in risky operations later.
+
+Similar to accessing a Tensor, modifying a Tensor by indexing or slicing can be on a single or multiple axes. In addition, it supports assigning multiple types of data to A Tensor. The supported data types are `int`, `float`,  `numpy.ndarray` and `Tensor`.
+
+```python
+import paddle
+import numpy as np
+
+x = paddle.to_tensor(np.ones((2, 3)).astype(np.float32)) # [[1,1,1], [1,1,1]]
+
+x[0] = 0                      # x : [[0, 0, 0], [1 ,1, 1]]        id(x) = 4433705584
+x[0:1] = 2.1                  # x : [[2.1, 2.1, 2.1], [1 ,1, 1]]  id(x) = 4433705584
+x[...] = 3                    # x : [[3, 3, 3], [3, 3, 3]]        id(x) = 4433705584
+
+x[0:1] = np.array([1,2,3])    # x : [[1, 2, 3], [3, 3, 3]]        id(x) = 4433705584
+x[1] = paddle.ones([3])       # x : [[1, 2, 3], [1,1,1]]          id(x) = 4433705584
+```
 
 ### mathematical operators
 ```python

--- a/doc/paddle/guides/tensor_introduction_en.md
+++ b/doc/paddle/guides/tensor_introduction_en.md
@@ -7,15 +7,7 @@ representing data.
 
 The dtypes of all elements in the same Tensor are the same. If you are familiar with [Numpy](https://www.paddlepaddle.org.cn/tutorials/projectdetail/590690), **Tensor** is similar to the **Numpy array**.
 
-### Contents
-
-* [Creation of Tensor](#1)
-* [Shape of Tensor](#2)
-* [Other attributes of Tensor](#3)
-* [Method of Tensor](#4)
-
-
-## <h2 id="1">Creation of Tensor</h2>
+## Creation of Tensor
 
 Firstly, let we create a **Tensor**:
 
@@ -154,7 +146,7 @@ paddle.linspace(start, end, 10) # Elements: from start to end, num of elementwi
 ```
 
 
-## <h2 id="2">Shape of Tensor</h2>
+## Shape of Tensor
 
 ### Basic Concept
 
@@ -234,7 +226,7 @@ Tensor flattened to Vector: [1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 1
 ```
 
 
-## <h2 id="3">Other attributes of Tensor</h2>
+## Other attributes of Tensor
 
 ### dtype of Tensor
 
@@ -320,7 +312,7 @@ Tensor name: generated_tensor_0
 ```
 
 
-## <h2 id="4">Method of Tensor</h2>
+## Method of Tensor
 
 
 Paddles provide rich Tensor operating API , including mathematical operators, logical operators, linear algebra operators and so on. The total number is more than 100+ kinds. For example:

--- a/doc/paddle/guides/tensor_introduction_en.md
+++ b/doc/paddle/guides/tensor_introduction_en.md
@@ -344,7 +344,7 @@ It can be seen that Tensor class method has the same result with paddle API. And
 
 ### Index and slice
 
-You can easily access or modify Tensors by indexing or slicing. Paddle follows standard Python indexing rules, similar to[ndexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. It has following characteristics:
+You can easily access or modify Tensors by indexing or slicing. Paddle follows standard Python indexing rules, similar to [Indexing a list or a string in Python](https://docs.python.org/3/tutorial/introduction.html#strings) and the basic rules for NumPy indexing. It has following characteristics:
 
 1. Indexing a Tensor based on the subscript 0-n. A negative subscript means counting backwards from the end.
 2. Slicing a Tensor base on separating parameters `start:stop:step` by colons `:`, and `start`, `stop` and `step` can be default.


### PR DESCRIPTION
1. 在 “Tensor 概念介绍” 页面增加内容"修改Tensor" 。
   - 背景：Paddle 支持了 VarBase 切片赋值功能，在此增加文档进行说明，并警告用户该用法可能会引入梯度计算的风险。
2. 调整目录，将"索引和切片" 移动到 "Tensor的操作" 目录下，并增加子目录" 访问 Tensor" 和 “修改 Tensor”（已与该页面负责人 @zhouwei25 沟通） 

文档预览链接：
<!-- http://gzhxy-inf-bce36a39de.gzhxy.baidu.com:8121/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc_review-1610 -->
http://gzhxy-inf-bce36a39de.gzhxy.baidu.com:8121/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc_review-1659

---

预览截图

- 中文
![image](https://user-images.githubusercontent.com/33742067/94511060-dfc50a80-024a-11eb-9338-a03729e7d010.png)


- 英文
![image](https://user-images.githubusercontent.com/33742067/94511093-f703f800-024a-11eb-90c6-0c5307eec726.png)
