### PR TITLE
test=develop Add FAQ for paddle inference python api enable_profile()

### DIFF
--- a/doc/paddle/faq/train_cn.md
+++ b/doc/paddle/faq/train_cn.md
@@ -334,7 +334,7 @@ for epoch in range(epochs):
 
 ##### 问题：预测时如何打印模型中每一步的耗时？
 
-+ 答复：可以在设置config时使用`config.enable_profile()`统计预测时每个算子和数据搬运的耗时。示例代码：
++ 答复：可以在设置config时使用`config.enable_profile()`统计预测时每个算子和数据搬运的耗时。对于推理api的使用，可以参考官网文档[Python预测API介绍](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/05_inference_deployment/inference/python_infer_cn.html)。示例代码：
 ```python
 # 设置config:
 def set_config(args):
@@ -347,5 +347,4 @@ def set_config(args):
     config.switch_ir_optim(False)
     return config
 ```
-对于推理api的使用，可以参考官网文档[Python预测API介绍](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/05_inference_deployment/inference/python_infer_cn.html)
 ----------

--- a/doc/paddle/faq/train_cn.md
+++ b/doc/paddle/faq/train_cn.md
@@ -332,4 +332,20 @@ for epoch in range(epochs):
 
 + 答复：目前`load_inference_model`加载进行的模型还不支持py_reader输入。
 
+##### 问题：预测时如何打印模型中每一步的耗时？
+
++ 答复：可以在设置config时使用`config.enable_profile()`统计预测时每个算子和数据搬运的耗时。示例代码：
+```python
+# 设置config:
+def set_config(args):
+    config = Config(args.model_file, args.params_file)
+    config.disable_gpu()
+    # enable_profile()打开后会统计每一步耗时
+    config.enable_profile()
+    config.switch_use_feed_fetch_ops(False)
+    config.switch_specify_input_names(True)
+    config.switch_ir_optim(False)
+    return config
+```
+对于推理api的使用，可以参考官网文档[Python预测API介绍](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/05_inference_deployment/inference/python_infer_cn.html)
 ----------


### PR DESCRIPTION
Add FAQ for Paddle Inference Python API: config.enable_profile().
This api is used to show time statistics.