### PR TITLE
[oneDNN] Doc on how keys used for oneDNN cache are made of

### DIFF
--- a/doc/fluid/design/mkldnn/caching/caching.md
+++ b/doc/fluid/design/mkldnn/caching/caching.md
@@ -6,7 +6,7 @@ Fluid MKL-DNN integration is having caching mechanism to store MKL-DNN objects. 
 
 ### 1. General architecture
 Basic idea is that MKL-DNN cache is hash map where [key](./keys.md) name is pointing to MKL-DNN object stored in mentioned hash map.
-In more detail MKL-DNN Cache is stored inside MKL-DNN Device Context and it consists of three level of unordered maps based structure. Picture below outlines mentioned architecture:
+In more detail MKL-DNN Cache is stored inside MKL-DNN Device Context and it consists of three levels of unordered maps based structure. Picture below outlines mentioned architecture:
 
 ![](images/cache.svg)
 

--- a/doc/fluid/design/mkldnn/caching/caching.md
+++ b/doc/fluid/design/mkldnn/caching/caching.md
@@ -10,17 +10,17 @@ In more detail MKL-DNN Cache is stored inside MKL-DNN Device Context and it cons
 
 ![](images/cache.svg)
 
-MKL-DNN cache is to work in both single-threaded and multi-threaded execution scenarios (both inference and training) as well as in a situation when memory constraints are applied. To address memory constraint problem, clear cache mode was introduced. 
+MKL-DNN cache is to work in both single-threaded and multi-threaded execution scenarios (both inference and training) as well as in a situation when memory constraints are applied. To address memory constraint problem, clear cache mode was introduced.
 
 To make MKL-DNN cache working with multi-threading scenarios:
-* Top level cache separates entries per session 
+* Top level cache separates entries per session
 * reading and modifying operations on MKL-DNN cache are ensured to be thread safe
 * cache key contains Thread ID (when applicable)
 
 The design of MKL-DNN cache is to support dynamic shapes scenario (BERT model for example). Since MKLDNN primitives are sensitive to src/dst shape, if new input shape comes, new primitive needs to be created. That means there will be many primitives cached and MKL-DNN cache would consume lots of memory. By introducing second level cache, we can consider these kind of primitive as a group, once reach memory limitation, we can clear a whole group instead of just one primitive, and release more memory.
 
-Performance-wise it is better to clear group of primitives at once rather than to erase one primitive based on FIFO. More over when searching a cache it is also more efficient to have grouped primitives via input shape , so 
-we referring to specific primitive we consider only primitives in a group not all registered MKL-DNN cached objects. 
+Performance-wise it is better to clear group of primitives at once rather than to erase one primitive based on FIFO. More over when searching a cache it is also more efficient to have grouped primitives via input shape , so
+we referring to specific primitive we consider only primitives in a group not all registered MKL-DNN cached objects.
 
 Currently model's input shape that is a key for second level cache is not related to input shape which is part of key in first level cache.
 
@@ -29,7 +29,7 @@ Cache default mode is normal operating mode of MKL-DNN cache, suitable for singl
 
 Cache clearing mode is a special operation mode designed for single threaded usage e.g. (Thread ID is not part of cache key). In this mode when set capacity of cache is to be exceeded (by adding next entry) then the registered entries corresponding to oldest input shape used by PaddlePaddle in given session , are erased (Refer to  _section b._ for details on erasing cache entries based on input shape). Input shape is registered as a key for second level cache in _AnalysisPredictor::MkldnnPreSet()_.
 
-##### b. Adding object to MKL-DNN cache 
+##### b. Adding object to MKL-DNN cache
 
 Picture |  Description
 ---------------|---------------------------------------------------
@@ -42,23 +42,23 @@ Picture |  Description
 ![](images/get_blob.svg) | Getting an cached objected (given by key (name) is done via <br/>_GetBlob_ method. General idea e.g. traversing through three <br/>level cache is the same as in _SetBlob_ it is just in case of when cached object (of any cache level) does not exist then null object is returned.
 
 ### 2. Clearing MKL-DNN cache
-MKL-DNN cache clearing is a solution created to address situation when memory consumed by cache outgrown physically available resources on given instance (Virtual Machine running PaddlePaddle). 
+MKL-DNN cache clearing is a solution created to address situation when memory consumed by cache outgrown physically available resources on given instance (Virtual Machine running PaddlePaddle).
 
 MKL-DNN Device context provide a method for erasing cache entries eg. _MKLDNNDeviceContext::ResetBlobMap()_. Currently _ResetBlobMap()_ is used in two situations:
-* Inference of integer based MKL-DNN models 
+* Inference of integer based MKL-DNN models
 * Releasing Executor object.
-* Cache clear mode 
+* Cache clear mode
 
-##### a. Inference of integer based MKL-DNN models 
+##### a. Inference of integer based MKL-DNN models
 Execution of Int8 MKL-DNN models consists of two stages:
 * Warm-up up run
 * Int8 inference execution
 
 At warm-up stage FP32 inference is performed and range of signal and weights is gathered for MKL-DNN kernels that are having int8 implementation. Based on recorded ranges , scale parameters are determined to be passed to MKL-DNN
 int8 primitives. This stage is executed by FP32 kernels and once Int8 inference execution starts we no longer need to have cached FP32 MKL-DNN primitives. This is the reason why clearing of cache is called after warm-up run stage.
- 
+
 ##### b. Releasing Executor object
-Additionally erasing MKL-DNN cache is performed when Executor object is to be destroyed. Here clearing procedure was introduced to enforce having empty MKL-DNN cache when starting to execute MKL-DNN unit tests. 
+Additionally erasing MKL-DNN cache is performed when Executor object is to be destroyed. Here clearing procedure was introduced to enforce having empty MKL-DNN cache when starting to execute MKL-DNN unit tests.
 To be more precise MKL-DNN unit tests file like *test_conv2d_mkldnn_op.py* are containing number of testing scenarios. Without clearing the MKL-DNN cache all of those tests are sharing cached primitives. This is totally not needed
 and made an impact on shape of hashing key, which was modified (extended) to make sure cached primitive is not reused for a situation when it should be recreated. In other words unit tests are sharing input and output
 names of Tensors which require that hash key is equipped with attributes data of given MKL-DNN primitive to avoid false reusing of MKL-DNN primitives. Hence in order not too complicate hashing key Clearing of cache was
@@ -76,9 +76,9 @@ Cache clearing mode is to use in single-threaded scenario where available memory
 Best performance of MKL-DNN kernels is achieved when efficient data arrangement (memory layout) is used as a holder for input/output memory objects and when
 number of conversions (reorders) among memory objects is limited to minimum (Not much time is wasted on rearranging data).
 Choosing optimal memory layout is done by allowing MKL-DNN computationally heavy primitives (convolution, Inner Product) to choose best memory arrangement based on requested size of data,  attributes of algorithm to be executed and architecture of platform. To help limit number of conversions (reorders), information on chosen memory layout and chosen MKL-DNN implementation, is shared among Forward and backward (grad) kernels of given operator instance. In particular forward MKL-DNN kernel decides which MKL-DNN implementation to use and then its decision (in a form of MKL-DNN primitive descriptor) is send to backward MKL-DNN operator. Transfer of MKL-DNN primitive descriptor from
-Forward to backward kernel is done via Caching mechanism. 
+Forward to backward kernel is done via Caching mechanism.
 
-Also MKL-DNN caching mechanism is used for transferring whole MKL-DNN memory allocations when there is no Tensor connecting Forward and Backward kernels available to be used for that purpose. An example could be a workspace MKL-DNN memory object in pooling (Max pooling) MKL-DNN kernel which transfers indices of maximal values (inside each pooling window) to the backward kernel where those indices are utilized for fast backward pooling computation. 
+Also MKL-DNN caching mechanism is used for transferring whole MKL-DNN memory allocations when there is no Tensor connecting Forward and Backward kernels available to be used for that purpose. An example could be a workspace MKL-DNN memory object in pooling (Max pooling) MKL-DNN kernel which transfers indices of maximal values (inside each pooling window) to the backward kernel where those indices are utilized for fast backward pooling computation.
 
 
 ##### Note on multi threading execution scenario
@@ -88,4 +88,4 @@ ensure MKL-DNN cache consistency.
 
 ### 4. Store once created MKL-DNN objects in order To avoid MKL-DNN recreation
 While MKL-DNN computational algorithms are fast to be executed, preparing to execution e.g. Creation of computational primitives and its primitive descriptors takes significant time (From 2% up to 40% for latency mode inference, depends on Platform instruction sets and MKL-DNN version). We can save some time on recreation
-of computational MKL-DNN primitives and its primitive descriptors, by storing once created MKL-DNN objects in a cache and refer to them in subsequent iterations when needed. 
+of computational MKL-DNN primitives and its primitive descriptors, by storing once created MKL-DNN objects in a cache and refer to them in subsequent iterations when needed.

--- a/doc/fluid/design/mkldnn/caching/caching.md
+++ b/doc/fluid/design/mkldnn/caching/caching.md
@@ -5,7 +5,7 @@ Fluid MKL-DNN integration is having caching mechanism to store MKL-DNN objects. 
 * Store once created MKL-DNN objects in order To avoid MKL-DNN recreation
 
 ### 1. General architecture
-Basic idea is that MKL-DNN cache is hash map where key name is pointing to MKL-DNN object stored in mentioned hash map.
+Basic idea is that MKL-DNN cache is hash map where [key](./keys.md) name is pointing to MKL-DNN object stored in mentioned hash map.
 In more detail MKL-DNN Cache is stored inside MKL-DNN Device Context and it consists of three level of unordered maps based structure. Picture below outlines mentioned architecture:
 
 ![](images/cache.svg)

--- a/doc/fluid/design/mkldnn/caching/index_en.rst
+++ b/doc/fluid/design/mkldnn/caching/index_en.rst
@@ -5,3 +5,4 @@ MKL-DNN Data Caching
   :maxdepth: 1
 
   caching.md
+  keys.md

--- a/doc/fluid/design/mkldnn/caching/keys.md
+++ b/doc/fluid/design/mkldnn/caching/keys.md
@@ -1,6 +1,6 @@
 # Design Doc: MKL-DNN Data Caching Keys
 
-[Caching](./caching.md) is a mechanism using associative objects so there is a key and stored value. This document describes ideas behind the 
+[Caching](./caching.md) is a mechanism using associative objects so there is a key and stored value. This document describes ideas behind the
 construction of keys used for caching oneDNN objects. Maintaining of keys is an ongoing effort so they tend to evolve.
 
 Key may consist of a several elements:
@@ -12,7 +12,7 @@ Key may consist of a several elements:
 
 ### 1. Output tensor name
 The foundation of generation of a key is the name of output Tensor of given instance of operator. The reason for that is operators in PaddlePaddle are stateless. So for example
-the same kernel implementing convolution operation will be used regardless the shapes and attributes of convolution. In fact this kernel for different shapes, attributes, data format may require
+the same kernel implementing convolution operation will be used regardless of the shapes and attributes of convolution. In fact this kernel for different shapes, attributes, data format may require
 different oneDNN convolution primitive. As an instance of convolution is identified uniquely with name of its output tensor then this name of output tensor was used as part of the caching key.
 
 ### 2. Inplace information
@@ -29,10 +29,10 @@ Then given operator instance may process different input signal each iteration a
 we need to include input tensor shape information into the caching key.
 
 ### 3. Executor identification
-On a scenario when there are are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A, it
-is needed to also add information to they key on what model is executed to avoid a situation that weights of one model will be used for weights of other model. Model during inference is connected
+On a scenario when there are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A, it
+is needed to also add information to the key on what model is executed to avoid a situation that weights of one model will be used for weights of other model. Model during inference is connected
 to Executor or Naive Executor so part of the address of used Executor or Naive Executor is made a part of the key as well.
 
 ### 4. Thread information
-Thread based information is needed as PaddlePaddle is often used in a multi-threaded execution of model e.g. Parallel Executor where there are multiple threads executing a single model or a number of threads where each of them is executing its own model then it is needed to add to the information on Thread ID which is a hash of thread id (provided by C++ thread structures). This element is only applied when cache is working in a mode where
+Thread based information is needed as PaddlePaddle is often used in a multi-threaded execution of model e.g. Parallel Executor where there are multiple threads executing a single model or a number of threads where each of them is executing its own model. Then it is needed to add to the key an information about Thread ID which is a hash of thread id (provided by C++ thread structures). This element is only applied when cache is working in a mode where
 multi threading is present.

--- a/doc/fluid/design/mkldnn/caching/keys.md
+++ b/doc/fluid/design/mkldnn/caching/keys.md
@@ -19,7 +19,7 @@ diffrent oneDNN convolution primitive. As instance of convolution is identified 
 One of situations when output tensor name is not enough to uniquely identify the instance of operator is when operators are performing [inplace](../inplace/inplace.md) execution. In this situation
 one of inputs and one of outputs of operator are the same Paddle Tensor and its name is the same so it is not enough to uniquely indentify instance of operator. So for that situation
 operators supprting inplace execution mode are having its caching key extended as follows:
-* softmax's key is having an attribute of normalization added
+* softmax's key is having a value of attribute of normalization axe added
 * activation's key is having an enum determining type of activation added
 * elementwise_mul's key is having character "M" added
 

--- a/doc/fluid/design/mkldnn/caching/keys.md
+++ b/doc/fluid/design/mkldnn/caching/keys.md
@@ -29,7 +29,7 @@ Then given operator instance may process diffrent input signal each iteration an
 we need to include input tensor shape information into caching key.
 
 ### 3. Executor identification
-On a scenario when there are are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A , it 
+On a scenario when there are are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A , it
 is needed to also add information to they key on what model is executed to avoid sitation that weights of one model will be used for weights of other model. Model during inference is connected
 to Executor or Naive Executor so part of address of used Executor or Naive Executor is made a part of key as well.
 
@@ -37,5 +37,3 @@ to Executor or Naive Executor so part of address of used Executor or Naive Execu
 When there is a multi-threaded execution of model e.g. Paralel Executor where there are multiple threads executing single model or number of threads where each of them is executing its own model
 then it is needed to add to the information on Thread ID which is a hash of thread id (provided by C++ thread structures). This element is only aplied when cache is working in a mode where
 multi threading is present.
-
-

--- a/doc/fluid/design/mkldnn/caching/keys.md
+++ b/doc/fluid/design/mkldnn/caching/keys.md
@@ -1,0 +1,41 @@
+# Design Doc: MKL-DNN Data Caching Keys
+
+[Caching](./caching.md) is a mechanism using associative objects so there is a key and stored value. This document describe ideas behind
+construction of keys used for caching oneDNN objects. Maintaining of keys is an ongoing effort so they tend to evolve.
+
+Key may consists of a several elements:
+* Output tensor name
+* Inplace information
+* Input shape
+* Executor identification
+* Thread information
+
+### 1. Output tensor name
+The foundation of generation of key is name of output Tensor of given instance of operator. The reason for that is operators in PaddlePaddle are stateless. So for example
+the same kernel implementing convolution operation will be used regardless the shapes and attributes of convolution. In practice this kernel for diffrent shapes, attributes, data format may require
+diffrent oneDNN convolution primitive. As instance of convolution is identified uniquely with name of its output tensor then this name of output tensor was used as part of caching key.
+
+### 2. Inplace information
+One of situations when output tensor name is not enough to uniquely identify the instance of operator is when operators are performing [inplace](../inplace/inplace.md) execution. In this situation
+one of inputs and one of outputs of operator are the same Paddle Tensor and its name is the same so it is not enough to uniquely indentify instance of operator. So for that situation
+operators supprting inplace execution mode are having its caching key extended as follows:
+* softmax's key is having an attribute of normalization added
+* activation's key is having an enum determining type of activation added
+* elementwise_mul's key is having character "M" added
+
+### 3. input shape
+Another situation is when PaddlePaddle is executing a model where the input shape can vary from iteration to iteration . This happens with NLP (BERT, ERNIE) models.
+Then given operator instance may process diffrent input signal each iteration and oneDNN primitive potentialy may use diffrent implementation , so to stay on save side
+we need to include input tensor shape information into caching key.
+
+### 3. Executor identification
+On a scenario when there are are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A , it 
+is needed to also add information to they key on what model is executed to avoid sitation that weights of one model will be used for weights of other model. Model during inference is connected
+to Executor or Naive Executor so part of address of used Executor or Naive Executor is made a part of key as well.
+
+### 4. Thread information
+When there is a multi-threaded execution of model e.g. Paralel Executor where there are multiple threads executing single model or number of threads where each of them is executing its own model
+then it is needed to add to the information on Thread ID which is a hash of thread id (provided by C++ thread structures). This element is only aplied when cache is working in a mode where
+multi threading is present.
+
+

--- a/doc/fluid/design/mkldnn/caching/keys.md
+++ b/doc/fluid/design/mkldnn/caching/keys.md
@@ -1,9 +1,9 @@
 # Design Doc: MKL-DNN Data Caching Keys
 
-[Caching](./caching.md) is a mechanism using associative objects so there is a key and stored value. This document describe ideas behind
+[Caching](./caching.md) is a mechanism using associative objects so there is a key and stored value. This document describes ideas behind the 
 construction of keys used for caching oneDNN objects. Maintaining of keys is an ongoing effort so they tend to evolve.
 
-Key may consists of a several elements:
+Key may consist of a several elements:
 * Output tensor name
 * Inplace information
 * Input shape
@@ -11,29 +11,28 @@ Key may consists of a several elements:
 * Thread information
 
 ### 1. Output tensor name
-The foundation of generation of key is name of output Tensor of given instance of operator. The reason for that is operators in PaddlePaddle are stateless. So for example
-the same kernel implementing convolution operation will be used regardless the shapes and attributes of convolution. In practice this kernel for diffrent shapes, attributes, data format may require
-diffrent oneDNN convolution primitive. As instance of convolution is identified uniquely with name of its output tensor then this name of output tensor was used as part of caching key.
+The foundation of generation of a key is the name of output Tensor of given instance of operator. The reason for that is operators in PaddlePaddle are stateless. So for example
+the same kernel implementing convolution operation will be used regardless the shapes and attributes of convolution. In fact this kernel for different shapes, attributes, data format may require
+different oneDNN convolution primitive. As an instance of convolution is identified uniquely with name of its output tensor then this name of output tensor was used as part of the caching key.
 
 ### 2. Inplace information
-One of situations when output tensor name is not enough to uniquely identify the instance of operator is when operators are performing [inplace](../inplace/inplace.md) execution. In this situation
-one of inputs and one of outputs of operator are the same Paddle Tensor and its name is the same so it is not enough to uniquely indentify instance of operator. So for that situation
-operators supprting inplace execution mode are having its caching key extended as follows:
-* softmax's key is having a value of attribute of normalization axe added
-* activation's key is having an enum determining type of activation added
-* elementwise_mul's key is having character "M" added
+One of situations when output tensor name is not enough to uniquely identify the instance of the operator is when operators are performing [inplace](../inplace/inplace.md) execution. In this situation
+one of inputs and one of outputs of the operator are the same Paddle Tensor and its name is the same so it is not enough to uniquely identify the instance of an operator. So for that situation
+operators supporting inplace execution mode are having its caching key extended as follows:
+* softmax's key is having a value of normalization axe attribute added
+* activation's key is having an enum determining the type of activation added
+* elementwise mul's key is having character "M" added
 
 ### 3. input shape
-Another situation is when PaddlePaddle is executing a model where the input shape can vary from iteration to iteration . This happens with NLP (BERT, ERNIE) models.
-Then given operator instance may process diffrent input signal each iteration and oneDNN primitive potentialy may use diffrent implementation , so to stay on save side
-we need to include input tensor shape information into caching key.
+Another situation is when PaddlePaddle is executing a model where the input shape can vary from iteration to iteration. This happens with NLP (BERT, ERNIE) models.
+Then given operator instance may process different input signal each iteration and oneDNN primitive potentially may use a different implementation , so to stay on save side
+we need to include input tensor shape information into the caching key.
 
 ### 3. Executor identification
-On a scenario when there are are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A , it
-is needed to also add information to they key on what model is executed to avoid sitation that weights of one model will be used for weights of other model. Model during inference is connected
-to Executor or Naive Executor so part of address of used Executor or Naive Executor is made a part of key as well.
+On a scenario when there are are multiple models executed in a interleaved mode e.g. one iteration of model A followed by one iteration of model B and then again one iteration of model A, it
+is needed to also add information to they key on what model is executed to avoid a situation that weights of one model will be used for weights of other model. Model during inference is connected
+to Executor or Naive Executor so part of the address of used Executor or Naive Executor is made a part of the key as well.
 
 ### 4. Thread information
-When there is a multi-threaded execution of model e.g. Paralel Executor where there are multiple threads executing single model or number of threads where each of them is executing its own model
-then it is needed to add to the information on Thread ID which is a hash of thread id (provided by C++ thread structures). This element is only aplied when cache is working in a mode where
+Thread based information is needed as PaddlePaddle is often used in a multi-threaded execution of model e.g. Parallel Executor where there are multiple threads executing a single model or a number of threads where each of them is executing its own model then it is needed to add to the information on Thread ID which is a hash of thread id (provided by C++ thread structures). This element is only applied when cache is working in a mode where
 multi threading is present.


### PR DESCRIPTION
This PR is adding an article on how keys used for caching mechanism of oneDNN objects are created.

Rendered version of document:
https://github.com/jczaja/FluidDoc/blob/prv-keys/doc/fluid/design/mkldnn/caching/keys.md