### PR TITLE
Update all the examples which use paddle.static.nn.fc.

### DIFF
--- a/doc/paddle/api/paddle/fluid/backward/append_backward_cn.rst
+++ b/doc/paddle/api/paddle/fluid/backward/append_backward_cn.rst
@@ -41,7 +41,7 @@ append_backward
         x = paddle.static.data(name='x', shape=[None, 13], dtype='int64')
         y = paddle.static.data(name='y', shape=[None, 1], dtype='float32')
         x_emb = paddle.static.nn.embedding(x, size=[100, 256])
-        y_predict = paddle.static.nn.fc(input=x_emb, size=1, act=None, name='my_fc')
+        y_predict = paddle.static.nn.fc(x=x_emb, size=1, activation=None, name='my_fc')
         loss = F.square_error_cost(input=y_predict, label=y)
         avg_loss = paddle.mean(loss)
 

--- a/doc/paddle/api/paddle/fluid/compiler/BuildStrategy_cn.rst
+++ b/doc/paddle/api/paddle/fluid/compiler/BuildStrategy_cn.rst
@@ -26,7 +26,7 @@ BuildStrategy，一个BuildStrategy的实例
     places = static.cpu_places()
 
     data = static.data(name="x", shape=[None, 1], dtype="float32")
-    hidden = static.nn.fc(input=data, size=10)
+    hidden = static.nn.fc(x=data, size=10)
     loss = paddle.mean(hidden)
     paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
 
@@ -162,7 +162,7 @@ bool类型。表明是否融合(fuse) relu和depthwise_conv2d，节省GPU内存�
         places = static.cuda_places()
 
     data = static.data(name='X', shape=[None, 1], dtype='float32')
-    hidden = static.nn.fc(input=data, size=10)
+    hidden = static.nn.fc(x=data, size=10)
     loss = paddle.mean(hidden)
     paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
 

--- a/doc/paddle/api/paddle/fluid/compiler/CompiledProgram_cn.rst
+++ b/doc/paddle/api/paddle/fluid/compiler/CompiledProgram_cn.rst
@@ -33,7 +33,7 @@ CompiledProgram，初始化后的 ``CompiledProgram`` 对象
     exe = static.Executor(place)
 
     data = static.data(name='X', shape=[None, 1], dtype='float32')
-    hidden = static.nn.fc(input=data, size=10)
+    hidden = static.nn.fc(x=data, size=10)
     loss = paddle.mean(hidden)
     paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
 
@@ -99,7 +99,7 @@ CompiledProgram，配置之后的 ``CompiledProgram`` 对象
     exe = static.Executor(place)
 
     data = static.data(name='X', shape=[None, 1], dtype='float32')
-    hidden = static.nn.fc(input=data, size=10)
+    hidden = static.nn.fc(x=data, size=10)
     loss = paddle.mean(hidden)
 
     test_program = static.default_main_program().clone(for_test=True)

--- a/doc/paddle/api/paddle/fluid/compiler/ExecutionStrategy_cn.rst
+++ b/doc/paddle/api/paddle/fluid/compiler/ExecutionStrategy_cn.rst
@@ -25,7 +25,7 @@ ExecutionStrategy，一个ExecutionStrategy的实例
 
     x = static.data(name='x', shape=[None, 13], dtype='float32')
     y = static.data(name='y', shape=[None, 1], dtype='float32')
-    y_predict = static.nn.fc(input=x, size=1, act=None)
+    y_predict = static.nn.fc(x=x, size=1, activation=None)
 
     cost = F.square_error_cost(input=y_predict, label=y)
     avg_loss = paddle.mean(cost)

--- a/doc/paddle/api/paddle/fluid/framework/Program_cn.rst
+++ b/doc/paddle/api/paddle/fluid/framework/Program_cn.rst
@@ -33,7 +33,7 @@ Program，创建的空的Program
     with static.program_guard(main_program=main_program, startup_program=startup_program):
         x = static.data(name="x", shape=[-1, 784], dtype='float32')
         y = static.data(name="y", shape=[-1, 1], dtype='int32')
-        z = static.nn.fc(name="fc", input=x, size=10, act="relu")
+        z = static.nn.fc(name="fc", x=x, size=10, activation="relu")
 
     print("main program is: {}".format(main_program))
     print("start up program is: {}".format(startup_program))
@@ -88,7 +88,7 @@ str，由Program转换得到的字符串
 
 **代码示例**
 
-   ::
+.. code-block:: python
 
         import paddle
         import paddle.static as static
@@ -96,7 +96,7 @@ str，由Program转换得到的字符串
         paddle.enable_static()
 
         img = static.data(name='image', shape=[None, 784])
-        pred = static.nn.fc(input=img, size=10, act='relu')
+        pred = static.nn.fc(x=img, size=10, activation='relu')
         loss = paddle.mean(pred)
         # Here we use clone before Momentum
         test_program = static.default_main_program().clone(for_test=True)
@@ -164,10 +164,10 @@ Program，当 ``for_test=True`` 时返回一个新的、仅包含当前Program�
     with static.program_guard(train_program, startup_program):
         with utils.unique_name.guard():
             img = static.data(name='image', shape=[None, 784])
-            hidden = static.nn.fc(input=img, size=200, act='relu')
+            hidden = static.nn.fc(x=img, size=200, activation='relu')
             hidden = F.dropout(hidden, p=0.5)
             loss = F.cross_entropy(
-                input=static.nn.fc(hidden, size=10, act='softmax'),
+                input=static.nn.fc(x=hidden, size=10, activation='softmax'),
                 label=static.data(name='label', shape=[1], dtype='int64'))
             avg_loss = paddle.mean(loss)
             test_program = train_program.clone(for_test=True)
@@ -211,10 +211,10 @@ Program，当 ``for_test=True`` 时返回一个新的、仅包含当前Program�
 
     def network():
         img = static.data(name='image', shape=[None, 784])
-        hidden = static.nn.fc(input=img, size=200, act='relu')
+        hidden = static.nn.fc(x=img, size=200, activation='relu')
         hidden = F.dropout(hidden, p=0.5)
         loss = F.cross_entropy(
-            input=static.nn.fc(hidden, size=10, act='softmax'),
+            input=static.nn.fc(x=hidden, size=10, activation='softmax'),
             label=static.data(name='label', shape=[1], dtype='int64'))
         avg_loss = paddle.mean(loss)
         return avg_loss
@@ -450,7 +450,7 @@ list[ :ref:`api_guide_parameter` ]，一个包含当前Program中所有参数的
 
     program = static.default_main_program()
     data = static.data(name='x', shape=[None, 13], dtype='float32')
-    hidden = static.nn.fc(input=data, size=10)
+    hidden = static.nn.fc(x=data, size=10)
     loss = paddle.mean(hidden)
     paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
 

--- a/doc/paddle/api/paddle/fluid/framework/default_main_program_cn.rst
+++ b/doc/paddle/api/paddle/fluid/framework/default_main_program_cn.rst
@@ -40,8 +40,8 @@ default_main_program
         bn2 = paddle.static.nn.batch_norm(conv2, act='relu')
         pool2 = paddle.nn.functional.pool2d(bn2, 2, 'max', 2)
         
-        fc1 = paddle.static.nn.fc(pool2, size=50, act='relu')
-        fc2 = paddle.static.nn.fc(fc1, size=102, act='softmax')
+        fc1 = paddle.static.nn.fc(x=pool2, size=50, activation='relu')
+        fc2 = paddle.static.nn.fc(x=fc1, size=102, activation='softmax')
         
         loss = paddle.nn.functional.loss.cross_entropy(input=fc2, label=label)
         loss = paddle.mean(loss)

--- a/doc/paddle/api/paddle/fluid/framework/default_startup_program_cn.rst
+++ b/doc/paddle/api/paddle/fluid/framework/default_startup_program_cn.rst
@@ -35,7 +35,7 @@ default_startup_program
         with paddle.static.program_guard(main_program=main_program, startup_program=startup_program):
             x = paddle.data(name="x", shape=[-1, 784], dtype='float32')
             y = paddle.data(name="y", shape=[-1, 1], dtype='int32')
-            z = paddle.static.nn.fc(name="fc", input=x, size=10, act="relu")
+            z = paddle.static.nn.fc(name="fc", x=x, size=10, activation="relu")
             print("main program is: {}".format(paddle.static.default_main_program()))
             print("start up program is: {}".format(paddle.static.default_startup_program()))
 

--- a/doc/paddle/api/paddle/fluid/framework/program_guard_cn.rst
+++ b/doc/paddle/api/paddle/fluid/framework/program_guard_cn.rst
@@ -28,7 +28,7 @@ program_guard
     startup_program = paddle.static.Program()
     with paddle.static.program_guard(main_program, startup_program):
         data = paddle.static.data(name='image', shape=[None, 784, 784], dtype='float32')
-        hidden = paddle.static.nn.fc(input=data, size=10, act='relu')
+        hidden = paddle.static.nn.fc(x=data, size=10, activation='relu')
 
 例如，当组的网不需要 startup_program 初始化各变量时，可以传入一个临时的 program。
 

--- a/doc/paddle/api/paddle/fluid/layers/nn/py_func_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/nn/py_func_cn.rst
@@ -32,7 +32,7 @@ PaddlePaddle 通过py_func在Python端注册OP。py_func的设计原理在于Pad
 
 **示例代码1**:
 
-..  code-block:: python
+.. code-block:: python
 
     import paddle
     import six
@@ -71,7 +71,7 @@ PaddlePaddle 通过py_func在Python端注册OP。py_func的设计原理在于Pad
             # 用户自定义的调试函数，打印出输入的LodTensor
             paddle.static.nn.py_func(func=debug_func, x=hidden, out=None)
 
-        prediction = paddle.static.nn.fc(hidden, size=10, act='softmax')
+        prediction = paddle.static.nn.fc(hidden, size=10, activation='softmax')
         loss = paddle.static.nn.cross_entropy(input=prediction, label=label)
         return paddle.mean(loss)
 

--- a/doc/paddle/api/paddle/fluid/param_attr/WeightNormParamAttr_cn.rst
+++ b/doc/paddle/api/paddle/fluid/param_attr/WeightNormParamAttr_cn.rst
@@ -38,14 +38,14 @@ WeightNormParamAttr
 
     data = paddle.static.data(name="data", shape=[3, 32, 32], dtype="float32")
 
-    fc = paddle.static.nn.fc(input=data,
+    fc = paddle.static.nn.fc(x=data,
                              size=1000,
-                             param_attr=paddle.static.WeightNormParamAttr(
-                                        dim=None,
-                                        name='weight_norm_param',
-                                        initializer=paddle.nn.initializer.Constant(1.0),
-                                        learning_rate=1.0,
-                                        regularizer=paddle.regularizer.L2Decay(0.1),
-                                        trainable=True,
-                                        o_model_average=False))
+                             weight_attr=paddle.static.WeightNormParamAttr(
+                                 dim=None,
+                                 name='weight_norm_param',
+                                 initializer=paddle.nn.initializer.Constant(1.0),
+                                 learning_rate=1.0,
+                                 regularizer=paddle.regularizer.L2Decay(0.1),
+                                 trainable=True,
+                                 o_model_average=False))
 


### PR DESCRIPTION
https://github.com/PaddlePaddle/Paddle/pull/27768 修改了`paddle.static.nn.fc`接口的部分参数名，但是一些代码示例没有随之改过来。这个PR修复所有引用到`paddle.static.nn.fc`的代码示例。

修改后grep结果如下：
![image](https://user-images.githubusercontent.com/12538138/95866937-206c6a00-0d9b-11eb-8d32-a72c8acf371d.png)
