### PR TITLE
Update macos-compile.md

### DIFF
--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -107,7 +107,7 @@
 10. 执行编译：
 
     ```
-    make -j$(nproc)
+    make -j$(sysctl -n hw.logicalcpu)
     ```
 
     > 使用多核编译


### PR DESCRIPTION
no `nproc` on mac, use `sysctl -n hw.logicalcpu` instead