### PR TITLE
save multiple functions and save after 'jit.load'

### DIFF
--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -343,7 +343,9 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
         def forward(self, x):
             return self._linear(x)
 
+
 (3) 如果您需要存储多个方法，需要用``paddle.jit.to_static`` 装饰每一个需要被存储的方法，并且``paddle.jit.save``的``input_spec``参数必须为None。示例如下：
+
 .. code-block:: python
 
     import paddle
@@ -352,7 +354,6 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
 
     IMAGE_SIZE = 784
     CLASS_NUM = 10
-
 
     class LinearNet(nn.Layer):
         def __init__(self):
@@ -367,7 +368,6 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
         @paddle.jit.to_static(input_spec=[InputSpec(shape=[None, IMAGE_SIZE], dtype='float32')])
         def another_forward(self, x):
             return self._linear_2(x)
-
 
     inps = paddle.randn([1, IMAGE_SIZE])
     layer = LinearNet()

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -379,7 +379,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     paddle.jit.save(layer, path)
 
 存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 ``example.model`` 文件夹下产生5个文件：
-``linear.another_forward.pdiparams  linear.pdiparams  linear.pdmodel  linear.another_forward.pdmodel  linear.pdiparams.info``
+``linear.another_forward.pdiparams, linear.pdiparams, linear.pdmodel, linear.another_forward.pdmodel, linear.pdiparams.info``
 
 3.1.2 动态图训练 + 模型&参数存储
 ``````````````````````````````

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -250,7 +250,7 @@
     paddle.jit.save(layer, path)
 
 
-通过动转静训练后保存模型&参数，有以下两项注意点：
+通过动转静训练后保存模型&参数，有以下三项注意点：
 
 (1) Layer对象的forward方法需要经由 ``paddle.jit.to_static`` 装饰
 
@@ -344,7 +344,8 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
             return self._linear(x)
 
 
-(3) 如果您需要存储多个方法，需要用 ``paddle.jit.to_static`` 装饰每一个需要被存储的方法，并且 ``paddle.jit.save`` 的 ``input_spec`` 参数必须为None。示例如下：
+(3) 如果您需要存储多个方法，需要用 ``paddle.jit.to_static`` 装饰每一个需要被存储的方法。
+只有在forward之外还需要存储其他方法时才用这个特性，如果仅装饰非forward的方法，而forward没有被装饰，是不符合规范的。此时 ``paddle.jit.save`` 的 ``input_spec`` 参数必须为None。示例如下：
 
 .. code-block:: python
 
@@ -377,6 +378,8 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     path = "example.model/linear"
     paddle.jit.save(layer, path)
 
+存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 `` example.model `` 文件夹下产生5个文件：
+`` linear.another_forward.pdiparams    linear.pdiparams    linear.pdmodel    linear.another_forward.pdmodel    linear.pdiparams.info ``
 
 3.1.2 动态图训练 + 模型&参数存储
 ``````````````````````````````
@@ -493,7 +496,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
 3.2 模型&参数载入
 ----------------
 
-载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。
+载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。为了规避变量名字冲突，参数的名字在使用 ``paddle.jit.load`` 载入之后可能发生变化。
 
 载入模型及参数，示例如下：
 
@@ -563,6 +566,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     loss_fn = nn.CrossEntropyLoss()
     adam = opt.Adam(learning_rate=0.001, parameters=loaded_layer.parameters())
     train(loaded_layer, loader, loss_fn, adam)
+    # save after fine-tuning
     paddle.jit.save(loaded_layer, "fine-tune.model/linear", input_spec=[x])
 
 

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -344,7 +344,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
             return self._linear(x)
 
 
-(3) 如果您需要存储多个方法，需要用``paddle.jit.to_static`` 装饰每一个需要被存储的方法，并且``paddle.jit.save``的``input_spec``参数必须为None。示例如下：
+(3) 如果您需要存储多个方法，需要用 ``paddle.jit.to_static`` 装饰每一个需要被存储的方法，并且 ``paddle.jit.save`` 的 ``input_spec`` 参数必须为None。示例如下：
 
 .. code-block:: python
 

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -379,7 +379,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     paddle.jit.save(layer, path)
 
 存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 ``example.model`` 文件夹下产生5个文件：
-``linear.another_forward.pdiparams    linear.pdiparams    linear.pdmodel    linear.another_forward.pdmodel    linear.pdiparams.info``
+``linear.another_forward.pdiparams、 linear.pdiparams、 linear.pdmodel、 linear.another_forward.pdmodel、 linear.pdiparams.info``
 
 3.1.2 动态图训练 + 模型&参数存储
 ``````````````````````````````

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -496,7 +496,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
 3.2 模型&参数载入
 ----------------
 
-载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。为了规避变量名字冲突，载入之后参数的名字可能发生变化。
+载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。为了规避变量名字冲突，载入之后会重命名变量。
 
 载入模型及参数，示例如下：
 

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -379,7 +379,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     paddle.jit.save(layer, path)
 
 存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 ``example.model`` 文件夹下产生5个文件：
-``linear.another_forward.pdiparams, linear.pdiparams, linear.pdmodel, linear.another_forward.pdmodel, linear.pdiparams.info``
+``linear.another_forward.pdiparams    linear.pdiparams    linear.pdmodel    linear.another_forward.pdmodel    linear.pdiparams.info``
 
 3.1.2 动态图训练 + 模型&参数存储
 ``````````````````````````````

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -379,7 +379,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     paddle.jit.save(layer, path)
 
 存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 ``example.model`` 文件夹下产生5个文件：
-``linear.another_forward.pdiparams    linear.pdiparams    linear.pdmodel    linear.another_forward.pdmodel    linear.pdiparams.info``
+``linear.another_forward.pdiparams  linear.pdiparams  linear.pdmodel  linear.another_forward.pdmodel  linear.pdiparams.info``
 
 3.1.2 动态图训练 + 模型&参数存储
 ``````````````````````````````

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -345,7 +345,11 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
 
 
 (3) 如果您需要存储多个方法，需要用 ``paddle.jit.to_static`` 装饰每一个需要被存储的方法。
-只有在forward之外还需要存储其他方法时才用这个特性，如果仅装饰非forward的方法，而forward没有被装饰，是不符合规范的。此时 ``paddle.jit.save`` 的 ``input_spec`` 参数必须为None。示例如下：
+
+.. note::
+    只有在forward之外还需要存储其他方法时才用这个特性，如果仅装饰非forward的方法，而forward没有被装饰，是不符合规范的。此时 ``paddle.jit.save`` 的 ``input_spec`` 参数必须为None。
+
+示例代码如下：
 
 .. code-block:: python
 
@@ -496,7 +500,10 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
 3.2 模型&参数载入
 ----------------
 
-载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。为了规避变量名字冲突，载入之后会重命名变量。
+载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。
+
+.. note::
+    为了规避变量名字冲突，载入之后会重命名变量。
 
 载入模型及参数，示例如下：
 

--- a/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
+++ b/doc/paddle/guides/02_paddle2.0_develop/08_model_save_load_cn.rst
@@ -378,8 +378,8 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
     path = "example.model/linear"
     paddle.jit.save(layer, path)
 
-存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 `` example.model `` 文件夹下产生5个文件：
-`` linear.another_forward.pdiparams    linear.pdiparams    linear.pdmodel    linear.another_forward.pdmodel    linear.pdiparams.info ``
+存储的模型命名规则：forward的模型名字为：模型名+后缀，其他函数的模型名字为：模型名+函数名+后缀。每个函数有各自的pdmodel和pdiparams的文件，所有函数共用pdiparams.info。上述代码将在 ``example.model`` 文件夹下产生5个文件：
+``linear.another_forward.pdiparams    linear.pdiparams    linear.pdmodel    linear.another_forward.pdmodel    linear.pdiparams.info``
 
 3.1.2 动态图训练 + 模型&参数存储
 ``````````````````````````````
@@ -496,7 +496,7 @@ Layer更准确的语义是描述一个具有预测功能的模型对象，接收
 3.2 模型&参数载入
 ----------------
 
-载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。为了规避变量名字冲突，参数的名字在使用 ``paddle.jit.load`` 载入之后可能发生变化。
+载入模型参数，使用 ``paddle.jit.load`` 载入即可，载入后得到的是一个Layer的派生类对象 ``TranslatedLayer`` ， ``TranslatedLayer`` 具有Layer具有的通用特征，支持切换 ``train`` 或者 ``eval`` 模式，可以进行模型调优或者预测。为了规避变量名字冲突，载入之后参数的名字可能发生变化。
 
 载入模型及参数，示例如下：
 


### PR DESCRIPTION
### 多个方法转存：
在3.1（3）中添加：动态图Layer多个方法经过转写保存的说明。

![image](https://user-images.githubusercontent.com/22128369/101856922-464a9b00-3ba1-11eb-928c-2989f442b350.png)
### jit.load 之后jit.save:
这块写的比较简单，只在3.2中添加了一行 代码( jit.load + fine-tune之后jit.save )

![image](https://user-images.githubusercontent.com/22128369/101856974-6a0de100-3ba1-11eb-9aa3-53c013dde9f0.png)
![image](https://user-images.githubusercontent.com/22128369/101857000-785bfd00-3ba1-11eb-973a-5dc5439933c4.png)
