### PR TITLE
fix docker directory while entering docker

### DIFF
--- a/doc/paddle/install/compile/compile_Linux.md
+++ b/doc/paddle/install/compile/compile_Linux.md
@@ -106,7 +106,7 @@
 
 4. 进入Docker后进入paddle目录下：
 
-    `cd paddle`
+    `cd /paddle`
 
 5. 切换到较稳定版本下进行编译：
 

--- a/doc/paddle/install/compile/compile_Linux_en.md
+++ b/doc/paddle/install/compile/compile_Linux_en.md
@@ -106,7 +106,7 @@ Please follow the steps below to install:
         > Note: hub.baidubce.com/paddlepaddle/paddle:latest-dev internally install CUDA 8.0.
 
 
-4. After entering Docker, go to the paddle directory: `cd paddle`
+4. After entering Docker, go to the paddle directory: `cd /paddle`
 
 5. Switch to a more stable version to compile:
 

--- a/doc/paddle/install/compile/compile_MacOS.md
+++ b/doc/paddle/install/compile/compile_MacOS.md
@@ -45,7 +45,7 @@
 
 5. 进入Docker后进入paddle目录下：
 
-	`cd paddle`
+	`cd /paddle`
 
 6. 切换到较稳定版本下进行编译：
 

--- a/doc/paddle/install/compile/compile_MacOS_en.md
+++ b/doc/paddle/install/compile/compile_MacOS_en.md
@@ -49,7 +49,7 @@ Please follow the steps below to install:
 
 5. After entering Docker, go to the paddle directory:
 
-    `cd paddle`
+    `cd /paddle`
 
 6. Switch to a more stable version to compile:
 


### PR DESCRIPTION
- problem
In doc, if users compile paddle using docker, the doc let them use `cd paddle` to get the environment when entering docker. However, they may be led to another directory at the first time they enter docker. 
Users may not directly find `paddle` in current directory.

- solve
change `cd paddle` to `cd /paddle` while entering docker