### PR TITLE
the names of inplace ops are end with underscore, escape them

### DIFF
--- a/doc/paddle/api/gen_doc.py
+++ b/doc/paddle/api/gen_doc.py
@@ -655,7 +655,7 @@ class EnDocGenerator(object):
         """
         as name
         """
-        mo = re.match(r'^(.*?)(_+)', name)
+        mo = re.match(r'^(.*?)(_+)$', name)
         if mo:
             name = mo.group(1) + r'\_' * len(mo.group(2))
         dot_line = dot * len(name)

--- a/doc/paddle/api/gen_doc.py
+++ b/doc/paddle/api/gen_doc.py
@@ -655,6 +655,9 @@ class EnDocGenerator(object):
         """
         as name
         """
+        mo = re.match(r'^(.*?)(_+)', name)
+        if mo:
+            name = mo.group(1) + r'\_' * len(mo.group(2))
         dot_line = dot * len(name)
         if is_title:
             self.stream.write(dot_line)


### PR DESCRIPTION
to avoid the sphinx's link syntax