### PR TITLE
Fix two chinese api documents, transpose and strided_slice

### DIFF
--- a/doc/paddle/api/paddle/fluid/layers/transpose_cn.rst
+++ b/doc/paddle/api/paddle/fluid/layers/transpose_cn.rst
@@ -3,7 +3,7 @@
 transpose
 -------------------------------
 
-.. py:function:: paddle.fluid.layers.transpose(x,perm,name=None)
+.. py:function:: paddle.transpose(x,perm,name=None)
 
 
 
@@ -11,13 +11,13 @@ transpose
 该OP根据perm对输入的多维Tensor进行数据重排。返回多维Tensor的第i维对应输入Tensor的perm[i]维。
 
 参数：
-    - **x** (Variable) - 输入：x:[N_1, N_2, ..., N_k, D]多维Tensor，可选的数据类型为float16, float32, float64, int32, int64。
+    - **x** (Tensor) - 输入：x:[N_1, N_2, ..., N_k, D]多维Tensor，可选的数据类型为float16, float32, float64, int32, int64。
     - **perm** (list|tuple) - perm长度必须和X的维度相同，并依照perm中数据进行重排。
     - **name** (str) - 该层名称（可选）。
 
 返回： 多维Tensor
 
-返回类型：Variable
+返回类型：Tensor
 
 **示例**:
 

--- a/doc/paddle/api/paddle/tensor/manipulation/strided_slice_cn.rst
+++ b/doc/paddle/api/paddle/tensor/manipulation/strided_slice_cn.rst
@@ -74,7 +74,7 @@ strided_slice算子。
         # sliced_1 is x[:, 1:3:1, 0:2:1, 2:4:1].                                        
         # example 2:
         # attr starts is a list which contain tensor Tensor.
-        minus_3 = paddle.fill_constant([1], "int32", -3)
+        minus_3 = paddle.full(shape=[1], fill_value=-3, dtype='int32')
         sliced_2 = paddle.strided_slice(x, axes=axes, starts=[minus_3, 0, 2], ends=ends, strides=strides_2)
         # sliced_2 is x[:, 1:3:1, 0:2:1, 2:4:2].
 


### PR DESCRIPTION
- strided_slice 新版截图:
![strided_slice_doc_1](https://user-images.githubusercontent.com/6309021/99389410-fa923200-2911-11eb-831f-45fa6d871bb7.png)
![strided_slice_doc2](https://user-images.githubusercontent.com/6309021/99389420-ff56e600-2911-11eb-8de4-4f2bb1f805e6.png)

- tranpose 新版截图:
![transpose_doc1](https://user-images.githubusercontent.com/6309021/99389455-0d0c6b80-2912-11eb-8e8d-28ed718c95e6.png)




strided_slice 原链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/tensor/manipulation/strided_slice_cn.html

transpose 原链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/layers_cn/transpose_cn.html