### PR TITLE
fix dygraph_to_static guide url

### DIFF
--- a/doc/paddle/guides/04_dygraph_to_static/debugging_cn.md
+++ b/doc/paddle/guides/04_dygraph_to_static/debugging_cn.md
@@ -132,7 +132,7 @@ func(np.ones([3, 2]))
     `set_code_level` 函数可以设置查看不同的 AST Transformer 转化后的代码，详情请见 [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_cn.html)。
 
 ## 使用 `print`
-`print` 函数可以用来查看变量，该函数在动转静中会被转化。当仅打印 Paddle Tensor 时，实际运行时会被转换为 Paddle 算子 [Print](../../api_cn/layers_cn/Print_cn.html)，否则仍然运行 `print`。
+`print` 函数可以用来查看变量，该函数在动转静中会被转化。当仅打印 Paddle Tensor 时，实际运行时会被转换为 Paddle 算子 [Print](../../api/paddle/fluid/layers/control_flow/Print_cn.html)，否则仍然运行 `print`。
 ```python
 @paddle.jit.to_static
 def func(x):

--- a/doc/paddle/guides/04_dygraph_to_static/debugging_en.md
+++ b/doc/paddle/guides/04_dygraph_to_static/debugging_en.md
@@ -131,7 +131,7 @@ There are two ways to print the transformed static graph code:
     `set_code_level` can set different levels to view the code transformed by different ast transformers. For details, please refer to [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_en.html).
 
 ## `print`
-You can call `print` to view variables. `print` will be transformed when using Dynamic-to-Static. When only Paddle Tensor is printed, `print` will be transformed and call Paddle operator [Print](../../api/paddle/fluid/layers/control_flow/Print.html) in runtime. Otherwise, call python `print`.
+You can call `print` to view variables. `print` will be transformed when using Dynamic-to-Static. When only Paddle Tensor is printed, `print` will be transformed and call Paddle operator [Print](../../api/paddle/fluid/layers/control_flow/Print_en.html) in runtime. Otherwise, call python `print`.
 
 ```python
 @paddle.jit.to_static

--- a/doc/paddle/guides/04_dygraph_to_static/debugging_en.md
+++ b/doc/paddle/guides/04_dygraph_to_static/debugging_en.md
@@ -131,7 +131,7 @@ There are two ways to print the transformed static graph code:
     `set_code_level` can set different levels to view the code transformed by different ast transformers. For details, please refer to [set_code_level](../../../paddle/api/paddle/fluid/dygraph/jit/set_code_level_en.html).
 
 ## `print`
-You can call `print` to view variables. `print` will be transformed when using Dynamic-to-Static. When only Paddle Tensor is printed, `print` will be transformed and call Paddle operator [Print](../../api/layers/Print.html) in runtime. Otherwise, call python `print`.
+You can call `print` to view variables. `print` will be transformed when using Dynamic-to-Static. When only Paddle Tensor is printed, `print` will be transformed and call Paddle operator [Print](../../api/paddle/fluid/layers/control_flow/Print.html) in runtime. Otherwise, call python `print`.
 
 ```python
 @paddle.jit.to_static


### PR DESCRIPTION
fix the "Print" url on https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/04_dygraph_to_static/debugging_cn.html