### PR TITLE
the names of inplace ops are end with underscore, escape them (#3463)

### DIFF
--- a/doc/paddle/api/gen_doc.py
+++ b/doc/paddle/api/gen_doc.py
@@ -655,6 +655,9 @@ class EnDocGenerator(object):
         """
         as name
         """
+        mo = re.match(r'^(.*?)(_+)$', name)
+        if mo:
+            name = mo.group(1) + r'\_' * len(mo.group(2))
         dot_line = dot * len(name)
         if is_title:
             self.stream.write(dot_line)


### PR DESCRIPTION
* the names of inplace ops are end with underscore, escape them