### PR TITLE
`pip install --no-cache-dir` to diasble the host's cache

### DIFF
--- a/ci_scripts/check_api_cn.sh
+++ b/ci_scripts/check_api_cn.sh
@@ -3,11 +3,11 @@ set -x
 
 function install_paddle() {
     # try to download paddle, and install
+    PADDLE_WHL=https://paddle-fluiddoc-ci.bj.bcebos.com/python/dist/paddlepaddle_gpu-0.0.0-cp38-cp38-linux_x86_64.whl
     if [ ${BRANCH} = 'release/2.1' ] ; then
-        pip install https://paddle-fluiddoc-ci.bj.bcebos.com/python/dist/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl
-    else
-        pip install https://paddle-fluiddoc-ci.bj.bcebos.com/python/dist/paddlepaddle_gpu-0.0.0-cp38-cp38-linux_x86_64.whl
+        PADDLE_WHL=https://paddle-fluiddoc-ci.bj.bcebos.com/python/dist/paddlepaddle_gpu-2.1.0-cp38-cp38-linux_x86_64.whl
     fi
+    pip install --no-cache-dir -i https://mirror.baidu.com/pypi/simple ${PADDLE_WHL}
     # if failed, build paddle
     if [ $? -ne 0 ];then
         build_paddle


### PR DESCRIPTION
some times, the CI machine's cache is not cleaned, so we should use `--no-cache-dir` to force pip install the latest paddle.whl


develop的修改已有 https://github.com/PaddlePaddle/docs/pull/3574 实施，不再单独提交。