### PR TITLE
fix Tanh remainder cn doc

### DIFF
--- a/doc/fluid/api_cn/nn_cn/activation_cn/Tanh_cn.rst
+++ b/doc/fluid/api_cn/nn_cn/activation_cn/Tanh_cn.rst
@@ -26,10 +26,8 @@ Tanh激活层
     import paddle
     import numpy as np
 
-    paddle.disable_static()
-
     x = paddle.to_tensor(np.array([-0.4, -0.2, 0.1, 0.3]))
     m = paddle.nn.Tanh()
     out = m(x)
-    print(out.numpy())
+    print(out)
     # [-0.37994896 -0.19737532  0.09966799  0.29131261]

--- a/doc/fluid/api_cn/tensor_cn/remainder_cn.rst
+++ b/doc/fluid/api_cn/tensor_cn/remainder_cn.rst
@@ -1,9 +1,9 @@
 .. _cn_api_tensor_remainder:
 
-remainder
+mod
 -------------------------------
 
-.. py:function:: paddle.remainder(x, y, name=None)
+.. py:function:: paddle.mod(x, y, name=None)
 
 逐元素取模算子。公式为：
 
@@ -11,7 +11,7 @@ remainder
         out = x \% y
 
 **注意**:
-        ``paddle.remainder`` 支持广播。关于广播规则，请参考 :ref:`use_guide_broadcasting`
+        ``paddle.mod`` 支持广播。关于广播规则，请参考 :ref:`use_guide_broadcasting`
 
 参数：
         - x（Tensor）- 多维Tensor。数据类型为float32 、float64、int32或int64。
@@ -29,5 +29,5 @@ remainder
 
         x = paddle.to_tensor([2, 3, 8, 7])
         y = paddle.to_tensor([1, 5, 3, 3])
-        z = paddle.remainder(x, y)
+        z = paddle.mod(x, y)
         print(z)  # [0, 3, 2, 1]

--- a/doc/fluid/api_cn/tensor_cn/remainder_cn.rst
+++ b/doc/fluid/api_cn/tensor_cn/remainder_cn.rst
@@ -5,38 +5,29 @@ remainder
 
 .. py:function:: paddle.remainder(x, y, name=None)
 
-该OP是逐元素取模算子，输入 ``x`` 与输入 ``y`` 逐元素取模，并将各个位置的输出元素保存到返回结果中。
-输入 ``x`` 与输入 ``y`` 必须可以广播为相同形状, 关于广播规则，请参考 :ref:`use_guide_broadcasting`
-
-等式为：
+逐元素取模算子。公式为：
 
 .. math::
-        Out = X \% Y
+        out = x \% y
 
-- :math:`X` ：多维Tensor。
-- :math:`Y` ：多维Tensor。
+**注意**:
+        ``paddle.remainder`` 支持广播。关于广播规则，请参考 :ref:`use_guide_broadcasting`
 
 参数：
         - x（Tensor）- 多维Tensor。数据类型为float32 、float64、int32或int64。
         - y（Tensor）- 多维Tensor。数据类型为float32 、float64、int32或int64。
         - name（str，可选）- 操作的名称(可选，默认值为None）。更多信息请参见 :ref:`api_guide_Name`。
 
-
-返回：   多维 Tensor， 数据类型与 ``x`` 相同，维度为广播后的形状。
-
-返回类型：        Tensor
-
+返回：
+        多维Tensor。存储计算的结果，数据类型与 ``x`` 相同，维度为广播后的形状。
 
 **代码示例**
 
 ..  code-block:: python
 
         import paddle
-        import numpy as np
-        paddle.disable_static()
-        np_x = np.array([2, 3, 8, 7])
-        np_y = np.array([1, 5, 3, 3])
-        x = paddle.to_tensor(np_x)
-        y = paddle.to_tensor(np_y)
+
+        x = paddle.to_tensor([2, 3, 8, 7])
+        y = paddle.to_tensor([1, 5, 3, 3])
         z = paddle.remainder(x, y)
-        print(z.numpy())  # [0, 3, 2, 1]
+        print(z)  # [0, 3, 2, 1]

--- a/doc/paddle/api/alias_api_mapping
+++ b/doc/paddle/api/alias_api_mapping
@@ -158,7 +158,6 @@ paddle.fluid.layers.ceil	paddle.ceil,paddle.tensor.ceil,paddle.tensor.math.ceil
 paddle.nn.layer.activation.ReLU	paddle.nn.ReLU
 paddle.tensor.logic.greater_equal	paddle.greater_equal,paddle.tensor.greater_equal
 paddle.nn.layer.pooling.AvgPool2D	paddle.nn.AvgPool2D,paddle.nn.layer.AvgPool2D
-paddle.tensor.math.floor_mod	paddle.floor_mod,paddle.tensor.floor_mod
 paddle.nn.functional.pooling.adaptive_avg_pool3d	paddle.nn.functional.adaptive_avg_pool3d
 paddle.tensor.math.inverse	paddle.inverse,paddle.tensor.inverse
 paddle.fluid.layers.label_smooth	paddle.nn.functional.label_smooth,paddle.nn.functional.common.label_smooth
@@ -170,7 +169,7 @@ paddle.nn.layer.conv.Conv3DTranspose	paddle.nn.Conv3DTranspose,paddle.nn.layer.C
 paddle.fluid.dygraph.layers.Layer	paddle.nn.Layer
 paddle.tensor.logic.greater_than	paddle.greater_than,paddle.tensor.greater_than
 paddle.fluid.dygraph.jit.set_code_level	paddle.jit.set_code_level
-paddle.tensor.math.remainder	paddle.remainder,paddle.tensor.remainder
+paddle.tensor.math.remainder	paddle.mod,paddle.tensor.mod,paddle.tensor.math.mod,paddle.remainder,paddle.tensor.remainder,paddle.floor_mod,paddle.tensor.floor_mod,paddle.tensor.math.floor_mod
 paddle.fluid.layers.shard_index	paddle.shard_index,paddle.tensor.shard_index,paddle.tensor.manipulation.shard_index
 paddle.nn.layer.pooling.AvgPool3D	paddle.nn.AvgPool3D,paddle.nn.layer.AvgPool3D
 paddle.fluid.dygraph.jit.save	paddle.jit.save
@@ -342,7 +341,6 @@ paddle.tensor.math.maximum	paddle.maximum,paddle.tensor.maximum
 paddle.fluid.layers.add_position_encoding	paddle.nn.functional.add_position_encoding,paddle.nn.functional.extension.add_position_encoding
 paddle.nn.functional.common.cosine_similarity	paddle.nn.functional.cosine_similarity
 paddle.fluid.layers.floor	paddle.floor,paddle.tensor.floor,paddle.tensor.math.floor
-paddle.tensor.math.mod	paddle.mod,paddle.tensor.mod
 paddle.fluid.layers.log2    paddle.log2,paddle.tensor.log2,paddle.tensor.math.log2
 paddle.tensor.math.log1p    paddle.log1p,paddle.tensor.log1p
 paddle.fluid.layers.unstack	paddle.unstack,paddle.tensor.unstack,paddle.tensor.manipulation.unstack

--- a/doc/paddle/api/paddle/nn/layer/activation/Tanh_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/activation/Tanh_cn.rst
@@ -26,10 +26,8 @@ Tanh激活层
     import paddle
     import numpy as np
 
-    paddle.disable_static()
-
     x = paddle.to_tensor(np.array([-0.4, -0.2, 0.1, 0.3]))
     m = paddle.nn.Tanh()
     out = m(x)
-    print(out.numpy())
+    print(out)
     # [-0.37994896 -0.19737532  0.09966799  0.29131261]

--- a/doc/paddle/api/paddle/tensor/math/remainder_cn.rst
+++ b/doc/paddle/api/paddle/tensor/math/remainder_cn.rst
@@ -1,9 +1,9 @@
 .. _cn_api_tensor_remainder:
 
-remainder
+mod
 -------------------------------
 
-.. py:function:: paddle.remainder(x, y, name=None)
+.. py:function:: paddle.mod(x, y, name=None)
 
 逐元素取模算子。公式为：
 
@@ -11,7 +11,7 @@ remainder
         out = x \% y
 
 **注意**:
-        ``paddle.remainder`` 支持广播。关于广播规则，请参考 :ref:`use_guide_broadcasting`
+        ``paddle.mod`` 支持广播。关于广播规则，请参考 :ref:`use_guide_broadcasting`
 
 参数：
         - x（Tensor）- 多维Tensor。数据类型为float32 、float64、int32或int64。
@@ -29,5 +29,5 @@ remainder
 
         x = paddle.to_tensor([2, 3, 8, 7])
         y = paddle.to_tensor([1, 5, 3, 3])
-        z = paddle.remainder(x, y)
+        z = paddle.mod(x, y)
         print(z)  # [0, 3, 2, 1]

--- a/doc/paddle/api/paddle/tensor/math/remainder_cn.rst
+++ b/doc/paddle/api/paddle/tensor/math/remainder_cn.rst
@@ -5,38 +5,29 @@ remainder
 
 .. py:function:: paddle.remainder(x, y, name=None)
 
-该OP是逐元素取模算子，输入 ``x`` 与输入 ``y`` 逐元素取模，并将各个位置的输出元素保存到返回结果中。
-输入 ``x`` 与输入 ``y`` 必须可以广播为相同形状, 关于广播规则，请参考 :ref:`use_guide_broadcasting`
-
-等式为：
+逐元素取模算子。公式为：
 
 .. math::
-        Out = X \% Y
+        out = x \% y
 
-- :math:`X` ：多维Tensor。
-- :math:`Y` ：多维Tensor。
+**注意**:
+        ``paddle.remainder`` 支持广播。关于广播规则，请参考 :ref:`use_guide_broadcasting`
 
 参数：
         - x（Tensor）- 多维Tensor。数据类型为float32 、float64、int32或int64。
         - y（Tensor）- 多维Tensor。数据类型为float32 、float64、int32或int64。
         - name（str，可选）- 操作的名称(可选，默认值为None）。更多信息请参见 :ref:`api_guide_Name`。
 
-
-返回：   多维 Tensor， 数据类型与 ``x`` 相同，维度为广播后的形状。
-
-返回类型：        Tensor
-
+返回：
+        多维Tensor。存储计算的结果，数据类型与 ``x`` 相同，维度为广播后的形状。
 
 **代码示例**
 
 ..  code-block:: python
 
         import paddle
-        import numpy as np
-        paddle.disable_static()
-        np_x = np.array([2, 3, 8, 7])
-        np_y = np.array([1, 5, 3, 3])
-        x = paddle.to_tensor(np_x)
-        y = paddle.to_tensor(np_y)
+
+        x = paddle.to_tensor([2, 3, 8, 7])
+        y = paddle.to_tensor([1, 5, 3, 3])
         z = paddle.remainder(x, y)
-        print(z.numpy())  # [0, 3, 2, 1]
+        print(z)  # [0, 3, 2, 1]


### PR DESCRIPTION
Fix `Tanh` & `remainder` cn docs, rm `enable_static` and change `print(out.numpy())` --> print(out).

Both `mod` and `floor_mod` are aliases of `remainder`，so change alias_api_mapping file, `paddle.tensor.math.remainder` use default alias `paddle.mod`.

EN docs see https://github.com/PaddlePaddle/Paddle/pull/28455

`Tanh` preview:
![image](https://user-images.githubusercontent.com/10208305/98244810-fcbbce80-1faa-11eb-90e4-5c20c9399247.png)

`remainder(paddle.mod)` preview
![image](https://user-images.githubusercontent.com/10208305/98337512-ae0e4300-2043-11eb-8ba9-5ff9360caf9d.png)

