### PR TITLE
fix nce, multinomial, Categorical, Normal, Uniform cn doc

### DIFF
--- a/doc/paddle/api/paddle/distribution/Categorical_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Categorical_cn.rst
@@ -33,13 +33,13 @@ Categorical
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([6])
-    print(x.numpy())
+    print(x)
     # [0.5535528  0.20714243 0.01162981
     #  0.51577556 0.36369765 0.2609165 ]
 
     paddle.seed(200) # on CPU device
     y = paddle.rand([6])
-    print(y.numpy())
+    print(y)
     # [0.77663314 0.90824795 0.15685187
     #  0.04279523 0.34468332 0.7955718 ]
 
@@ -84,7 +84,7 @@ Categorical
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([6])
-    print(x.numpy())
+    print(x)
     # [0.5535528  0.20714243 0.01162981
     #  0.51577556 0.36369765 0.2609165 ]
 
@@ -115,13 +115,13 @@ Categorical
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([6])
-    print(x.numpy())
+    print(x)
     # [0.5535528  0.20714243 0.01162981
     #  0.51577556 0.36369765 0.2609165 ]
 
     paddle.seed(200) # on CPU device
     y = paddle.rand([6])
-    print(y.numpy())
+    print(y)
     # [0.77663314 0.90824795 0.15685187
     #  0.04279523 0.34468332 0.7955718 ]
 
@@ -148,7 +148,7 @@ Categorical
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([6])
-    print(x.numpy())
+    print(x)
     # [0.5535528  0.20714243 0.01162981
     #  0.51577556 0.36369765 0.2609165 ]
 
@@ -178,7 +178,7 @@ Categorical
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([6])
-    print(x.numpy())
+    print(x)
     # [0.5535528  0.20714243 0.01162981
     #  0.51577556 0.36369765 0.2609165 ]
 
@@ -206,7 +206,7 @@ Categorical
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([6])
-    print(x.numpy())
+    print(x)
     # [0.5535528  0.20714243 0.01162981
     #  0.51577556 0.36369765 0.2609165 ]
 

--- a/doc/paddle/api/paddle/distribution/Normal_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Normal_cn.rst
@@ -37,7 +37,6 @@ Normal
     import paddle
     from paddle.distribution import Normal
 
-    paddle.disable_static()
     # Define a single scalar Normal distribution.
     dist = Normal(loc=0., scale=3.)
     # Define a batch of two scalar valued Normals.

--- a/doc/paddle/api/paddle/distribution/Uniform_cn.rst
+++ b/doc/paddle/api/paddle/distribution/Uniform_cn.rst
@@ -39,7 +39,6 @@ Uniform
     import paddle
     from paddle.distribution import Uniform
 
-    paddle.disable_static()
     # Without broadcasting, a single uniform distribution [3, 4]:
     u1 = Uniform(low=3.0, high=4.0)
     # 2 distributions [1, 3], [2, 4]

--- a/doc/paddle/api/paddle/fluid/layers/nce_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/nce_cn.rst
@@ -19,8 +19,8 @@ nce
     - **label** (Tensor) -  标签，2-D 张量，形状为 [batch_size, num_true_class]，数据类型为 int64。
     - **num_total_classes** (int) - 所有样本中的类别的总数。
     - **sample_weight** (Tensor，可选) - 存储每个样本权重，shape 为 [batch_size, 1] 存储每个样本的权重。每个样本的默认权重为1.0。
-    - **param_attr** (ParamAttr，可选) ：指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
-    - **bias_attr** (ParamAttr，可选) : 指定偏置参数属性的对象。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
+    - **param_attr** (ParamAttr，可选) ：指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **bias_attr** (ParamAttr，可选) : 指定偏置参数属性的对象。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **num_neg_samples** (int) - 负样例的数量，默认值是10。
     - **name** (str，可选) - 该layer的名称，具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
     - **sampler** (str，可选) – 采样器，用于从负类别中进行取样。可以是 ``uniform``, ``log_uniform`` 或 ``custom_dist`` ， 默认 ``uniform`` 。

--- a/doc/paddle/api/paddle/fluid/layers/nce_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/nce_cn.rst
@@ -15,12 +15,12 @@ nce
 该层默认使用均匀分布进行抽样。
 
 参数:
-    - **input** (Variable) -  输入变量, 2-D 张量，形状为 [batch_size, dim]，数据类型为 float32 或者 float64。
-    - **label** (Variable) -  标签，2-D 张量，形状为 [batch_size, num_true_class]，数据类型为 int64。
+    - **input** (Tensor) -  输入张量, 2-D 张量，形状为 [batch_size, dim]，数据类型为 float32 或者 float64。
+    - **label** (Tensor) -  标签，2-D 张量，形状为 [batch_size, num_true_class]，数据类型为 int64。
     - **num_total_classes** (int) - 所有样本中的类别的总数。
-    - **sample_weight** (Variable，可选) - 存储每个样本权重，shape 为 [batch_size, 1] 存储每个样本的权重。每个样本的默认权重为1.0。
-    - **param_attr** (ParamAttr，可选) ：指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
-    - **bias_attr** (ParamAttr，可选) : 指定偏置参数属性的对象。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **sample_weight** (Tensor，可选) - 存储每个样本权重，shape 为 [batch_size, 1] 存储每个样本的权重。每个样本的默认权重为1.0。
+    - **param_attr** (ParamAttr，可选) ：指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
+    - **bias_attr** (ParamAttr，可选) : 指定偏置参数属性的对象。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
     - **num_neg_samples** (int) - 负样例的数量，默认值是10。
     - **name** (str，可选) - 该layer的名称，具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
     - **sampler** (str，可选) – 采样器，用于从负类别中进行取样。可以是 ``uniform``, ``log_uniform`` 或 ``custom_dist`` ， 默认 ``uniform`` 。
@@ -30,20 +30,22 @@ nce
 
 返回： nce loss，数据类型与 **input** 相同
 
-返回类型: Variable
+返回类型: Tensor
 
 
 **代码示例**
 
 ..  code-block:: python
 
-    import paddle.fluid as fluid
+    import paddle
     import numpy as np
+
+    paddle.enable_static()
 
     window_size = 5
     words = []
     for i in range(window_size):
-        words.append(fluid.data(
+        words.append(paddle.static.data(
             name='word_{0}'.format(i), shape=[-1, 1], dtype='int64'))
 
     dict_size = 10000
@@ -54,18 +56,18 @@ nce
         if i == label_word:
             continue
 
-        emb = fluid.layers.embedding(input=words[i], size=[dict_size, 32],
-                        param_attr='embed', is_sparse=True)
+        emb = paddle.static.nn.embedding(input=words[i], size=[dict_size, 32],
+                            param_attr='embed', is_sparse=True)
         embs.append(emb)
 
-    embs = fluid.layers.concat(input=embs, axis=1)
-    loss = fluid.layers.nce(input=embs, label=words[label_word],
-            num_total_classes=dict_size, param_attr='nce.w_0',
-            bias_attr='nce.b_0')
+    embs = paddle.concat(x=embs, axis=1)
+    loss = paddle.static.nn.nce(input=embs, label=words[label_word],
+                num_total_classes=dict_size, param_attr='nce.w_0',
+                bias_attr='nce.b_0')
 
     #or use custom distribution
     dist = np.array([0.05,0.5,0.1,0.3,0.05])
-    loss = fluid.layers.nce(input=embs, label=words[label_word],
+    loss = paddle.static.nn.nce(input=embs, label=words[label_word],
             num_total_classes=5, param_attr='nce.w_1',
             bias_attr='nce.b_1',
             num_neg_samples=3,

--- a/doc/paddle/api/paddle/tensor/random/multinomial_cn.rst
+++ b/doc/paddle/api/paddle/tensor/random/multinomial_cn.rst
@@ -30,13 +30,13 @@ multinomial
 
     paddle.seed(100) # on CPU device
     x = paddle.rand([2,4])
-    print(x.numpy())
+    print(x)
     # [[0.5535528  0.20714243 0.01162981 0.51577556]
     # [0.36369765 0.2609165  0.18905126 0.5621971 ]]
 
     paddle.seed(200) # on CPU device
     out1 = paddle.multinomial(x, num_samples=5, replacement=True)
-    print(out1.numpy())
+    print(out1)
     # [[3 3 0 0 0]
     # [3 3 3 1 0]]
 
@@ -46,7 +46,7 @@ multinomial
 
     paddle.seed(300) # on CPU device
     out3 = paddle.multinomial(x, num_samples=3)
-    print(out3.numpy())
+    print(out3)
     # [[3 0 1]
     # [3 1 0]]
 


### PR DESCRIPTION
Fix cn doc for apis

## paddle.static.nn.nce

- code_example:['nce_en_1.py']   ->   add `paddle.enable_static()` in sample code
- has_fluid:True   ->   use `paddle.xxx` instead of `fluid.xxx`
- has_variable:True   ->   change `Variable` to `Tensor`

![图片](https://user-images.githubusercontent.com/26408901/98803388-a12c8d80-244f-11eb-8be7-7b59b88290f9.png)
![图片](https://user-images.githubusercontent.com/26408901/98803397-a689d800-244f-11eb-9f83-2e6a74dfa18b.png)


## paddle.multinomial
- has_print:True   ->   delete `x.numpy()` in `print`

![图片](https://user-images.githubusercontent.com/26408901/98803581-f5d00880-244f-11eb-8751-ebcb95c82066.png)
![图片](https://user-images.githubusercontent.com/26408901/98803596-f9638f80-244f-11eb-829e-43b784827270.png)


## paddle.distribution.Categorical
- has_print:True   ->   delete `x.numpy()` in `print`

![图片](https://user-images.githubusercontent.com/26408901/98803663-14360400-2450-11eb-8618-f004386c9703.png)


## paddle.distribution.Normal
- has_disable_static   ->   delete `disable_static()`

![图片](https://user-images.githubusercontent.com/26408901/99754505-7911ee00-2b23-11eb-8681-befae8908dea.png)

## paddle.distribution.Uniform
- has_disable_static   ->   delete `disable_static()`

![图片](https://user-images.githubusercontent.com/26408901/99754493-70211c80-2b23-11eb-8e2c-002f249f688c.png)
