### PR TITLE
Update callback doc

### DIFF
--- a/docs/api/paddle/callbacks/Callback_cn.rst
+++ b/docs/api/paddle/callbacks/Callback_cn.rst
@@ -5,7 +5,7 @@ Callback
 
 .. py:class:: paddle.callbacks.Callback()
 
- ``Callback`` 是一个基类，用于实现用户自定义的callback。如果想使用除 :ref:`EarlyStopping <_api_paddle_callbacks_EarlyStopping>` 外的自定义策略终止训练，可以通过在自定义的callback类中设置 ``model.stop_training=True`` 来实现。
+ ``Callback`` 是一个基类，用于实现用户自定义的callback。如果想使用除 :ref:`EarlyStopping <_cn_api_paddle_callbacks_EarlyStopping>` 外的自定义策略终止训练，可以通过在自定义的callback类中设置 ``model.stop_training=True`` 来实现。
 
 **代码示例**：
 

--- a/docs/api/paddle/callbacks/Callback_cn.rst
+++ b/docs/api/paddle/callbacks/Callback_cn.rst
@@ -5,7 +5,7 @@ Callback
 
 .. py:class:: paddle.callbacks.Callback()
 
- ``Callback`` 是一个基类，用于实现用户自定义的callback。
+ ``Callback`` 是一个基类，用于实现用户自定义的callback。如果想使用除 :ref:`EarlyStopping <_api_paddle_callbacks_EarlyStopping>` 外的自定义策略终止训练，可以通过在自定义的callback类中设置 ``model.stop_training=True`` 来实现。
 
 **代码示例**：
 

--- a/docs/api/paddle/callbacks/EarlyStopping_cn.rst
+++ b/docs/api/paddle/callbacks/EarlyStopping_cn.rst
@@ -5,7 +5,7 @@ EarlyStopping
 
 .. py:class:: paddle.callbacks.EarlyStopping(monitor='loss', mode='auto', patience=0, verbose=1, min_delta=0, baseline=None, save_best_model=True)
 
-在模型评估阶段，模型效果如果没有提升，``EarlyStopping`` 会让模型提前停止训练。
+在模型评估阶段，模型效果如果没有提升，``EarlyStopping`` 会通过设置 ``model.stop_training=True`` 让模型提前停止训练。
 
 参数：
   - **monitor** (str，可选) - 监控量。该量作为模型是否停止学习的监控指标。默认值：'loss'。


### PR DESCRIPTION
若用户自定义callback想要阻断训练过程，只需要在自定义的callback中设置`model.stop_training=True`，在这里更新文档以提示用户。