### PR TITLE
update name_scope doc

### DIFF
--- a/doc/paddle/api/paddle/fluid/framework/name_scope_cn.rst
+++ b/doc/paddle/api/paddle/fluid/framework/name_scope_cn.rst
@@ -4,7 +4,7 @@ name_scope
 -------------------------------
 
 
-.. py:function:: paddle.fluid.name_scope(prefix=None)
+.. py:function:: paddle.static.name_scope(prefix=None)
 
 
 
@@ -23,7 +23,7 @@ name_scope
       import paddle
       paddle.enable_static()
       with paddle.static.name_scope("s1"):
-         a = paddle.data(name='data', shape=[None, 1], dtype='int32')
+         a = paddle.static.data(name='data', shape=[None, 1], dtype='int32')
          b = a + 1
          with paddle.static.name_scope("s2"):
             c = b * 1


### PR DESCRIPTION
update name_scope doc

一、问题描述
1.API真实路径：paddle.fluid.framework.name_scope 
2.2.0上API推荐别名：paddle.static.name_scope
 
3.细节问题：
中文问题汇总
code_example:['name_scope_1.py']
has_fluid:True
has_enable_static:True

![image](https://user-images.githubusercontent.com/6836917/98198350-babb6a00-1f63-11eb-8540-091f1d2fc3f1.png)
