### PR TITLE
add Baidu Kunlun XPU Card support models for installation documents in Chinese/English

### DIFF
--- a/doc/paddle/install/install_Kunlun_en.md
+++ b/doc/paddle/install/install_Kunlun_en.md
@@ -179,7 +179,10 @@ or
 
 ## Appendix: Current models supported by Kunlun XPU adaptation
 
-|  Models   | Download links  |
+|  Model Name  | Model Link |
 |  ----  | ----  |
-| ResNet50  | [click to download](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNet50_vd_pretrained.pdparams) |
-| MobileNetv3  | [click to download](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileNetV3_large_x1_0_pretrained.pdparams) |
+| ResNet50  | [Model Link](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
+| MobileNetv3  | [Model Link](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
+| Deeplabv3  | [Model Link](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/usage.md) |
+| DQN  | [Model Link](https://github.com/PaddlePaddle/PARL/blob/develop/examples/DQN/README.md) |
+| Bertbase  | [Model Link](https://github.com/PaddlePaddle/models/blob/develop/PaddleNLP/legacy/pretrain_language_models/BERT/README.md) |

--- a/doc/paddle/install/install_Kunlun_en.md
+++ b/doc/paddle/install/install_Kunlun_en.md
@@ -183,6 +183,6 @@ or
 |  ----  | ----  |
 | ResNet50  | [Model Link](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
 | MobileNetv3  | [Model Link](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
-| Deeplabv3  | [Model Link](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/usage.md) |
+| Deeplabv3  | [Model Link](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/train_on_xpu.md) |
 | DQN  | [Model Link](https://github.com/PaddlePaddle/PARL/blob/develop/examples/DQN/README.md) |
 | Bertbase  | [Model Link](https://github.com/PaddlePaddle/models/blob/develop/PaddleNLP/legacy/pretrain_language_models/BERT/README.md) |

--- a/doc/paddle/install/install_Kunlun_zh.md
+++ b/doc/paddle/install/install_Kunlun_zh.md
@@ -186,6 +186,6 @@ o  ```python mnist_example.py --use_device=xpu --num_epochs=5```
 |  ----  | ----  |
 | ResNet50  | [模型地址](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
 | MobileNetv3  | [模型地址](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
-| Deeplabv3  | [模型地址](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/usage.md) |
+| Deeplabv3  | [模型地址](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/train_on_xpu.md) |
 | DQN  | [模型地址](https://github.com/PaddlePaddle/PARL/blob/develop/examples/DQN/README.md) |
 | Bertbase  | [模型地址](https://github.com/PaddlePaddle/models/blob/develop/PaddleNLP/legacy/pretrain_language_models/BERT/README.md) |

--- a/doc/paddle/install/install_Kunlun_zh.md
+++ b/doc/paddle/install/install_Kunlun_zh.md
@@ -182,7 +182,10 @@ o  ```python mnist_example.py --use_device=xpu --num_epochs=5```
 
 ## 附录：当前昆仑XPU适配支持的模型
 
-|  模型   | 下载链接  |
+|  模型名称  | 模型地址  |
 |  ----  | ----  |
-| ResNet50  | [点击下载](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNet50_vd_pretrained.pdparams) |
-| MobileNetv3  | [点击下载](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileNetV3_large_x1_0_pretrained.pdparams) |
+| ResNet50  | [模型地址](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
+| MobileNetv3  | [模型地址](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) |
+| Deeplabv3  | [模型地址](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/usage.md) |
+| DQN  | [模型地址](https://github.com/PaddlePaddle/PARL/blob/develop/examples/DQN/README.md) |
+| Bertbase  | [模型地址](https://github.com/PaddlePaddle/models/blob/develop/PaddleNLP/legacy/pretrain_language_models/BERT/README.md) |


### PR DESCRIPTION

Add five models Baidu Kunlun XPU Card supported as following:
-  [ResNet50 ](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) 
-  [MobileNetv3](https://github.com/PaddlePaddle/PaddleClas/tree/dygraph/docs/zh_CN/extension/train_on_xpu.md) 
-  [Deeplabv3](https://github.com/PaddlePaddle/PaddleSeg/blob/develop/legacy/docs/train_on_xpu.md) 
-  [DQN](https://github.com/PaddlePaddle/PARL/blob/develop/examples/DQN/README.md) 
-  [Bertbase](https://github.com/PaddlePaddle/models/blob/develop/PaddleNLP/legacy/pretrain_language_models/BERT/README.md) 