### PR TITLE
add paddle.manual_seed in sample code of multinomial, bernoulli op and Categorical class

### DIFF
--- a/doc/paddle/api/paddle/distribution/Categorical_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Categorical_cn.rst
@@ -31,38 +31,38 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
-    paddle.manual_seed(100)
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.00224779 0.50324494 0.13526054
-    #  0.1611277  0.7955702  0.96897715]
+    # [0.5535528  0.20714243 0.01162981
+    #  0.51577556 0.36369765 0.2609165 ]
 
-    paddle.manual_seed(200)
+    paddle.manual_seed(200) # on CPU device
     y = paddle.rand([6])
     print(y.numpy())
-    # [0.00449559 0.00648983 0.27052107
-    #  0.3222554  0.5911404  0.93795437]
+    # [0.77663314 0.90824795 0.15685187
+    #  0.04279523 0.34468332 0.7955718 ]
 
     cat = Categorical(x)
     cat2 = Categorical(y)
 
+    paddle.manual_seed(1000) # on CPU device
     cat.sample([2,3])
-    # [[4, 5, 5],
-    # [4, 2, 3]]
+    # [[0, 0, 5],
+    #  [3, 4, 5]]
 
     cat.entropy()
-    # [1.72595]
+    # [1.77528]
 
     cat.kl_divergence(cat2)
-    # [0.0218145]
+    # [0.071952]
 
     value = paddle.to_tensor([2,1,3])
     cat.probs(value)
-    # [0.0527038 0.196088 0.0627829]
+    # [0.00608027 0.108298 0.269656]
 
     cat.log_prob(value)
-    # [-2.94307 -1.62919 -2.76807]
-
+    # [-5.10271 -2.22287 -1.31061]
 
 .. py:function:: sample(shape)
 
@@ -82,17 +82,18 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
-    paddle.manual_seed(100)
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.00224779 0.50324494 0.13526054
-    #  0.1611277  0.7955702  0.96897715]
+    # [0.5535528  0.20714243 0.01162981
+    #  0.51577556 0.36369765 0.2609165 ]
 
     cat = Categorical(x)
 
+    paddle.manual_seed(1000) # on CPU device
     cat.sample([2,3])
-    # [[4, 5, 5],
-    # [4, 2, 3]]
+    # [[0, 0, 5],
+    #  [3, 4, 5]]
 
 .. py:function:: kl_divergence(other)
 
@@ -112,23 +113,23 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
-    paddle.manual_seed(100)
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.00224779 0.50324494 0.13526054
-    #  0.1611277  0.7955702  0.96897715]
+    # [0.5535528  0.20714243 0.01162981
+    #  0.51577556 0.36369765 0.2609165 ]
 
-    paddle.manual_seed(200)
+    paddle.manual_seed(200) # on CPU device
     y = paddle.rand([6])
     print(y.numpy())
-    # [0.00449559 0.00648983 0.27052107
-    #  0.3222554  0.5911404  0.93795437]
+    # [0.77663314 0.90824795 0.15685187
+    #  0.04279523 0.34468332 0.7955718 ]
 
     cat = Categorical(x)
     cat2 = Categorical(y)
 
     cat.kl_divergence(cat2)
-    # [0.0218145]
+    # [0.071952]
 
 .. py:function:: entropy()
 
@@ -145,16 +146,16 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
-    paddle.manual_seed(100)
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.00224779 0.50324494 0.13526054
-    #  0.1611277  0.7955702  0.96897715]
+    # [0.5535528  0.20714243 0.01162981
+    #  0.51577556 0.36369765 0.2609165 ]
 
     cat = Categorical(x)
 
     cat.entropy()
-    # [1.72595]
+    # [1.77528]
 
 .. py:function:: probs(value)
 
@@ -175,17 +176,17 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
-    paddle.manual_seed(100)
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.00224779 0.50324494 0.13526054
-    #  0.1611277  0.7955702  0.96897715]
+    # [0.5535528  0.20714243 0.01162981
+    #  0.51577556 0.36369765 0.2609165 ]
 
     cat = Categorical(x)
 
     value = paddle.to_tensor([2,1,3])
     cat.probs(value)
-    # [0.0527038 0.196088 0.0627829]
+    # [0.00608027 0.108298 0.269656]
 
 .. py:function:: log_prob(value)
 
@@ -203,17 +204,17 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
-    paddle.manual_seed(100)
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.00224779 0.50324494 0.13526054
-    #  0.1611277  0.7955702  0.96897715]
+    # [0.5535528  0.20714243 0.01162981
+    #  0.51577556 0.36369765 0.2609165 ]
 
     cat = Categorical(x)
 
     value = paddle.to_tensor([2,1,3])
     cat.log_prob(value)
-    # [-2.94307 -1.62919 -2.76807]
+    # [-5.10271 -2.22287 -1.31061]
     
 
 

--- a/doc/paddle/api/paddle/distribution/Categorical_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Categorical_cn.rst
@@ -31,34 +31,37 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
+    paddle.manual_seed(100)
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.32564053, 0.99334985, 0.99034804,
-    #  0.09053693, 0.30820143, 0.19095989]
+    # [0.00224779 0.50324494 0.13526054
+    #  0.1611277  0.7955702  0.96897715]
+
+    paddle.manual_seed(200)
     y = paddle.rand([6])
     print(y.numpy())
-    # [0.6365463 , 0.7278677 , 0.90260243, 
-    # 0.5226815 , 0.35837543, 0.13981032]
+    # [0.00449559 0.00648983 0.27052107
+    #  0.3222554  0.5911404  0.93795437]
 
     cat = Categorical(x)
     cat2 = Categorical(y)
 
     cat.sample([2,3])
-    # [[5, 1, 1],
-    # [0, 1, 2]]
+    # [[4, 5, 5],
+    # [4, 2, 3]]
 
     cat.entropy()
-    # [1.71887]
+    # [1.72595]
 
     cat.kl_divergence(cat2)
-    # [0.0278455]
+    # [0.0218145]
 
     value = paddle.to_tensor([2,1,3])
     cat.probs(value)
-    # [0.341613 0.342648 0.03123]
+    # [0.0527038 0.196088 0.0627829]
 
     cat.log_prob(value)
-    # [-1.07408 -1.07105 -3.46638]
+    # [-2.94307 -1.62919 -2.76807]
 
 
 .. py:function:: sample(shape)
@@ -79,16 +82,17 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
+    paddle.manual_seed(100)
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.32564053, 0.99334985, 0.99034804,
-    #  0.09053693, 0.30820143, 0.19095989]
+    # [0.00224779 0.50324494 0.13526054
+    #  0.1611277  0.7955702  0.96897715]
 
     cat = Categorical(x)
 
     cat.sample([2,3])
-    # [[5, 1, 1],
-    # [0, 1, 2]]
+    # [[4, 5, 5],
+    # [4, 2, 3]]
 
 .. py:function:: kl_divergence(other)
 
@@ -108,20 +112,23 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
+    paddle.manual_seed(100)
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.32564053, 0.99334985, 0.99034804,
-    #  0.09053693, 0.30820143, 0.19095989]
+    # [0.00224779 0.50324494 0.13526054
+    #  0.1611277  0.7955702  0.96897715]
+
+    paddle.manual_seed(200)
     y = paddle.rand([6])
     print(y.numpy())
-    # [0.6365463 , 0.7278677 , 0.90260243, 
-    # 0.5226815 , 0.35837543, 0.13981032]
+    # [0.00449559 0.00648983 0.27052107
+    #  0.3222554  0.5911404  0.93795437]
 
     cat = Categorical(x)
     cat2 = Categorical(y)
 
     cat.kl_divergence(cat2)
-    # [0.0278455]
+    # [0.0218145]
 
 .. py:function:: entropy()
 
@@ -138,15 +145,16 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
+    paddle.manual_seed(100)
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.32564053, 0.99334985, 0.99034804,
-    #  0.09053693, 0.30820143, 0.19095989]
+    # [0.00224779 0.50324494 0.13526054
+    #  0.1611277  0.7955702  0.96897715]
 
     cat = Categorical(x)
 
     cat.entropy()
-    # [1.71887]
+    # [1.72595]
 
 .. py:function:: probs(value)
 
@@ -167,16 +175,17 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
+    paddle.manual_seed(100)
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.32564053, 0.99334985, 0.99034804,
-    #  0.09053693, 0.30820143, 0.19095989]
+    # [0.00224779 0.50324494 0.13526054
+    #  0.1611277  0.7955702  0.96897715]
 
     cat = Categorical(x)
 
     value = paddle.to_tensor([2,1,3])
     cat.probs(value)
-    # [0.341613 0.342648 0.03123]
+    # [0.0527038 0.196088 0.0627829]
 
 .. py:function:: log_prob(value)
 
@@ -194,17 +203,18 @@ Categorical
     import paddle
     from paddle.distribution import Categorical
 
+    paddle.manual_seed(100)
     x = paddle.rand([6])
     print(x.numpy())
-    # [0.32564053, 0.99334985, 0.99034804,
-    #  0.09053693, 0.30820143, 0.19095989]
+    # [0.00224779 0.50324494 0.13526054
+    #  0.1611277  0.7955702  0.96897715]
 
     cat = Categorical(x)
 
     value = paddle.to_tensor([2,1,3])
-
     cat.log_prob(value)
-    # [-1.07408 -1.07105 -3.46638]
+    # [-2.94307 -1.62919 -2.76807]
+    
 
 
 

--- a/doc/paddle/api/paddle/tensor/random/bernoulli_cn.rst
+++ b/doc/paddle/api/paddle/tensor/random/bernoulli_cn.rst
@@ -26,19 +26,18 @@ bernoulli
 .. code-block:: python
 
     import paddle
-    import numpy as np
 
-    paddle.disable_static()
-
-    x = paddle.rand([2, 3])
+    paddle.manual_seed(100) # on CPU device
+    x = paddle.rand([2,3])
     print(x.numpy())
-    # [[0.11272584 0.3890902  0.7730957 ]
-    # [0.10351662 0.8510418  0.63806665]]
+    # [[0.5535528  0.20714243 0.01162981]
+    # [0.51577556 0.36369765 0.2609165 ]]
 
+    paddle.manual_seed(200) # on CPU device
     out = paddle.bernoulli(x)
     print(out.numpy())
-    # [[0. 0. 1.]
-    # [0. 0. 1.]]
+    # [[0. 0. 0.]
+    # [1. 1. 0.]]
 
 
 

--- a/doc/paddle/api/paddle/tensor/random/multinomial_cn.rst
+++ b/doc/paddle/api/paddle/tensor/random/multinomial_cn.rst
@@ -28,24 +28,27 @@ multinomial
 
     import paddle
 
+    paddle.manual_seed(100) # on CPU device
     x = paddle.rand([2,4])
     print(x.numpy())
-    # [[0.7713825  0.4055941  0.433339   0.70706886]
-    # [0.9223313  0.8519825  0.04574518 0.16560672]]
+    # [[0.5535528  0.20714243 0.01162981 0.51577556]
+    # [0.36369765 0.2609165  0.18905126 0.5621971 ]]
 
+    paddle.manual_seed(200) # on CPU device
     out1 = paddle.multinomial(x, num_samples=5, replacement=True)
     print(out1.numpy())
-    # [[3, 3, 1, 1, 0]
-    # [0, 0, 0, 0, 1]]
+    # [[3 3 0 0 0]
+    # [3 3 3 1 0]]
 
     # out2 = paddle.multinomial(x, num_samples=5)
-    # OutOfRangeError: When replacement is False, number of samples
+    # InvalidArgumentError: When replacement is False, number of samples
     #  should be less than non-zero categories
 
+    paddle.manual_seed(300) # on CPU device
     out3 = paddle.multinomial(x, num_samples=3)
     print(out3.numpy())
-    # [[0, 2, 3]
-    # [0, 1, 3]]
+    # [[3 0 1]
+    # [3 1 0]]
 
 
 


### PR DESCRIPTION
Add `paddle.manual_seed` in sample code of `multinomial`, `bernoulli` op and `Categorical` class.
Note that `paddle.manual_seed` only have effect on CPU device of `multinomial`, `bernoulli` op and `Categorical` class.

## multinomial op
refer to PR #2743 

![屏幕快照 2020-10-19 下午6 00 41](https://user-images.githubusercontent.com/26408901/96430715-192edb80-1235-11eb-94ea-aecc5c98b039.png)

## bernoulli op
refer to PR #2549 

![屏幕快照 2020-10-19 下午6 03 53](https://user-images.githubusercontent.com/26408901/96431005-7f1b6300-1235-11eb-8fd9-27a5ae3064b5.png)

## Categorical class
refer to PR #2745 

![屏幕快照 2020-10-19 下午6 07 07](https://user-images.githubusercontent.com/26408901/96431334-f0f3ac80-1235-11eb-97c3-605327c1fa7c.png)

