### PR TITLE
Add cn docs for conv1d, conv1d_transpose, Conv1D and Conv1DTranspose

### DIFF
--- a/doc/paddle/api/paddle/nn/functional/conv/conv1d_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/conv/conv1d_cn.rst
@@ -1,0 +1,101 @@
+conv1d
+-------------------------------
+
+.. py:function:: paddle.nn.functional.conv1d(x, weight, bias=None, stride=1, padding=0, dilation=1, groups=1, data_format="NCL", name=None)
+
+该OP是一维卷积层（convolution1d layer），根据输入、卷积核、步长（stride）、填充（padding）、空洞大小（dilation）一组参数计算输出特征层大小。输入和输出是NCL或NLC格式，其中N是批尺寸，C是通道数，L是长度。卷积核是MCL格式，M是输出图像通道数，C是输入图像通道数，L是卷积核长度。如果组数(groups)大于1，C等于输入图像通道数除以组数的结果。详情请参考UFLDL's : `卷积 <http://ufldl.stanford.edu/tutorial/supervised/FeatureExtractionUsingConvolution/>`_ 。如果bias_attr不为False，卷积计算会添加偏置项。如果指定了激活函数类型，相应的激活函数会作用在最终结果上。
+
+对每个输入X，有等式：
+
+.. math::
+
+    Out = \sigma \left ( W * X + b \right )
+
+其中：
+    - :math:`X` ：输入值，NCL或NLC格式的3-D Tensor
+    - :math:`W` ：卷积核值，MCL格式的3-D Tensor
+    - :math:`*` ：卷积操作
+    - :math:`b` ：偏置值，2-D Tensor，形状为 ``[M,1]``
+    - :math:`\sigma` ：激活函数
+    - :math:`Out` ：输出值，NCL或NLC格式的3-D Tensor， 和 ``X`` 的形状可能不同
+
+**示例**
+
+- 输入：
+
+  输入形状：:math:`（N,C_{in},L_{in}）`
+
+  卷积核形状： :math:`（C_{out},C_{in},L_{f}}）`
+
+- 输出：
+
+  输出形状： :math:`（N,C_{out},L_{out}）`
+
+其中
+
+.. math::
+
+    L_{out} &= \frac{\left ( L_{in} + padding * 2 - \left ( dilation*\left ( L_{f}-1 \right )+1 \right ) \right )}{stride}+1
+
+如果 ``padding`` = "SAME":
+
+.. math::
+    L_{out} = \frac{(L_{in} + stride - 1)}{stride}
+
+如果 ``padding`` = "VALID":
+
+.. math::
+    L_{out} = \frac{\left ( L_{in} -\left ( dilation*\left ( L_{f}-1 \right )+1 \right ) \right )}{stride}+1
+
+参数：
+    - **x** (Tensor) - 输入是形状为 :math:`[N, C, L]` 或 :math:`[N, L, C]` 的4-D Tensor，N是批尺寸，C是通道数，L是特征长度，数据类型为float16, float32或float64。
+    - **weight** (Tensor)) - 形状为 :math:`[M, C/g, kL]` 的卷积核。 M是输出通道数， g是分组的个数，kL是卷积核的长度度。
+    - **bias** (int|list|tuple) - 偏置项，形状为： :math:`[M,]` 。
+    - **stride** (int|list|tuple，可选) - 步长大小。卷积核和输入进行卷积计算时滑动的步长。整数或包含一个整数的列表或元组。默认值：1。
+    - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
+    - **dilation** (int|list|tuple，可选) - 空洞大小。空洞卷积时会使用该参数，卷积核对输入进行卷积时，感受野里每相邻两个特征点之间的空洞信息。整数或包含一个整型数的列表或元组。默认值：1。
+    - **groups** (int，可选) - 一维卷积层的组数。根据Alex Krizhevsky的深度卷积神经网络（CNN）论文中的成组卷积：当group=n，输入和卷积核分别根据通道数量平均分为n组，第一组卷积核和第一组输入进行卷积计算，第二组卷积核和第二组输入进行卷积计算，……，第n组卷积核和第n组输入进行卷积计算。默认值：1。
+    - **weight_attr** (ParamAttr，可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **bias_attr** （ParamAttr|bool，可选）- 指定偏置参数属性的对象。若 ``bias_attr`` 为bool类型，只支持为False，表示没有偏置参数。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是"NCL"和"NLC"。N是批尺寸，C是通道数，L是特征长度。默认值："NCL"。
+    - **name** (str，可选) – 具体用法请参见 :ref:`cn_api_guide_Name` ，一般无需设置，默认值：None。
+
+返回：3-D Tensor，数据类型与 ``x`` 一致。返回卷积的结果。
+
+返回类型：Tensor。
+
+抛出异常：
+    - ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
+    - ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
+    - ``ShapeError`` - 如果输入不是3-D Tensor。
+    - ``ShapeError`` - 如果输入和卷积核的维度大小不相同。
+    - ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
+    - ``ShapeError`` - 如果输出的通道数不能被 ``groups`` 整除。
+
+
+**代码示例**：
+
+.. code-block:: python
+    import paddle
+    import paddle.nn.functional as F
+    import numpy as np
+    x = np.array([[[4, 8, 1, 9],
+      [7, 2, 0, 9],
+      [6, 9, 2, 6]]]).astype(np.float32)
+    w=np.array(
+    [[[9, 3, 4],
+      [0, 0, 7],
+      [2, 5, 6]],
+     [[0, 3, 4],
+      [2, 9, 7],
+      [5, 6, 8]]]).astype(np.float32)
+    
+    x_var = paddle.to_tensor(x)
+    w_var = paddle.to_tensor(w)
+    y_var = F.conv1d(x_var, w_var)
+    y_np = y_var.numpy()
+    print(y_np)
+    
+    # [[[133. 238.]
+    #   [160. 211.]]]
+

--- a/doc/paddle/api/paddle/nn/functional/conv/conv1d_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/conv/conv1d_cn.rst
@@ -1,3 +1,5 @@
+.. _cn_api_nn_functional_conv1d:
+
 conv1d
 -------------------------------
 
@@ -50,27 +52,15 @@ conv1d
 参数：
     - **x** (Tensor) - 输入是形状为 :math:`[N, C, L]` 或 :math:`[N, L, C]` 的4-D Tensor，N是批尺寸，C是通道数，L是特征长度，数据类型为float16, float32或float64。
     - **weight** (Tensor)) - 形状为 :math:`[M, C/g, kL]` 的卷积核。 M是输出通道数， g是分组的个数，kL是卷积核的长度度。
-    - **bias** (int|list|tuple) - 偏置项，形状为： :math:`[M,]` 。
+    - **bias** (int|list|tuple，可选) - 偏置项，形状为： :math:`[M,]` 。
     - **stride** (int|list|tuple，可选) - 步长大小。卷积核和输入进行卷积计算时滑动的步长。整数或包含一个整数的列表或元组。默认值：1。
     - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
     - **dilation** (int|list|tuple，可选) - 空洞大小。空洞卷积时会使用该参数，卷积核对输入进行卷积时，感受野里每相邻两个特征点之间的空洞信息。整数或包含一个整型数的列表或元组。默认值：1。
     - **groups** (int，可选) - 一维卷积层的组数。根据Alex Krizhevsky的深度卷积神经网络（CNN）论文中的成组卷积：当group=n，输入和卷积核分别根据通道数量平均分为n组，第一组卷积核和第一组输入进行卷积计算，第二组卷积核和第二组输入进行卷积计算，……，第n组卷积核和第n组输入进行卷积计算。默认值：1。
-    - **weight_attr** (ParamAttr，可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
-    - **bias_attr** （ParamAttr|bool，可选）- 指定偏置参数属性的对象。若 ``bias_attr`` 为bool类型，只支持为False，表示没有偏置参数。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是"NCL"和"NLC"。N是批尺寸，C是通道数，L是特征长度。默认值："NCL"。
     - **name** (str，可选) – 具体用法请参见 :ref:`cn_api_guide_Name` ，一般无需设置，默认值：None。
 
 返回：3-D Tensor，数据类型与 ``x`` 一致。返回卷积的结果。
-
-返回类型：Tensor。
-
-抛出异常：
-    - ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
-    - ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
-    - ``ShapeError`` - 如果输入不是3-D Tensor。
-    - ``ShapeError`` - 如果输入和卷积核的维度大小不相同。
-    - ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
-    - ``ShapeError`` - 如果输出的通道数不能被 ``groups`` 整除。
 
 
 **代码示例**：

--- a/doc/paddle/api/paddle/nn/functional/conv/conv1d_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/conv/conv1d_cn.rst
@@ -25,7 +25,7 @@ conv1d
 
   输入形状：:math:`（N,C_{in},L_{in}）`
 
-  卷积核形状： :math:`（C_{out},C_{in},L_{f}}）`
+  卷积核形状： :math:`（C_{out},C_{in},L_{f}）`
 
 - 输出：
 
@@ -35,7 +35,7 @@ conv1d
 
 .. math::
 
-    L_{out} &= \frac{\left ( L_{in} + padding * 2 - \left ( dilation*\left ( L_{f}-1 \right )+1 \right ) \right )}{stride}+1
+    L_{out} = \frac{\left ( L_{in} + padding * 2 - \left ( dilation*\left ( L_{f}-1 \right )+1 \right ) \right )}{stride}+1
 
 如果 ``padding`` = "SAME":
 
@@ -76,6 +76,7 @@ conv1d
 **代码示例**：
 
 .. code-block:: python
+
     import paddle
     import paddle.nn.functional as F
     import numpy as np

--- a/doc/paddle/api/paddle/nn/functional/conv/conv1d_transpose_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/conv/conv1d_transpose_cn.rst
@@ -33,11 +33,11 @@ conv1d_transpose
 
     输入Tensor的形状： :math:`（N，C_{in}， L_{in}）`
 
-    卷积核的形状 ： :math:`（C_{in}, C_{out}, L_f）`
+    卷积核的形状 ： :math:`（C_{in}， C_{out}， L_f）`
 
 - 输出：
 
-    输出Tensor的形状 ： :math:`（N，C_{out}, L_{out}）`
+    输出Tensor的形状 ： :math:`（N，C_{out}， L_{out}）`
 
 其中
 
@@ -49,12 +49,14 @@ conv1d_transpose
 如果 ``padding`` = "SAME":
 
 .. math::
-   & L'_{out} = \frac{(L_{in} + stride - 1)}{stride}
+
+   L'_{out} = \frac{(L_{in} + stride - 1)}{stride}
 
 如果 ``padding`` = "VALID":
 
 .. math::
-    & L'_{out} = (L_{in}-1)*stride + dilation*(L_f-1)+1
+
+    L'_{out} = (L_{in}-1)*stride + dilation*(L_f-1)+1
 
 注意：
 

--- a/doc/paddle/api/paddle/nn/functional/conv/conv1d_transpose_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/conv/conv1d_transpose_cn.rst
@@ -1,0 +1,112 @@
+
+conv1d_transpose
+-------------------------------
+
+
+.. py:function:: paddle.nn.functional.conv1d_transpose(x, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1, output_size=None, data_format='NCL', name=None)
+
+
+
+一维转置卷积层（Convlution1D transpose layer）
+
+该层根据输入（input）、卷积核（kernel）和空洞大小（dilations）、步长（stride）、填充（padding）来计算输出特征层大小或者通过output_size指定输出特征层大小。输入(Input)和输出(Output)为NCL或NLC格式，其中N为批尺寸，C为通道数（channel），L为特征层长度。卷积核是MCL格式，M是输出图像通道数，C是输入图像通道数，L是卷积核长度。如果组数大于1，C等于输入图像通道数除以组数的结果。转置卷积的计算过程相当于卷积的反向计算。转置卷积又被称为反卷积（但其实并不是真正的反卷积）。欲了解转置卷积层细节，请参考下面的说明和 参考文献_ 。如果参数bias_attr不为False, 转置卷积计算会添加偏置项。如果act不为None，则转置卷积计算之后添加相应的激活函数。
+
+.. _参考文献: https://arxiv.org/pdf/1603.07285.pdf
+
+
+输入 :math:`X` 和输出 :math:`Out` 函数关系如下：
+
+.. math::
+                        Out=\sigma (W*X+b)\\
+
+其中：
+    -  :math:`X` : 输入，具有NCL或NLC格式的3-D Tensor
+    -  :math:`W` : 卷积核，具有NCL格式的3-D Tensor
+    -  :math:`*` : 卷积计算（注意：转置卷积本质上的计算还是卷积）
+    -  :math:`b` : 偏置（bias），2-D Tensor，形状为 ``[M,1]``
+    -  :math:`σ` : 激活函数
+    -  :math:`Out` : 输出值，NCL或NLC格式的3-D Tensor， 和 ``X`` 的形状可能不同
+
+**示例**
+
+- 输入：
+
+    输入Tensor的形状： :math:`（N，C_{in}， L_{in}）`
+
+    卷积核的形状 ： :math:`（C_{in}, C_{out}, L_f）`
+
+- 输出：
+
+    输出Tensor的形状 ： :math:`（N，C_{out}, L_{out}）`
+
+其中
+
+.. math::
+
+        & L'_{out} = (L_{in}-1)*stride - padding * 2 + dilation*(L_f-1)+1\\
+        & L_{out}\in[L'_{out},L'_{out} + stride)
+
+如果 ``padding`` = "SAME":
+
+.. math::
+   & L'_{out} = \frac{(L_{in} + stride - 1)}{stride}
+
+如果 ``padding`` = "VALID":
+
+.. math::
+    & L'_{out} = (L_{in}-1)*stride + dilation*(L_f-1)+1
+
+注意：
+
+如果output_size为None，则 :math:`L_{out}` = :math:`L^\prime_{out}` ;否则，指定的output_size（输出特征层的长度） :math:`L_{out}` 应当介于 :math:`L^\prime_{out}` 和 :math:`L^\prime_{out} + stride` 之间（不包含 :math:`L^\prime_{out} + stride` ）。
+
+由于转置卷积可以当成是卷积的反向计算，而根据卷积的输入输出计算公式来说，不同大小的输入特征层可能对应着相同大小的输出特征层，所以对应到转置卷积来说，固定大小的输入特征层对应的输出特征层大小并不唯一。
+
+如果指定了output_size， ``conv1d_transpose`` 可以自动计算卷积核的大小。
+
+参数:
+  - **x** (Tensor) - 输入是形状为 :math:`[N, C, L]` 或 :math:`[N, L, C]` 的3-D Tensor，N是批尺寸，C是通道数，L是特征长度，数据类型为float16, float32或float64。
+  - **weight** (Tensor) - 形状为 :math:`[C, M/g, kL]` 的卷积核（卷积核）。 M是输出通道数， g是分组的个数，kL是卷积核的长度。
+  - **bias** (int|list|tuple) - 偏置项，形状为： :math:`[M,]` 。
+  - **stride** (int|list|tuple，可选) - 步长大小。整数或包含一个整数的列表或元组。默认值：1。
+    - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
+  - **output_padding** (int|list|tuple, optional): 输出形状上尾部一侧额外添加的大小. 默认值: 0.
+  - **groups** (int，可选) - 一维卷积层的组数。根据Alex Krizhevsky的深度卷积神经网络（CNN）论文中的成组卷积：当group=n，输入和卷积核分别根据通道数量平均分为n组，第一组卷积核和第一组输入进行卷积计算，第二组卷积核和第二组输入进行卷积计算，……，第n组卷积核和第n组输入进行卷积计算。默认值：1。
+  - **dilation** (int|list|tuple，可选) - 空洞大小。空洞卷积时会使用该参数，卷积核对输入进行卷积时，感受野里每相邻两个特征点之间的空洞信息。整数或包含一个整数的列表或元组。默认值：1。
+  - **output_size** (int|list|tuple，可选) - 输出特征的长度，整数或包含一个整数的列表或元组。如果为 ``None`` , 则会用 ``filter_size``, ``padding`` 和 ``stride`` 计算出输出特征的长度。如果 ``output_size`` 和 ``filter_size`` 同时被指定，则会遵循上述公式进行计算。``output_size`` 和 ``filter_size`` 不能同时被设置为 ``None`` 。默认值：None。
+  - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是"NCL"和"NLC"。N是批尺寸，C是通道数，L是特征长度。默认值："NCL"。
+  - **name** (str，可选) – 具体用法请参见 :ref:`cn_api_guide_Name` ，一般无需设置，默认值：None。
+
+
+返回：3-D Tensor，数据类型与 ``input`` 一致。如果未指定激活层，则返回转置卷积计算的结果，如果指定激活层，则返回转置卷积和激活计算之后的最终结果。
+
+返回类型：Tensor
+
+抛出异常:
+    -  ``ValueError`` : 如果输入的shape、kernel_size、stride、padding和groups不匹配，抛出ValueError
+    -  ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
+    -  ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
+    -  ``ValueError`` - 如果 ``output_size`` 和 ``filter_size`` 同时为None。
+    -  ``ShapeError`` - 如果输入不是3-D Tensor。
+    -  ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
+
+**代码示例**
+
+..  code-block:: python
+
+    import paddle
+    import paddle.nn.functional as F
+    import numpy as np
+    
+    # shape: (1, 2, 4)
+    x=np.array([[[4, 0, 9, 7],
+                 [8, 0, 9, 2,]]]).astype(np.float32)
+    # shape: (2, 1, 2)
+    w=np.array([[[7, 0]],
+                [[4, 2]]]).astype(np.float32)
+    x_var = paddle.to_tensor(x)
+    w_var = paddle.to_tensor(w)
+    y_var = F.conv1d_transpose(x_var, w_var)
+    print(y_var)
+    
+    # [[[60. 16. 99. 75.  4.]]]

--- a/doc/paddle/api/paddle/nn/functional/conv/conv1d_transpose_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/conv/conv1d_transpose_cn.rst
@@ -1,3 +1,4 @@
+.. _cn_api_nn_functional_conv1d_transpose:
 
 conv1d_transpose
 -------------------------------
@@ -69,7 +70,7 @@ conv1d_transpose
 参数:
   - **x** (Tensor) - 输入是形状为 :math:`[N, C, L]` 或 :math:`[N, L, C]` 的3-D Tensor，N是批尺寸，C是通道数，L是特征长度，数据类型为float16, float32或float64。
   - **weight** (Tensor) - 形状为 :math:`[C, M/g, kL]` 的卷积核（卷积核）。 M是输出通道数， g是分组的个数，kL是卷积核的长度。
-  - **bias** (int|list|tuple) - 偏置项，形状为： :math:`[M,]` 。
+  - **bias** (int|list|tuple，可选) - 偏置项，形状为： :math:`[M,]` 。
   - **stride** (int|list|tuple，可选) - 步长大小。整数或包含一个整数的列表或元组。默认值：1。
     - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
   - **output_padding** (int|list|tuple, optional): 输出形状上尾部一侧额外添加的大小. 默认值: 0.
@@ -82,15 +83,6 @@ conv1d_transpose
 
 返回：3-D Tensor，数据类型与 ``input`` 一致。如果未指定激活层，则返回转置卷积计算的结果，如果指定激活层，则返回转置卷积和激活计算之后的最终结果。
 
-返回类型：Tensor
-
-抛出异常:
-    -  ``ValueError`` : 如果输入的shape、kernel_size、stride、padding和groups不匹配，抛出ValueError
-    -  ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
-    -  ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
-    -  ``ValueError`` - 如果 ``output_size`` 和 ``filter_size`` 同时为None。
-    -  ``ShapeError`` - 如果输入不是3-D Tensor。
-    -  ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
 
 **代码示例**
 

--- a/doc/paddle/api/paddle/nn/functional/vision/affine_grid_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/vision/affine_grid_cn.rst
@@ -1,31 +1,53 @@
-.. _cn_api_fluid_layers_affine_grid:
+.. _cn_api_nn_functional_affine_grid:
 
 affine_grid
 -------------------------------
 
-.. py:function:: paddle.fluid.layers.affine_grid(theta, out_shape, name=None)
-
-
+.. py:function:: paddle.nn.functional.affine_grid(theta, out_shape, align_corners=True, name=None)
 
 
 该OP用于生成仿射变换前后的feature maps的坐标映射关系。在视觉应用中，根据该OP得到的映射关系，将输入feature map的像素点变换到对应的坐标，就得到了经过仿射变换的feature map。
 
 参数：
-  - **theta** (Variable) - Shape为 ``[batch_size, 2, 3]`` 的Tensor，表示batch_size个 ``2X3`` 的变换矩阵。数据类型支持float32，float64。
-  - **out_shape** (Variable | list | tuple) - 类型可以是1-D Tensor、list或tuple。用于表示在仿射变换中的输出的shape，其格式 ``[N, C, H, W]`` ，分别为输出feature map的batch size、channel数量、高和宽。数据类型支持int32。
- - **name** (None|str) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:api_guide_Name ，默认值为None。
+  - **theta** (Tensor) - Shape为 ``[batch_size, 2, 3]`` 的Tensor，表示batch_size个 ``2X3`` 的变换矩阵。数据类型支持float32，float64。
+  - **out_shape** (Tensor | list | tuple) - 类型可以是1-D Tensor、list或tuple。用于表示在仿射变换中的输出的shape，其格式 ``[N, C, H, W]`` ，分别为输出feature map的batch size、channel数量、高和宽。数据类型支持int32。
+  - **align_corners** (bool, optional): 一个可选的bool型参数，如果为True，则将输入和输出张量的4个角落像素的中心对齐，并保留角点像素的值。 默认值：True。
+  - **name** (None|str) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:api_guide_Name ，默认值为None。
 
-返回： Variable。Shape为 ``[N, H, W, 2]`` 的4-D Tensor，表示仿射变换前后的坐标的映射关系。其中，N、H、W分别为仿射变换中输出feature map的batch size、高和宽。 数据类型与 ``theta`` 一致。
+返回： Tensor。Shape为 ``[N, H, W, 2]`` 的4-D Tensor，表示仿射变换前后的坐标的映射关系。其中，N、H、W分别为仿射变换中输出feature map的batch size、高和宽。 数据类型与 ``theta`` 一致。
 
-返回类型：Variable
+返回类型：Tensor
+
+抛出异常：
+    - ``ValueError`` - 如果输入参数类型不支持。
+
+
 
 **代码示例：**
 
 .. code-block:: python
 
-    import paddle.fluid as fluid
-    theta = fluid.layers.data(name="x", shape=[2, 3], dtype="float32")
-    out_shape = fluid.layers.data(name="y", shape=[-1], dtype="float32")
-    data = fluid.layers.affine_grid(theta, out_shape)
-    # or
-    data = fluid.layers.affine_grid(theta, [5, 3, 28, 28])
+   import paddle
+   import paddle.nn.functional as F
+   import numpy as np
+   # theta shape = [1, 2, 3]
+   theta = np.array([[[-0.7, -0.4, 0.3],
+                      [ 0.6,  0.5, 1.5]]]).astype("float32")
+   theta_t = paddle.to_tensor(theta)
+   y_t = F.affine_grid(
+           theta_t,
+           [1, 2, 3, 3],
+           align_corners=False)
+   print(y_t)
+   
+   #[[[[ 1.0333333   0.76666665]
+   #   [ 0.76666665  1.0999999 ]
+   #   [ 0.5         1.4333333 ]]
+   #
+   #  [[ 0.5666667   1.1666666 ]
+   #   [ 0.3         1.5       ]
+   #   [ 0.03333333  1.8333334 ]]
+   #
+   #  [[ 0.10000002  1.5666667 ]
+   #   [-0.16666666  1.9000001 ]
+   #   [-0.43333334  2.2333333 ]]]]

--- a/doc/paddle/api/paddle/nn/functional/vision/affine_grid_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/vision/affine_grid_cn.rst
@@ -12,7 +12,7 @@ affine_grid
   - **theta** (Tensor) - Shape为 ``[batch_size, 2, 3]`` 的Tensor，表示batch_size个 ``2X3`` 的变换矩阵。数据类型支持float32，float64。
   - **out_shape** (Tensor | list | tuple) - 类型可以是1-D Tensor、list或tuple。用于表示在仿射变换中的输出的shape，其格式 ``[N, C, H, W]`` ，分别为输出feature map的batch size、channel数量、高和宽。数据类型支持int32。
   - **align_corners** (bool, optional): 一个可选的bool型参数，如果为True，则将输入和输出张量的4个角落像素的中心对齐，并保留角点像素的值。 默认值：True。
-  - **name** (None|str) – 该参数供开发人员打印调试信息时使用，具体用法请参见 :ref:api_guide_Name ，默认值为None。
+  - **name** (None|str) – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置。默认值：None。
 
 返回： Tensor。Shape为 ``[N, H, W, 2]`` 的4-D Tensor，表示仿射变换前后的坐标的映射关系。其中，N、H、W分别为仿射变换中输出feature map的batch size、高和宽。 数据类型与 ``theta`` 一致。
 

--- a/doc/paddle/api/paddle/nn/functional/vision/affine_grid_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/vision/affine_grid_cn.rst
@@ -16,12 +16,6 @@ affine_grid
 
 返回： Tensor。Shape为 ``[N, H, W, 2]`` 的4-D Tensor，表示仿射变换前后的坐标的映射关系。其中，N、H、W分别为仿射变换中输出feature map的batch size、高和宽。 数据类型与 ``theta`` 一致。
 
-返回类型：Tensor
-
-抛出异常：
-    - ``ValueError`` - 如果输入参数类型不支持。
-
-
 
 **代码示例：**
 

--- a/doc/paddle/api/paddle/nn/functional/vision/grid_sample_cn.rst
+++ b/doc/paddle/api/paddle/nn/functional/vision/grid_sample_cn.rst
@@ -54,7 +54,7 @@ step 2：
 
 参数：
   - **x** (Tensor): 输入张量，维度为 :math:`[N, C, H, W]` 的4-D Tensor，N为批尺寸，C是通道数，H是特征高度，W是特征宽度, 数据类型为float32或float64。
-  - **grid** (Variable): 输入网格数据张量，维度为 :math:`[N, H, W, 2]` 的4-D Tensor，N为批尺寸，C是通道数，H是特征高度，W是特征宽度, 数据类型为float32或float64。
+  - **grid** (Tensor): 输入网格数据张量，维度为 :math:`[N, H, W, 2]` 的4-D Tensor，N为批尺寸，C是通道数，H是特征高度，W是特征宽度, 数据类型为float32或float64。
   - **mode** (str, optional): 插值方式，可以为 'bilinear' 或者 'nearest'. 默认值：'bilinear'。
   - **padding_mode** (str, optional) 当原来的索引超过输入的图像大小时的填充方式。可以为 'zeros', 'reflection' 和 'border'. 默认值：'zeros'。
   - **align_corners** (bool, optional): 一个可选的bool型参数，如果为True，则将输入和输出张量的4个角落像素的中心对齐，并保留角点像素的值。 默认值：True。
@@ -101,7 +101,7 @@ step 2：
         mode='bilinear',
         padding_mode='border',
         align_corners=True)
-    print(y_t.numpy())
+    print(y_t)
     
     # output shape = [1, 1, 3, 4]
     # [[[[ 0.34   0.016  0.086 -0.448]

--- a/doc/paddle/api/paddle/nn/layer/conv/Conv1DTranspose_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/conv/Conv1DTranspose_cn.rst
@@ -1,3 +1,5 @@
+.. _cn_api_paddle_nn_Conv1DTranspose:
+
 Conv1DTranspose
 -------------------------------
 
@@ -30,7 +32,7 @@ Conv1DTranspose
   - **out_channels** (int) - 卷积核的个数，和输出特征通道数相同。
   - **kernel_size** (int|list|tuple) - 卷积核大小。可以为单个整数或包含一个整数的元组或列表，表示卷积核的长度。
   - **stride** (int|tuple, 可选) - 步长大小。如果 ``stride`` 为元组或列表，则必须包含一个整型数，表示滑动步长 。默认值：1。
-    - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
+  - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
   - **output_padding** (int|list|tuple, optional): 输出特征尾部一侧额外添加的大小. 默认值: 0.
   - **groups** (int, 可选) - 一维卷积层的组数。根据Alex Krizhevsky的深度卷积神经网络（CNN）论文中的分组卷积：当group=2，卷积核的前一半仅和输入特征图的前一半连接。卷积核的后一半仅和输入特征图的后一半连接。默认值：1。
   - **dilation** (int|tuple, 可选) - 空洞大小。可以为单个整数或包含一个整数的元组或列表，表示卷积核中的空洞。默认值：1。
@@ -62,13 +64,6 @@ Conv1DTranspose
     .. math::
         L'_{out} = (L_{in}-1)*stride + dilation*(kernel\_size-1)+1
 
-抛出异常:
-    -  ``ValueError`` : 如果输入的shape、filter_size、stride、padding和groups不匹配，抛出ValueError
-    -  ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
-    -  ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
-    -  ``ShapeError`` - 如果输入不是3-D Tensor。
-    -  ``ShapeError`` - 如果输入和卷积核的维度大小不相同。
-    -  ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
 
 **代码示例**
 

--- a/doc/paddle/api/paddle/nn/layer/conv/Conv1DTranspose_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/conv/Conv1DTranspose_cn.rst
@@ -1,0 +1,91 @@
+Conv1DTranspose
+-------------------------------
+
+.. py:class:: paddle.nn.Conv1DTranspose(in_channels, out_channels, kernel_size, stride=1, padding=0, output_padding=0, groups=1, dilation=1, weight_attr=None, bias_attr=None, data_format="NCL")
+
+
+一维转置卷积层（Convlution1d transpose layer）
+
+该层根据输入（input）、卷积核（kernel）和空洞大小（dilations）、步长（stride）、填充（padding）来计算输出特征大小或者通过output_size指定输出特征层大小。输入(Input)和输出(Output)为NCL或NLC格式，其中N为批尺寸，C为通道数（channel），L为特征长度。卷积核是MCL格式，M是输出图像通道数，C是输入图像通道数，L是卷积核长度。如果组数大于1，C等于输入图像通道数除以组数的结果。转置卷积的计算过程相当于卷积的反向计算。转置卷积又被称为反卷积（但其实并不是真正的反卷积）。欲了解转置卷积层细节，请参考下面的说明和 参考文献_ 。如果参数bias_attr不为False, 转置卷积计算会添加偏置项。
+
+.. _参考文献: https://arxiv.org/pdf/1603.07285.pdf
+
+
+输入 :math:`X` 和输出 :math:`Out` 函数关系如下：
+
+.. math::
+                        Out=\sigma (W*X+b)\\
+
+其中：
+    -  :math:`X` : 输入，具有NCL或NLC格式的3-D Tensor
+    -  :math:`W` : 卷积核，具有NCL格式的3-D Tensor
+    -  :math:`*` : 卷积计算（注意：转置卷积本质上的计算还是卷积）
+    -  :math:`b` : 偏置（bias），2-D Tensor，形状为 ``[M,1]``
+    -  :math:`σ` : 激活函数
+    -  :math:`Out` : 输出值，NCL或NLC格式的3-D Tensor， 和 ``X`` 的形状可能不同
+
+
+参数:
+  - **in_channels** (int) - 输入特征的通道数。
+  - **out_channels** (int) - 卷积核的个数，和输出特征通道数相同。
+  - **kernel_size** (int|list|tuple) - 卷积核大小。可以为单个整数或包含一个整数的元组或列表，表示卷积核的长度。
+  - **stride** (int|tuple, 可选) - 步长大小。如果 ``stride`` 为元组或列表，则必须包含一个整型数，表示滑动步长 。默认值：1。
+    - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
+  - **output_padding** (int|list|tuple, optional): 输出特征尾部一侧额外添加的大小. 默认值: 0.
+  - **groups** (int, 可选) - 一维卷积层的组数。根据Alex Krizhevsky的深度卷积神经网络（CNN）论文中的分组卷积：当group=2，卷积核的前一半仅和输入特征图的前一半连接。卷积核的后一半仅和输入特征图的后一半连接。默认值：1。
+  - **dilation** (int|tuple, 可选) - 空洞大小。可以为单个整数或包含一个整数的元组或列表，表示卷积核中的空洞。默认值：1。
+  - **weight_attr** (ParamAttr, 可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+  - **bias_attr** (ParamAttr|bool, 可选) - 指定偏置参数属性的对象。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+  - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是"NCL"和"NLC"。N是批尺寸，C是通道数，L特征长度。默认值："NCL"。
+  
+
+形状:
+
+    - 输入：:math:`（N，C_{in}， L_{in}）`
+
+
+    - 输出：:math:`（N，C_{out}, L_{out}）`
+
+    其中
+
+    .. math::
+        & L'_{out} = (L_{in}-1)*stride - 2*padding + dilation*(kernel\_size-1)+1\\
+        & L_{out}\in[L'_{out},L'_{out} + stride)
+
+    如果 ``padding`` = "SAME":
+
+    .. math::
+        & L'_{out} = \frac{(L_{in} + stride - 1)}{stride}
+
+    如果 ``padding`` = "VALID":
+
+    .. math::
+        & L'_{out} = (L_{in}-1)*stride + dilation*(kernel\_size-1)+1
+
+抛出异常:
+    -  ``ValueError`` : 如果输入的shape、filter_size、stride、padding和groups不匹配，抛出ValueError
+    -  ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
+    -  ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
+    -  ``ShapeError`` - 如果输入不是3-D Tensor。
+    -  ``ShapeError`` - 如果输入和卷积核的维度大小不相同。
+    -  ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
+
+**代码示例**
+
+..  code-block:: python
+
+    import paddle
+    from paddle.nn import Conv1DTranspose
+    import numpy as np
+    
+    # shape: (1, 2, 4)
+    x=np.array([[[4, 0, 9, 7],
+                 [8, 0, 9, 2]]]).astype(np.float32)
+    # shape: (2, 1, 2)
+    y=np.array([[[7, 0]],
+                [[4, 2]]]).astype(np.float32)
+    x_t = paddle.to_tensor(x)
+    conv = Conv1DTranspose(2, 1, 2)
+    conv.weight.set_value(y)
+    y_t = conv(x_t)
+    print(y_t)

--- a/doc/paddle/api/paddle/nn/layer/conv/Conv1DTranspose_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/conv/Conv1DTranspose_cn.rst
@@ -44,7 +44,7 @@ Conv1DTranspose
     - 输入：:math:`（N，C_{in}， L_{in}）`
 
 
-    - 输出：:math:`（N，C_{out}, L_{out}）`
+    - 输出：:math:`（N，C_{out}， L_{out}）`
 
     其中
 
@@ -55,12 +55,12 @@ Conv1DTranspose
     如果 ``padding`` = "SAME":
 
     .. math::
-        & L'_{out} = \frac{(L_{in} + stride - 1)}{stride}
+        L'_{out} = \frac{(L_{in} + stride - 1)}{stride}
 
     如果 ``padding`` = "VALID":
 
     .. math::
-        & L'_{out} = (L_{in}-1)*stride + dilation*(kernel\_size-1)+1
+        L'_{out} = (L_{in}-1)*stride + dilation*(kernel\_size-1)+1
 
 抛出异常:
     -  ``ValueError`` : 如果输入的shape、filter_size、stride、padding和groups不匹配，抛出ValueError

--- a/doc/paddle/api/paddle/nn/layer/conv/Conv1D_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/conv/Conv1D_cn.rst
@@ -1,3 +1,5 @@
+.. _cn_api_paddle_nn_Conv1D:
+
 Conv1D
 -------------------------------
 
@@ -65,15 +67,6 @@ Conv1D
     .. math::
         L_{out} = \frac{\left ( L_{in} -\left ( dilation*\left ( kernel\_size-1 \right )+1 \right ) \right )}{stride}+1
 
-
-抛出异常：
-    - ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
-    - ``ValueError`` - 如果 ``input`` 的通道数未被明确定义。
-    - ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
-    - ``ShapeError`` - 如果输入不是3-D Tensor。
-    - ``ShapeError`` - 如果输入和卷积核的维度大小不相同。
-    - ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
-    - ``ShapeError`` - 如果输出的通道数不能被 ``groups`` 整除。
 
 
 **代码示例**：

--- a/doc/paddle/api/paddle/nn/layer/conv/Conv1D_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/conv/Conv1D_cn.rst
@@ -47,8 +47,8 @@ Conv1D
 本层的可学习偏置，类型为 ``Parameter``
     
 形状:
-    - 输入: :math:`(N, C_{in}, L_{in})`
-    - 输出: :math:`(N, C_{out}, L_{out})`
+    - 输入: :math:`(N， C_{in}， L_{in})`
+    - 输出: :math:`(N， C_{out}， L_{out})`
 
     其中:
 

--- a/doc/paddle/api/paddle/nn/layer/conv/Conv1D_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/conv/Conv1D_cn.rst
@@ -1,0 +1,102 @@
+Conv1D
+-------------------------------
+
+.. py:class:: paddle.nn.Conv1D(in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, padding_mode='zeros', weight_attr=None, bias_attr=None, data_format="NCL")
+
+
+
+**一维卷积层**
+
+该OP是一维卷积层（convolution1d layer），根据输入、卷积核、步长（stride）、填充（padding）、空洞大小（dilations）一组参数计算输出特征层大小。输入和输出是NCL或NLC格式，其中N是批尺寸，C是通道数，L是特征长度。卷积核是MCL格式，M是输出特征通道数，C是输入特征通道数，L是卷积核长度度。如果组数(groups)大于1，C等于输入图像通道数除以组数的结果。详情请参考UFLDL's : `卷积 <http://ufldl.stanford.edu/tutorial/supervised/FeatureExtractionUsingConvolution/>`_ 。如果bias_attr不为False，卷积计算会添加偏置项。
+
+对每个输入X，有等式：
+
+.. math::
+
+    Out = \sigma \left ( W * X + b \right )
+
+其中：
+    - :math:`X` ：输入值，NCL或NLC格式的3-D Tensor
+    - :math:`W` ：卷积核值，MCL格式的3-D Tensor
+    - :math:`*` ：卷积操作
+    - :math:`b` ：偏置值，2-D Tensor，形状为 ``[M,1]``
+    - :math:`\sigma` ：激活函数
+    - :math:`Out` ：输出值，NCL或NLC格式的3-D Tensor， 和 ``X`` 的形状可能不同
+
+
+参数：
+    - **in_channels** (int) - 输入特征的通道数。
+    - **out_channels** (int) - 由卷积操作产生的输出的通道数。
+    - **kernel_size** (int|list|tuple) - 卷积核大小。可以为单个整数或包含一个整数的元组或列表，表示卷积核的长度。
+    - **stride** (int|list|tuple，可选) - 步长大小。可以为单个整数或包含一个整数的元组或列表，表示卷积的步长。默认值：1。
+    - **padding** (int|list|tuple|str，可选) - 填充大小。可以是以下三种格式：（1）字符串，可以是"VALID"或者"SAME"，表示填充算法，计算细节可参考下述 ``padding`` = "SAME"或  ``padding`` = "VALID" 时的计算公式。（2）整数，表示在输入特征两侧各填充 ``padding`` 大小的0。（3）包含一个整数的列表或元组，表示在输入特征两侧各填充 ``padding[0]`` 大小的0. 默认值：0。
+    - **dilation** (int|list|tuple，可选) - 空洞大小。可以为单个整数或包含一个整数的元组或列表，表示卷积核中的元素的空洞。默认值：1。
+    - **groups** (int，可选) - 一维卷积层的组数。根据Alex Krizhevsky的深度卷积神经网络（CNN）论文中的成组卷积：当group=n，输入和卷积核分别根据通道数量平均分为n组，第一组卷积核和第一组输入进行卷积计算，第二组卷积核和第二组输入进行卷积计算，……，第n组卷积核和第n组输入进行卷积计算。默认值：1。
+    - **padding_mode** (str, 可选): 填充模式。 包括 ``'zeros'``, ``'reflect'``, ``'replicate'`` 或者 ``'circular'``. 默认值: ``'zeros'`` .
+    - **weight_attr** (ParamAttr，可选) - 指定权重参数属性的对象。默认值为None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **bias_attr** （ParamAttr|bool，可选）- 指定偏置参数属性的对象。若 ``bias_attr`` 为bool类型，只支持为False，表示没有偏置参数。默认值为None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是"NCL"和"NLC"。N是批尺寸，C是通道数，L是特征长度。默认值："NCL"。
+
+
+属性
+::::::::::::
+.. py:attribute:: weight
+本层的可学习参数，类型为 ``Parameter``
+
+.. py:attribute:: bias
+本层的可学习偏置，类型为 ``Parameter``
+    
+形状:
+    - 输入: :math:`(N, C_{in}, L_{in})`
+    - 输出: :math:`(N, C_{out}, L_{out})`
+
+    其中:
+
+    .. math::
+        L_{out} = \frac{(L_{in} + 2 * padding - (dilation * (kernel\_size - 1) + 1))}{stride} + 1
+
+    如果 ``padding`` = "SAME":
+
+    .. math::
+        L_{out} = \frac{(L_{in} + stride - 1)}{stride}
+
+    如果 ``padding`` = "VALID":
+
+    .. math::
+        L_{out} = \frac{\left ( L_{in} -\left ( dilation*\left ( kernel\_size-1 \right )+1 \right ) \right )}{stride}+1
+
+
+抛出异常：
+    - ``ValueError`` - 如果 ``data_format`` 既不是"NCL"也不是"NLC"。
+    - ``ValueError`` - 如果 ``input`` 的通道数未被明确定义。
+    - ``ValueError`` - 如果 ``padding`` 是字符串，既不是"SAME"也不是"VALID"。
+    - ``ShapeError`` - 如果输入不是3-D Tensor。
+    - ``ShapeError`` - 如果输入和卷积核的维度大小不相同。
+    - ``ShapeError`` - 如果输入的维度大小与 ``stride`` 之差不是2。
+    - ``ShapeError`` - 如果输出的通道数不能被 ``groups`` 整除。
+
+
+**代码示例**：
+
+.. code-block:: python
+
+   import paddle
+   from paddle.nn import Conv1D
+   import numpy as np
+   x = np.array([[[4, 8, 1, 9],
+     [7, 2, 0, 9],
+     [6, 9, 2, 6]]]).astype(np.float32)
+   w=np.array(
+   [[[9, 3, 4],
+     [0, 0, 7],
+     [2, 5, 6]],
+    [[0, 3, 4],
+     [2, 9, 7],
+     [5, 6, 8]]]).astype(np.float32)
+   x_t = paddle.to_tensor(x)
+   conv = Conv1D(3, 2, 3)
+   conv.weight.set_value(w)
+   y_t = conv(x_t)
+   print(y_t)
+   # [[[133. 238.]
+   #   [160. 211.]]]


### PR DESCRIPTION
中文文档修复如下：

## grid_sample

- has_variable:True
- has_print:True

## affine_grid

- code_example:['affine_grid_1.py']
- has_fluid:True
- has_variable:True

## conv1d_transpose

- 新增

## conv1d

- 新增

## Conv1D

- 新增

# Conv1DTranspose

- 新增