### PR TITLE
update version 2.1.0 Tables.md of install doc

### DIFF
--- a/docs/install/Tables.md
+++ b/docs/install/Tables.md
@@ -22,7 +22,7 @@
     </tr>
     <tr>
         <td> GCC (Linux Only) </td>
-        <td> 4.8 / 5.4 </td>
+        <td> 5.4 / 8.2 </td>
         <td>  推荐使用CentOS的devtools2 </td>
         <td>  </td>
     </tr>
@@ -34,9 +34,9 @@
     </tr>
         <tr>
         <td> Python（64 bit） </td>
-        <td> 2.7.x. 或 3.5+.x </td>
-        <td> 依赖libpython2.7.so 或 libpython3.5+.so </td>
-        <td> <code> apt install python-dev </code> 或 <code> yum install python-devel </code> 如果安装python3请访问<a href="https://www.python.org">Python 官网</a></td>
+        <td> 3.6+.x </td>
+        <td> 依赖 libpython3.6+.so </td>
+        <td> 请访问<a href="https://www.python.org">Python 官网</a></td>
     </tr>
     <tr>
         <td> SWIG </td>
@@ -228,12 +228,12 @@ PaddePaddle通过编译时指定路径来实现引用各种BLAS/CUDA/cuDNN库。
     </thead>
     <tbody>
     <tr>
-        <td> paddlepaddle==[版本号] 例如 paddlepaddle==2.0.2 </td>
+        <td> paddlepaddle==[版本号] 例如 paddlepaddle==2.1.0 </td>
         <td> 只支持CPU对应版本的PaddlePaddle，具体版本请参见<a href=https://pypi.org/project/paddlepaddle/#history>Pypi</a> </td>
     </tr>
     <tr>
-        <td> paddlepaddle-gpu==[版本号] 例如 paddlepaddle-gpu==2.0.2 </td>
-        <td> 默认安装支持CUDA 10.0和cuDNN 7的对应[版本号]的PaddlePaddle安装包 </td>
+        <td> paddlepaddle-gpu==[版本号] 例如 paddlepaddle-gpu==2.1.0 </td>
+        <td> 默认安装支持CUDA 10.2和cuDNN 7的对应[版本号]的PaddlePaddle安装包 </td>
     </tr>
    </tbody>
 </table>
@@ -242,7 +242,7 @@ PaddePaddle通过编译时指定路径来实现引用各种BLAS/CUDA/cuDNN库。
 您可以在 [Release History](https://pypi.org/project/paddlepaddle-gpu/#history) 中找到PaddlePaddle-gpu的各个发行版本。
 > 其中`postXX` 对应的是CUDA和cuDNN的版本，`postXX`之前的数字代表Paddle的版本
 
-需要注意的是，命令中<code> paddlepaddle-gpu==2.0.2 </code> 在windows环境下，会默认安装支持CUDA 10.2和cuDNN 7的对应[版本号]的PaddlePaddle安装包
+需要注意的是，命令中<code> paddlepaddle-gpu==2.1.0 </code> 在windows环境下，会默认安装支持CUDA 10.2和cuDNN 7的对应[版本号]的PaddlePaddle安装包
 
 <a name="ciwhls-release"></a>
 </br></br>
@@ -254,336 +254,146 @@ PaddePaddle通过编译时指定路径来实现引用各种BLAS/CUDA/cuDNN库。
     <thead>
     <tr>
         <th> 版本说明 </th>
-        <th> cp27-cp27mu </th>
-        <th> cp27-cp27m </th>
-        <th> cp35-cp35m    </th>
         <th> cp36-cp36m    </th>
         <th> cp37-cp37m    </th>
         <th> cp38-cp38    </th>
+        <th> cp39-cp39    </th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td> cpu-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp27-cp27mu-linux_x86_64.whl"> paddlepaddle-2.0.2-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp35-cp35m-linux_x86_64.whl"> paddlepaddle-2.0.2-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.0.2-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.0.2-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.0.2-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> cpu-mkl-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.1.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.1.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp39-cp39-linux_x86_64.whl"> paddlepaddle-2.1.0-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> cuda9.0-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp27-cp27mu-linux_x86_64.whl</a></td>
+        <td> cpu-openblas-avx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-openblas/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.0-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp27-cp27mu-linux_x86_64.whl</a></td>
+        <td> cpu-mkl-noavx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-noavx-mkl/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.1-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl</a></td>
+        <td> cpu-openblas-noavx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-noavx-openblas/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.2-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> cuda10.1-cudnn7-mkl-gcc5.4-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> cuda11.0-cudnn8-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp38-cp38-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
-        <td> cuda10.0-cudnn7.6-trt6.0.1.5 </td>
+        <td> cuda10.1-cudnn7-mkl-gcc5.4-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-noavx-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
     </tr>
     <tr>
         <td> cuda10.1-cudnn7.6-trt6.0.1.5 </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.1-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.1-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> cuda10.2-cudnn8.0-trt7.1.3 </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.2-cudnn8-mkl/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.2-cudnn8-mkl/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
-        <td> nv-jetson-jetpack4.3-all </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.3-all/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl</a></td>
+        <td> cuda10.1-cudnn7-mkl-gcc8.2-avx-trt6.0.1.5 </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl</a></td>
+    </tr>
+    <tr>
+        <td> cuda10.2-cudnn7-mkl-gcc8.2-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp39-cp39-linux_x86_64.whl</a></td>
+    </tr>
+    <tr>
+        <td> cuda10.2-cudnn7-mkl-gcc8.2-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.3-all/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-noavx-gcc8.2/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+    </tr>
+    <tr>
+        <td> cuda10.2-cudnn8-mkl-gcc8.2-trt7.1.3.4 </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
-        <td> nv-jetson-jetpack4.4/4.5-all </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl</a></td>
+        <td> jetpack4.4-cuda10.2-cudnn8-trt7.1.3 </td>
+        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.1.0-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_aarch64.whl">
+        paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_aarch64.whl</a></td>
         <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl</a></td>
-        <td> - </td>
+        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.1.0-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_aarch64.whl">
+        paddlepaddle_gpu-2.1.0-cp38-cp38-linux_aarch64.whl</a></td>
         <td> - </td>
     </tr>
     <tr>
-        <td> win-cpu-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp35-cp35m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp37-cp37m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp38-cp38-win_amd64.whl">
-        paddlepaddle-2.0.2-cp38-cp38-win_amd64.whl</a></td>
+        <td> cuda11.0-cudnn8-mkl-gcc8.2-avx-trt7.1.3 </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> win-cpu-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
+        <td> cuda11.2-cudnn8-mkl-gcc8.2-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> win-cpu-openblas-avx </td>
+        <td> rocm4.0.1-miopen2.11-mkl </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-rocm4.0.1-miopen2.11-mkl/paddlepaddle_rocm-2.1.0.rocm401.miopen211-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_rocm-2.1.0.rocm401.miopen211-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cpu-openblas-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/opennoavx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-openblas-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-openblas-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/opennoavx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.0-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.0-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2.post100-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2.post101-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.2-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.2-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda11.0-cudnn8-mkl-avx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> mac-cpu </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp27-cp27m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp35-cp35m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp35-cp35m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp36-cp36m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp37-cp37m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp37-cp37m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp38-cp38-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.0.2-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
     </tr>
    </tbody>
 </table>
@@ -600,9 +410,9 @@ cuda10_cudnn7-mkl: 支持GPU训练和预测，使用Intel mkl数学库
 
 - 横轴
 
-一般是类似于“cp27-cp27mu”的形式，其中：
+一般是类似于“cp37-cp37m”的形式，其中：
 
-27:python tag,指python2.7，类似的还有“35”、“36”、“37”等
+37:python tag,指python3.7，类似的还有“36”、“38”、“39”等
 
 mu:指unicode版本python，若为m则指非unicode版本python
 
@@ -616,7 +426,7 @@ mu:指unicode版本python，若为m则指非unicode版本python
 
 distribution: wheel名称version: 版本，例如0.14.0 (要求必须是数字格式)
 
-python tag: 类似'py27', 'py2', 'py3'，用于标明对应的python版本
+python tag: 类似'py36', 'py37', 'py38', 'py39'，用于标明对应的python版本
 
 abi tag:  类似'cp33m', 'abi3', 'none'
 

--- a/docs/install/Tables_en.md
+++ b/docs/install/Tables_en.md
@@ -23,7 +23,7 @@
     </tr>
     <tr>
         <td> GCC </td>
-        <td> 4.8 / 5.4 </td>
+        <td> 5.4 / 8.2 </td>
         <td>  recommends using devtools2 for CentOS </td>
         <td>  </td>
     </tr>
@@ -35,9 +35,9 @@
     </tr>
         <tr>
         <td> Python（64 bit） </td>
-        <td> 2.7.x. or 3.5+.x </td>
-        <td> depends on libpython2.7.so or libpython3.5+.so </td>
-        <td> <code> apt install python-dev </code> or <code> yum install python-devel </code> if installing python3, please go to <a href="https://www.python.org">Python official website </a></td>
+        <td> 3.6+.x </td>
+        <td> depends on libpython3.6+.so </td>
+        <td> please go to <a href="https://www.python.org">Python official website </a></td>
     </tr>
     <tr>
         <td> SWIG </td>
@@ -220,12 +220,12 @@ PaddePaddle implements references to various BLAS/CUDA/cuDNN libraries by specif
     </thead>
     <tbody>
     <tr>
-        <td> paddlepaddle==[version code] such as paddlepaddle==2.0.2 </td>
+        <td> paddlepaddle==[version code] such as paddlepaddle==2.1.0 </td>
         <td> Only support the corresponding version of the CPU PaddlePaddle, please refer to <a href=https://pypi.org/project/paddlepaddle/#history>Pypi</a> for the specific version. </td>
     </tr>
     <tr>
-        <td> paddlepaddle-gpu==[version code], such as paddlepaddle-gpu==2.0.2 </td>
-        <td> The default installation supports the PaddlePaddle installation package corresponding to [version number] of CUDA 10.0 and cuDNN 7 </td>
+        <td> paddlepaddle-gpu==[version code], such as paddlepaddle-gpu==2.1.0 </td>
+        <td> The default installation supports the PaddlePaddle installation package corresponding to [version number] of CUDA 10.2 and cuDNN 7 </td>
     </tr>
    </tbody>
 </table>
@@ -234,7 +234,7 @@ PaddePaddle implements references to various BLAS/CUDA/cuDNN libraries by specif
 You can find various distributions of PaddlePaddle-gpu in [the Release History](https://pypi.org/project/paddlepaddle-gpu/#history).
 > 'postxx' corresponds to CUDA and cuDNN versions, and the number before 'postxx' represents the version of Paddle
 
-Please note that: in the commands, <code> paddlepaddle-gpu==2.0.2 </code> will install the installation package of PaddlePaddle that supports CUDA 10.0 and cuDNN 7 by default under Windows environment.
+Please note that: in the commands, <code> paddlepaddle-gpu==2.1.0 </code> will install the installation package of PaddlePaddle that supports CUDA 10.2 and cuDNN 7 by default under Windows environment.
 
 
 <a name="ciwhls-release"></a>
@@ -248,341 +248,146 @@ Please note that: in the commands, <code> paddlepaddle-gpu==2.0.2 </code> will i
     <thead>
     <tr>
         <th> Release Instruction </th>
-        <th> cp27-cp27mu </th>
-        <th> cp27-cp27m </th>
-        <th> cp35-cp35m    </th>
         <th> cp36-cp36m    </th>
         <th> cp37-cp37m    </th>
         <th> cp38-cp38    </th>
+        <th> cp39-cp39    </th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td> cpu-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle-2.0.2-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle-2.0.2-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle-2.0.2-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mkl/paddlepaddle-2.0.2-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle-2.0.2-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> cpu-mkl-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.1.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.1.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-mkl/paddlepaddle-2.1.0-cp39-cp39-linux_x86_64.whl"> paddlepaddle-2.1.0-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> cuda9.0-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp27-cp27mu-linux_x86_64.whl</a></td>
+        <td> cpu-openblas-avx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda9-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post90-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post90-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-avx-openblas/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.0-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp27-cp27mu-linux_x86_64.whl</a></td>
+        <td> cpu-mkl-noavx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-noavx-mkl/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.1-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl</a></td>
+        <td> cpu-openblas-noavx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.1-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post101-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-cpu-noavx-openblas/paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.2-cudnn7-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda10.2-cudnn7-mkl_gcc8.2/paddlepaddle_gpu-2.0.2-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> cuda10.1-cudnn7-mkl-gcc5.4-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> cuda11.0-cudnn8-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp35-cp35m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp35-cp35m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-gpu-cuda11.0-cudnn8-mkl_gcc8.2/paddlepaddle_gpu-2.0.2.post110-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post110-cp38-cp38-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
-        <td> cuda10.0-cudnn7.6-trt6.0.1.5 </td>
+        <td> cuda10.1-cudnn7-mkl-gcc5.4-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> - </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.1-cudnn7-mkl-noavx-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
     </tr>
     <tr>
         <td> cuda10.1-cudnn7.6-trt6.0.1.5 </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.1-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.1-cudnn7-mkl/paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> cuda10.2-cudnn8.0-trt7.1.3 </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.2-cudnn8-mkl/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.0.2-gpu-cuda10.2-cudnn8-mkl/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc5.4/paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
-        <td> nv-jetson-jetpack4.3-all </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.3-all/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl</a></td>
+        <td> cuda10.1-cudnn7-mkl-gcc8.2-avx-trt6.0.1.5 </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.1-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post101-cp39-cp39-linux_x86_64.whl</a></td>
+    </tr>
+    <tr>
+        <td> cuda10.2-cudnn7-mkl-gcc8.2-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp39-cp39-linux_x86_64.whl</a></td>
+    </tr>
+    <tr>
+        <td> cuda10.2-cudnn7-mkl-gcc8.2-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.3-all/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda10.2-cudnn7-mkl-noavx-gcc8.2/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> - </td>
+    </tr>
+    <tr>
+        <td> cuda10.2-cudnn8-mkl-gcc8.2-trt7.1.3.4 </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda10.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
-        <td> nv-jetson-jetpack4.4/4.5-all </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27mu-linux_aarch64.whl</a></td>
+        <td> jetpack4.4-cuda10.2-cudnn8-trt7.1.3 </td>
+        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.1.0-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_aarch64.whl">
+        paddlepaddle_gpu-2.1.0-cp36-cp36m-linux_aarch64.whl</a></td>
         <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.0.2-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-linux_aarch64.whl</a></td>
-        <td> - </td>
+        <td> <a href="https://paddle-inference-lib.bj.bcebos.com/2.1.0-nv-jetson-jetpack4.4-all/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_aarch64.whl">
+        paddlepaddle_gpu-2.1.0-cp38-cp38-linux_aarch64.whl</a></td>
         <td> - </td>
     </tr>
     <tr>
-        <td> win-cpu-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp35-cp35m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp37-cp37m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle-2.0.2-cp38-cp38-win_amd64.whl">
-        paddlepaddle-2.0.2-cp38-cp38-win_amd64.whl</a></td>
+        <td> cuda11.0-cudnn8-mkl-gcc8.2-avx-trt7.1.3 </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/with-trt/2.1.0-gpu-cuda11.0-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post110-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post110-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> win-cpu-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
+        <td> cuda11.2-cudnn8-mkl-gcc8.2-avx </td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-cuda11.2-cudnn8-mkl-gcc8.2/paddlepaddle_gpu-2.1.0.post112-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.1.0.post112-cp39-cp39-linux_x86_64.whl</a></td>
     </tr>
     <tr>
-        <td> win-cpu-openblas-avx </td>
+        <td> rocm4.0.1-miopen2.11-mkl </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.1.0-gpu-rocm4.0.1-miopen2.11-mkl/paddlepaddle_rocm-2.1.0.rocm401.miopen211-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_rocm-2.1.0.rocm401.miopen211-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cpu-openblas-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/opennoavx/paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post90-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2--win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-openblas-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/openavx/paddlepaddle_gpu-2.0.2.post90-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda9.0-cudnn7-openblas-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/opennoavx/paddlepaddle_gpu-2.0.2.post90-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.0-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post100-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.0-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2.post100-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post101-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2.post101-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.2-cudnn7-mkl-avx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.2-cudnn7-mkl-noavx </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/noavx/paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp27-cp27m-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda11.0-cudnn8-mkl-avx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp35-cp35m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp35-cp35m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp36-cp36m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp37-cp37m-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2/avx/paddlepaddle_gpu-2.0.2.post110-cp38-cp38-win_amd64.whl">
-        paddlepaddle_gpu-2.0.2-cp38-cp38-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> mac-cpu </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp27-cp27m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp27-cp27m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp35-cp35m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp35-cp35m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp36-cp36m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp37-cp37m-macosx_10_6_intel.whl">
-        paddlepaddle-2.0.2-cp37-cp37m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.0.2-cpu-mac/paddlepaddle-2.0.2-cp38-cp38-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.0.2-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
     </tr>
     </tbody>
 </table>
@@ -600,9 +405,9 @@ cuda10_cudnn7-mkl: Support GPU training and prediction, use Intel MKL math libra
 
 - Transverse axis
 
-Generally, it is similar to "cp27-cp27mu", in which:
+Generally, it is similar to "cp37-cp37m", in which:
 
-27:python tag, refers to python2. Similarly, there are "35", "36", "37", etc
+37:python tag, refers to python3.7. Similarly, there are "36", "38", "39", etc
 
 mu:refers to unicode version python, if it is m, refers to non Unicode version Python
 
@@ -618,7 +423,7 @@ distribution: wheel name
 
 version: Version, for example 0.14.0 (must be in numeric format)
 
-python tag: similar to 'py27', 'py2', 'py3', used to indicate the corresponding Python version
+python tag: similar to 'py36', 'py37', 'py38', 'py39', used to indicate the corresponding Python version
 
 abi tag: similar to 'cp33m', 'abi3', 'none'
 


### PR DESCRIPTION
更新了安装附录里 2.1.0 版本的 release 包。
- 删除了对 python2.7 和 python3.5 的支持，新增对 python3.9 的支持。
- 删除了对 cuda9.0 cuda10.0的支持。

没有更新develop的包。
