### PR TITLE
fix some dead links in install docs

### DIFF
--- a/doc/paddle/install/compile/arm-compile.md
+++ b/doc/paddle/install/compile/arm-compile.md
@@ -84,7 +84,7 @@
 
 8. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     For Python2:
     ```

--- a/doc/paddle/install/compile/linux-compile.md
+++ b/doc/paddle/install/compile/linux-compile.md
@@ -163,7 +163,7 @@
 
 8. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
     >请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本,  例如`-DPY_VERSION=3.5`表示python版本为3.5.x
 
     * 对于需要编译**CPU版本PaddlePaddle**的用户：
@@ -465,7 +465,7 @@
 
 10. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     *  对于需要编译**CPU版本PaddlePaddle**的用户：
 

--- a/doc/paddle/install/compile/linux-compile_en.md
+++ b/doc/paddle/install/compile/linux-compile_en.md
@@ -172,7 +172,7 @@ Please follow the steps below to install:
 
 8. Execute cmake:
 
-    > For details on the compilation options, see the [compilation options table](../Tables.html/#Compile).
+    > For details on the compilation options, see the [compilation options table](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile).
     > Please attention to modify parameters `-DPY_VERSION` for the version of Python you want to compile with, for example `-DPY_VERSION=3.5` means the version of python is 3.5.x
 
     * For users who need to compile the **CPU version PaddlePaddle**:
@@ -456,7 +456,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
 10. Execute cmake:
 
-    > For details on the compilation options, see the [compilation options table](../Tables.html/#Compile).
+    > For details on the compilation options, see the [compilation options table](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile).
 
     * For users who need to compile the **CPU version PaddlePaddle**:
 

--- a/doc/paddle/install/compile/macos-compile.md
+++ b/doc/paddle/install/compile/macos-compile.md
@@ -93,7 +93,7 @@
 
 9. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
     >请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本,  例如`-DPY_VERSION=3.5`表示python版本为3.5.x
 
     *  对于需要编译**CPU版本PaddlePaddle**的用户：
@@ -248,7 +248,7 @@
 
 9. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     *  对于需要编译**CPU版本PaddlePaddle**的用户：
 

--- a/doc/paddle/install/compile/macos-compile_en.md
+++ b/doc/paddle/install/compile/macos-compile_en.md
@@ -254,7 +254,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
 9. Execute cmake:
 
-    > For details on the compilation options, see the [compilation options table](../Tables.html/#Compile).
+    > For details on the compilation options, see the [compilation options table](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile).
 
     * For users who need to compile the **CPU version PaddlePaddle**:
 

--- a/doc/paddle/install/compile/mips-compile.md
+++ b/doc/paddle/install/compile/mips-compile.md
@@ -99,7 +99,7 @@
 
 8. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     For Python2:
     ```

--- a/doc/paddle/install/compile/sw-compile.md
+++ b/doc/paddle/install/compile/sw-compile.md
@@ -74,7 +74,7 @@
 
 8. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     ```
     CBLAS_ROOT=/opt/CBLAS

--- a/doc/paddle/install/compile/windows-compile.md
+++ b/doc/paddle/install/compile/windows-compile.md
@@ -79,7 +79,7 @@
 
 5. 执行cmake：
 
-    > 具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    > 具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     *  编译**CPU版本PaddlePaddle**：
 

--- a/doc/paddle/install/compile/windows-compile_en.md
+++ b/doc/paddle/install/compile/windows-compile_en.md
@@ -83,7 +83,7 @@ There is one compilation methods in Windows system:
 
 5. Execute cmake:
 
-    > For details on the compilation options, see [the compilation options list](../Tables.html/#Compile).
+    > For details on the compilation options, see [the compilation options list](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile).
     * For users who need to compile **the CPU version PaddlePaddle**:
 
         ```

--- a/doc/paddle/install/compile/zhaoxin-compile.md
+++ b/doc/paddle/install/compile/zhaoxin-compile.md
@@ -88,7 +88,7 @@
 
 8. 执行cmake：
 
-    >具体编译选项含义请参见[编译选项表](../Tables.html#Compile)
+    >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     For Python2:
     ```

--- a/doc/paddle/install/install_Kunlun_en.md
+++ b/doc/paddle/install/install_Kunlun_en.md
@@ -123,7 +123,7 @@ For running Paddle on Kunlun XPU machine, we must first install the Paddle packa
    ```ulimit -n 4096```
 
 8. Execute cmake ：
-9. For the meaning of specific compilation options, please refer to [Compile Options Table](https://www.paddlepaddle.org.cn/install/quick/Tables.html#Compile)
+9. For the meaning of specific compilation options, please refer to [Compile Options Table](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile)
 
 For Python2: ```cmake .. -DPY_VERSION=2 -DPYTHON_EXECUTABLE=`which python2` -DWITH_MKL=OFF -DWITH_XPU=ON -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ```
 

--- a/doc/paddle/install/install_Kunlun_zh.md
+++ b/doc/paddle/install/install_Kunlun_zh.md
@@ -123,9 +123,8 @@ o  ```python mnist_example.py --use_device=xpu --num_epochs=5```
 7. 链接过程中打开文件数较多，可能超过系统默认限制导致编译出错，设置进程允许打开的最大文件数：
 
    ```ulimit -n 4096```
-
 8. 执行cmake：
-9. 具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/install/quick/Tables.html#Compile)
+9. 具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
 For Python2: ```cmake .. -DPY_VERSION=2 -DPYTHON_EXECUTABLE=`which python2` -DWITH_MKL=OFF -DWITH_XPU=ON -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ```
 


### PR DESCRIPTION
fix "the compilation options list"  links to [the compilation options list](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile)