### PR TITLE
fix api bugs

### DIFF
--- a/docs/api/paddle/nn/AdaptiveAvgPool2D_cn.rst
+++ b/docs/api/paddle/nn/AdaptiveAvgPool2D_cn.rst
@@ -6,7 +6,7 @@ AdaptiveAvgPool2D
 .. py:function:: paddle.nn.AdaptiveAvgPool2D(output_size, data_format="NCHW", name=None)
 
 该算子根据输入 `x` , `output_size` 等参数对一个输入Tensor计算2D的自适应平均池化。输入和输出都是4-D Tensor，
-默认是以 `NCHW` 格式表示的，其中 `N` 是 batch size, `C` 是通道数, `H` 是输入特征的高度, `H` 是输入特征的宽度。
+默认是以 `NCHW` 格式表示的，其中 `N` 是 batch size, `C` 是通道数, `H` 是输入特征的高度, `W` 是输入特征的宽度。
 
 计算公式如下:
 

--- a/docs/api/paddle/nn/AdaptiveAvgPool3D_cn.rst
+++ b/docs/api/paddle/nn/AdaptiveAvgPool3D_cn.rst
@@ -6,7 +6,7 @@ AdaptiveAvgPool3D
 .. py:function:: paddle.nn.AdaptiveAvgPool3D(output_size, data_format="NCDHW", name=None)
 
 该算子根据输入 `x` , `output_size` 等参数对一个输入Tensor计算3D的自适应平均池化。输入和输出都是5-D Tensor，
-默认是以 `NCDHW` 格式表示的，其中 `N` 是 batch size, `C` 是通道数, `D` 是特征图长度, `H` 是输入特征的高度, `H` 是输入特征的宽度。
+默认是以 `NCDHW` 格式表示的，其中 `N` 是 batch size, `C` 是通道数, `D` 是特征图长度, `H` 是输入特征的高度, `W` 是输入特征的宽度。
 
 计算公式如下:
 

--- a/docs/api/paddle/nn/ClipGradByGlobalNorm_cn.rst
+++ b/docs/api/paddle/nn/ClipGradByGlobalNorm_cn.rst
@@ -16,7 +16,7 @@ ClipGradByGlobalNorm
 
 输入的 Tensor 不是从该类里传入， 而是默认选择优化器中输入的所有参数的梯度。如果某个参数 ``ParamAttr`` 中的 ``need_clip`` 值被设置为 ``False`` ，则该参数的梯度不会被裁剪。
 
-该类需要在初始化 ``optimizer`` 时进行设置后才能生效，可参看 ``optimizer`` 文档(例如： :ref:`cn_api_fluid_optimizer_SGD` )。
+该类需要在初始化 ``optimizer`` 时进行设置后才能生效，可参看 ``optimizer`` 文档(例如： :ref:`cn_api_paddle_optimizer_SGD` )。
 
 裁剪公式如下：
 

--- a/docs/api/paddle/nn/ClipGradByNorm_cn.rst
+++ b/docs/api/paddle/nn/ClipGradByNorm_cn.rst
@@ -16,7 +16,7 @@ ClipGradByNorm
 
 输入的 Tensor 不是从该类里传入， 而是默认选择优化器中输入的所有参数的梯度。如果某个参数 ``ParamAttr`` 中的 ``need_clip`` 值被设置为 ``False`` ，则该参数的梯度不会被裁剪。
 
-该类需要在初始化 ``optimizer`` 时进行设置后才能生效，可参看 ``optimizer`` 文档(例如： :ref:`cn_api_fluid_optimizer_SGD` )。
+该类需要在初始化 ``optimizer`` 时进行设置后才能生效，可参看 ``optimizer`` 文档(例如： :ref:`cn_api_paddle_optimizer_SGD` )。
 
 裁剪公式如下：
 

--- a/docs/api/paddle/nn/ClipGradByValue_cn.rst
+++ b/docs/api/paddle/nn/ClipGradByValue_cn.rst
@@ -12,7 +12,7 @@ ClipGradByValue
 
 输入的 Tensor 不是从该类里传入， 而是默认选择优化器中输入的所有参数的梯度。如果某个参数 ``ParamAttr`` 中的 ``need_clip`` 值被设置为 ``False`` ，则该参数的梯度不会被裁剪。
 
-该类需要在初始化 ``optimizer`` 时进行设置后才能生效，可参看 ``optimizer`` 文档(例如： :ref:`cn_api_fluid_optimizer_SGD` )。
+该类需要在初始化 ``optimizer`` 时进行设置后才能生效，可参看 ``optimizer`` 文档(例如： :ref:`cn_api_paddle_optimizer_SGD` )。
 
 给定一个 Tensor  ``t`` ，该操作将它的值压缩到 ``min`` 和 ``max`` 之间
 


### PR DESCRIPTION
fix api bugs
- paddle.nn.AdaptiveAvgPool2D typo
- paddle.nn.AdaptiveAvgPool2D typo
- paddle.nn.ClipGradByGlobalNorm dead link 
- paddle.nn.ClipGradByNorm dead link 
- paddle.nn.ClipGradByValue dead link 

preview: http://10.136.157.23:8090/documentation/docs/zh/api/paddle/nn/ClipGradByGlobalNorm_cn.html?reviewVersion=jenkins-doc-review-873
![image](https://user-images.githubusercontent.com/11935832/122499103-e0910d00-d022-11eb-88d4-f47838121f99.png)
