### PR TITLE
[install doc] update develop install doc in 2.1.1 version

### DIFF
--- a/docs/install/Tables.md
+++ b/docs/install/Tables.md
@@ -504,17 +504,17 @@ platform tag: 类似 'linux_x86_64', 'any'
 cd /home/work
 ```
 ```
-docker run -it -v $PWD:/work hub.baidubce.com/paddlepaddle/paddle /work/train.py
+docker run -it -v $PWD:/work registry.baidubce.com/paddlepaddle/paddle /work/train.py
 ```
 
 上述命令中，`-it` 参数说明容器已交互式运行；`-v $PWD:/work`
 指定将当前路径（Linux中PWD变量会展开为当前路径的绝对路径）挂载到容器内部的:`/work`
-目录: `hub.baidubce.com/paddlepaddle/paddle` 指定需要使用的容器； 最后`/work/train.py`为容器内执行的命令，即运行训练程序。
+目录: `registry.baidubce.com/paddlepaddle/paddle` 指定需要使用的容器； 最后`/work/train.py`为容器内执行的命令，即运行训练程序。
 
 当然，您也可以进入到Docker容器中，以交互式的方式执行或调试您的代码：
 
 ```
-docker run -it -v $PWD:/work hub.baidubce.com/paddlepaddle/paddle /bin/bash
+docker run -it -v $PWD:/work registry.baidubce.com/paddlepaddle/paddle /bin/bash
 ```
 ```
 cd /work
@@ -538,13 +538,13 @@ PaddlePaddle Book是为用户和开发者制作的一个交互式的Jupyter Note
 我们提供可以直接运行PaddlePaddle Book的Docker镜像，直接运行：
 
 ```
-docker run -p 8888:8888 hub.baidubce.com/paddlepaddle/book
+docker run -p 8888:8888 registry.baidubce.com/paddlepaddle/book
 ```
 
 国内用户可以使用下面的镜像源来加速访问：
 
 ```
-docker run -p 8888:8888 hub.baidubce.com/paddlepaddle/book
+docker run -p 8888:8888 registry.baidubce.com/paddlepaddle/book
 ```
 
 然后在浏览器中输入以下网址：
@@ -563,7 +563,7 @@ http://localhost:8888/
 请不要忘记提前在物理机上安装GPU最新驱动。
 
 ```
-nvidia-docker run -it -v $PWD:/work hub.baidubce.com/paddlepaddle/paddle:latest-gpu /bin/bash
+nvidia-docker run -it -v $PWD:/work registry.baidubce.com/paddlepaddle/paddle:latest-gpu /bin/bash
 ```
 
 **注: 如果没有安装nvidia-docker，可以尝试以下的方法，将CUDA库和Linux设备挂载到Docker容器内：**
@@ -573,5 +573,5 @@ export CUDA_SO="$(\ls /usr/lib64/libcuda* | xargs -I{} echo '-v {}:{}') \
 $(\ls /usr/lib64/libnvidia* | xargs -I{} echo '-v {}:{}')"
 export DEVICES=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
 docker run ${CUDA_SO} \
-${DEVICES} -it hub.baidubce.com/paddlepaddle/paddle:latest-gpu
+${DEVICES} -it registry.baidubce.com/paddlepaddle/paddle:latest-gpu
 ```

--- a/docs/install/Tables_en.md
+++ b/docs/install/Tables_en.md
@@ -500,16 +500,16 @@ Suppose you have written a PaddlePaddle program in the current directory (such a
 cd /home/work
 ```
 ```
-docker run -it -v $PWD:/work hub.baidubce.com/paddlepaddle/paddle /work/train.py
+docker run -it -v $PWD:/work registry.baidubce.com/paddlepaddle/paddle /work/train.py
 ```
 
 
-In the above commands, the `-it` parameter indicates that the container has been run interactively; `-v $PWD:/work` specifies that the current path (the absolute path where the PWD variable in Linux will expand to the current path) is mounted to the `:/work` directory inside the container: `Hub.baidubce.com/paddlepaddle/paddle` specifies the container to be used; finally `/work/train.py` is the command executed inside the container, ie. the training program.
+In the above commands, the `-it` parameter indicates that the container has been run interactively; `-v $PWD:/work` specifies that the current path (the absolute path where the PWD variable in Linux will expand to the current path) is mounted to the `:/work` directory inside the container: `registry.baidubce.com/paddlepaddle/paddle` specifies the container to be used; finally `/work/train.py` is the command executed inside the container, ie. the training program.
 
 Of course, you can also enter into the Docker container and execute or debug your code interactively:
 
 ```
-docker run -it -v $PWD:/work hub.baidubce.com/paddlepaddle/paddle /bin/bash
+docker run -it -v $PWD:/work registry.baidubce.com/paddlepaddle/paddle /bin/bash
 ```
 ```
 cd /work
@@ -531,13 +531,13 @@ Use Docker to quickly launch a local Jupyter Notebook containing the PaddlePaddl
 We provide a Docker image that can run the PaddlePaddle Book directly, running directly:
 
 ```
-docker run -p 8888:8888 hub.baidubce.com/paddlepaddle/book
+docker run -p 8888:8888 registry.baidubce.com/paddlepaddle/book
 ```
 
 Domestic users can use the following image source to speed up access:
 
 ```
-docker run -p 8888:8888 hub.baidubce.com/paddlepaddle/book
+docker run -p 8888:8888 registry.baidubce.com/paddlepaddle/book
 ```
 
 Then enter the following URL in your browser:
@@ -555,7 +555,7 @@ http://localhost:8888/
 In order to ensure that the GPU driver works properly in the image, we recommend using [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) to run the image. Don't forget to install the latest GPU drivers on your physical machine in advance.
 
 ```
-Nvidia-docker run -it -v $PWD:/work hub.baidubce.com/paddlepaddle/paddle:latest-gpu /bin/bash
+Nvidia-docker run -it -v $PWD:/work registry.baidubce.com/paddlepaddle/paddle:latest-gpu /bin/bash
 ```
 
 **Note: If you don't have nvidia-docker installed, you can try the following to mount the CUDA library and Linux devices into the Docker container:**
@@ -565,5 +565,5 @@ export CUDA_SO="$(\ls /usr/lib64/libcuda* | xargs -I{} echo '-v {}:{}') \
 $(\ls /usr/lib64/libnvidia* | xargs -I{} echo '-v {}:{}')"
 export DEVICES=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
 docker run ${CUDA_SO} \
-${DEVICES} -it hub.baidubce.com/paddlepaddle/paddle:latest-gpu
+${DEVICES} -it registry.baidubce.com/paddlepaddle/paddle:latest-gpu
 ```

--- a/docs/install/compile/linux-compile.md
+++ b/docs/install/compile/linux-compile.md
@@ -125,16 +125,10 @@
     cd /paddle
     ```
 
-5. 切换到较稳定版本下进行编译：
+5. 切换到develop版本进行编译：
 
     ```
-    git checkout [分支名]
-    ```
-
-    例如：
-
-    ```
-    git checkout release/2.1
+    git checkout develop
     ```
 
     注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持, python3.9版本从release/2.1分支开始支持

--- a/docs/install/compile/linux-compile.md
+++ b/docs/install/compile/linux-compile.md
@@ -4,12 +4,12 @@
 
 * **Linux 版本 (64 bit)**
     * **CentOS 6 (不推荐，不提供编译出现问题时的官方支持)**
-    * **CentOS 7 (GPU 版本支持CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0 CUDA 9.1 仅支持单卡模式)**
-    * **Ubuntu 14.04 (GPU 版本支持 CUDA 10.0/10.1)**
-    * **Ubuntu 16.04 (GPU 版本支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2)**
-    * **Ubuntu 18.04 (GPU 版本支持 CUDA 10.0/10.1/10.2/11.0)**
-* **Python 版本 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
-* **pip 或 pip3 版本 20.2.2+ (64 bit)**
+    * **CentOS 7 (GPU 版本支持CUDA 10.1/10.2/11.2)**
+    * **Ubuntu 14.04 (不推荐，不提供编译出现问题时的官方支持)**
+    * **Ubuntu 16.04 (GPU 版本支持 CUDA 10.1/10.2/11.2)**
+    * **Ubuntu 18.04 (GPU 版本支持 CUDA 10.1/10.2/11.2)**
+* **Python 版本 3.6/3.7/3.8/3.9 (64 bit)**
+* **pip 或 pip3 版本 20.2.2或更高版本 (64 bit)**
 
 ## 选择CPU/GPU
 
@@ -17,10 +17,9 @@
 
 * 如果您的计算机有NVIDIA® GPU，请确保满足以下条件以编译GPU版PaddlePaddle
 
-    * **CUDA 工具包9.0/10.0配合cuDNN v7.6+(如需多卡支持，需配合NCCL2.3.7及更高)**
     * **CUDA 工具包10.1/10.2配合cuDNN v7.6+(如需多卡支持，需配合NCCL2.7及更高)**
-    * **CUDA 工具包11.0配合cuDNN v8.0.4(如需多卡支持，需配合NCCL2.7及更高)**
-    * **GPU运算能力超过1.0的硬件设备**
+    * **CUDA 工具包11.2配合cuDNN v8.1.1(如需多卡支持，需配合NCCL2.7及更高)**
+    * **GPU运算能力超过3.5的硬件设备**
 
         您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -63,7 +62,7 @@
 
 在Linux的系统下有2种编译方式：
 
-* [使用Docker编译](#compile_from_docker)（GPU版本不支持CentOS 6）
+* [使用Docker编译](#compile_from_docker)（不提供在CentOS 6下编译中遇到问题的支持）
 * [本机编译](#compile_from_host)（不提供在CentOS 6下编译中遇到问题的支持）
 
 <a name="ct_docker"></a>
@@ -95,28 +94,29 @@
 
     * 编译CPU版本的PaddlePaddle：
         ```
-        docker run --name paddle-test -v $PWD:/paddle --network=host -it hub.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
+        docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
         ```
 
        > --name paddle-test为您创建的Docker容器命名为paddle-test;
 
        > -v $PWD:/paddle 将当前目录挂载到Docker容器中的/paddle目录下（Linux中PWD变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185));
 
-       > -it 与宿主机保持交互状态，`hub.baidubce.com/paddlepaddle/paddle:latest-dev` 使用名为`hub.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建Docker容器，/bin/bash 进入容器后启动/bin/bash命令。
+       > -it 与宿主机保持交互状态，`registry.baidubce.com/paddlepaddle/paddle:latest-dev` 使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建Docker容器，/bin/bash 进入容器后启动/bin/bash命令。
 
 
-    * 编译GPU版本的PaddlePaddle（仅支持CentOS 7）：
+    * 编译GPU版本的PaddlePaddle：
         ```
-        nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it hub.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
+        nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-gpu-cuda10.2-cudnn7-dev /bin/bash
         ```
 
         > --name paddle-test为您创建的Docker容器命名为paddle-test;
 
         > -v $PWD:/paddle 将当前目录挂载到Docker容器中的/paddle目录下（Linux中PWD变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185));
 
-        > -it 与宿主机保持交互状态，`hub.baidubce.com/paddlepaddle/paddle:latest-dev` 使用名为`hub.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建Docker容器，/bin/bash 进入容器后启动/bin/bash命令。
+        > -it 与宿主机保持交互状态，`registry.baidubce.com/paddlepaddle/paddle:latest-gpu-cuda10.2-cudnn7-dev` 使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-gpu-cuda10.2-cudnn7-dev`的镜像创建Docker容器，/bin/bash 进入容器后启动/bin/bash命令。
 
-        > 注意：hub.baidubce.com/paddlepaddle/paddle:latest-dev内部安装CUDA 10.0。
+        > 注：上例中，`latest-gpu-cuda10.2-cudnn7-dev` 也仅作示意用，表示安装GPU版的镜像。如果您还想安装其他cuda/cudnn版本的镜像，可以将其替换成`latest-dev-cuda11.2-cudnn8-gcc82`、`latest-gpu-cuda10.1-cudnn7-gcc82-dev`、`latest-gpu-cuda10.1-cudnn7-gcc54-dev`等。
+        您可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取与您机器适配的镜像。
 
 
 4. 进入Docker后进入paddle目录下：
@@ -125,13 +125,19 @@
     cd /paddle
     ```
 
-5. 切换到develop版本进行编译：
+5. 切换到较稳定版本下进行编译：
 
     ```
-    git checkout develop
+    git checkout [分支名]
     ```
 
-    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持
+    例如：
+
+    ```
+    git checkout release/2.1
+    ```
+
+    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持, python3.9版本从release/2.1分支开始支持
 
 6. 创建并进入/paddle/build路径下：
 
@@ -141,17 +147,11 @@
 
 7. 使用以下命令安装相关依赖：
 
-    For Python2:
     ```
-    pip install protobuf
-    ```
-
-    For Python3:
-    ```
-    pip3.5 install protobuf
+    pip3.7 install protobuf
     ```
 
-    注意：以上用Python3.5命令来举例，如您的Python版本为3.6/3.7/3.8，请将上述命令中的Python3.5改成Python3.6/Python3.7/Python3.8
+    注意：以上用Python3.7命令来举例，如您的Python版本为3.6/3.8/3.9，请将上述命令中的pip3.7改成pip3.6/pip3.8/pip3.9
 
     > 安装protobuf。
 
@@ -164,16 +164,16 @@
 8. 执行cmake：
 
     >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
-    >请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本,  例如`-DPY_VERSION=3.5`表示python版本为3.5.x
+    >请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本,  例如`-DPY_VERSION=3.7`表示python版本为3.7
 
     * 对于需要编译**CPU版本PaddlePaddle**的用户：
         ```
-        cmake .. -DPY_VERSION=3.5 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPY_VERSION=3.7 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
     * 对于需要编译**GPU版本PaddlePaddle**的用户：
         ```
-        cmake .. -DPY_VERSION=3.5 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPY_VERSION=3.7 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
     > 我们目前不支持CentOS 6下使用Docker编译GPU版本的PaddlePaddle
@@ -194,17 +194,13 @@
 
 11. 在当前机器或目标机器安装编译好的`.whl`包：
 
-    For Python2:
-    ```
-    pip install -U（whl包的名字）
-    ```
 
     For Python3:  
     ```
-    pip3.5 install -U（whl包的名字）
+    pip3.7 install -U（whl包的名字）
     ```
 
-    注意：以上涉及Python3的命令，用Python3.5来举例，如您的Python版本为3.6/3.7/3.8，请将上述命令中的Python3.5改成Python3.6/Python3.7/Python3.8
+    注意：以上用Python3.7命令来举例，如您的Python版本为3.6/3.8/3.9，请将上述命令中的pip3.7改成pip3.6/pip3.8/pip3.9
 
 恭喜，至此您已完成PaddlePaddle的编译安装。您只需要进入Docker容器后运行PaddlePaddle，即可开始使用。更多Docker使用请参见[Docker官方文档](https://docs.docker.com)
 
@@ -337,33 +333,20 @@
 
     * a. 安装Python-dev:
 
-        For Python2:
-
-        ```
-        yum install python-devel
-        ```
-
-        For Python3: (请参照Python官方流程安装）
+        (请参照Python官方流程安装）
 
 
     * b. 安装pip:
 
-        For Python2:
+        (请参照Python官方流程安装, 并保证拥有20.2.2及以上的pip3版本，请注意，python3.6及以上版本环境下，pip3并不一定对应python版本，如python3.7下默认只有pip3.7）
 
-        ```
-        yum install python-pip
-        ```
-        (请保证拥有20.2.2及以上的pip版本)
-
-        For Python3: (请参照Python官方流程安装, 并保证拥有20.2.2及以上的pip3版本，请注意，python3.6及以上版本环境下，pip3并不一定对应python版本，如python3.7下默认只有pip3.7）
-
-    * c.（Only For Python3）设置Python3相关的环境变量，这里以python3.5版本示例，请替换成您使用的版本（3.6、3.7、3.8）：
+    * c.（Only For Python3）设置Python3相关的环境变量，这里以python3.7版本示例，请替换成您使用的版本（3.6、3.8、3.9）：
 
         1. 首先使用
             ```
             find `dirname $(dirname $(which python3))` -name "libpython3.so"
             ```
-            找到Python lib的路径，如果是3.6、3.7、3.8，请将`python3`改成`python3.6`、`python3.7`、`python3.8`，然后将下面[python-lib-path]替换为找到文件路径
+            找到Python lib的路径，如果是3.6、3.7、3.8、3.9，请将`python3`改成`python3.6`、`python3.7`、`python3.8`、`python3.9`，然后将下面[python-lib-path]替换为找到文件路径
 
         2. 设置PYTHON_LIBRARIES：
             ```
@@ -372,7 +355,7 @@
 
         3. 其次使用
             ```
-            find `dirname $(dirname $(which python3))`/include -name "python3.5m"
+            find `dirname $(dirname $(which python3))`/include -name "python3.7m"
             ```
             找到Python Include的路径，请注意python版本，然后将下面[python-include-path]替换为找到文件路径
 
@@ -387,7 +370,7 @@
             ```
             （这里将[python-lib-path]的最后两级目录替换为/bin/)
 
-    * d. 安装虚环境`virtualenv`以及`virtualenvwrapper`并创建名为`paddle-venv`的虚环境：(请注意对应python版本的pip3的命令，如pip3.6、pip3.7、pip3.8)
+    * d. 安装虚环境`virtualenv`以及`virtualenvwrapper`并创建名为`paddle-venv`的虚环境：(请注意对应python版本的pip3的命令，如pip3.6、pip3.7、pip3.8、pip3.9)
 
         1. 安装`virtualenv`
             ```
@@ -469,16 +452,9 @@
 
     *  对于需要编译**CPU版本PaddlePaddle**的用户：
 
-        For Python2:
 
         ```
-        cmake .. -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-        ```
-
-        For Python3:
-
-        ```
-        cmake .. -DPY_VERSION=3.5 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
+        cmake .. -DPY_VERSION=3.7 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
         -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
@@ -486,7 +462,7 @@
         > 请注意PY_VERSION参数更换为您需要的python版本
 
 
-    * 对于需要编译**GPU版本PaddlePaddle**的用户：(**仅支持CentOS7（CUDA10.2/CUDA10.1/CUDA10.0/CUDA9)**)
+    * 对于需要编译**GPU版本PaddlePaddle**的用户：(**仅支持CentOS7（CUDA11.2/CUDA10.2/CUDA10.1)**)
 
         1. 请确保您已经正确安装nccl2，或者按照以下指令安装nccl2（这里提供的是CUDA9，cuDNN7下nccl2的安装指令，更多版本的安装信息请参考NVIDIA[官方网站](https://developer.nvidia.com/nccl)）:
 
@@ -520,19 +496,11 @@
 
         2. 如果您已经正确安装了`nccl2`，就可以开始cmake了：(*For Python3: 请给PY_VERSION参数配置正确的python版本*)
 
-            For Python2:
-
-            ```
-            cmake .. -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-            ```
-
-            For Python3:
-
             ```
             cmake .. -DPYTHON_EXECUTABLE:FILEPATH=[您可执行的Python3的路径] -DPYTHON_INCLUDE_DIR:PATH=[之前的PYTHON_INCLUDE_DIRS] -DPYTHON_LIBRARY:FILEPATH=[之前的PYTHON_LIBRARY] -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
             ```
 
-    注意：以上涉及Python3的命令，用Python3.5来举例，如您的Python版本为3.6/3.7/3.8，请将上述命令中的Python3.5改成Python3.6/Python3.7/Python3.8
+    注意：以上涉及Python3的命令，用Python3.7来举例，如您的Python版本为3.6/3.8/3.9，请将上述命令中的Python3.7改成Python3.6/Python3.8/Python3.9
 
 
 

--- a/docs/install/compile/linux-compile_en.md
+++ b/docs/install/compile/linux-compile_en.md
@@ -2,14 +2,14 @@
 
 ## Environment preparation
 
-* **CentOS version (64 bit)**
+* **Linux version (64 bit)**
     * **CentOS 6 (not recommended, no official support for compilation problems)**
-    * **CentOS 7 (GPU version supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0 CUDA 9.1, only support single-card mode)**
-    * **Ubuntu 14.04 (GPU version supports CUDA 10.0/10.1)**
-    * **Ubuntu 16.04 (GPU version supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2)**
-    * **Ubuntu 18.04 (GPU version supports CUDA 10.0/10.1/10.2/11.0)**
-* **Python version 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
-* **pip or pip3 version 20.2.2+ (64 bit)**
+    * **CentOS 7 (GPU version supports CUDA 10.1/10.2/11.2**
+    * **Ubuntu 14.04 (not recommended, no official support for compilation problems)**
+    * **Ubuntu 16.04 (GPU version supports CUDA 10.1/10.2/11.2)**
+    * **Ubuntu 18.04 (GPU version supports CUDA 10.1/10.2/11.2)**
+* **Python version 3.6/3.7/3.8/3.9 (64 bit)**
+* **pip or pip3 version 20.2.2 or above (64 bit)**
 
 ## Choose CPU/GPU
 
@@ -17,10 +17,9 @@
 
 * If your computer has NVIDIA® GPU, and the following conditions are met，GPU version of PaddlePaddle is recommended.
 
-    * **CUDA toolkit 9.0/10.0 with cuDNN v7.6+(for multi card support, NCCL2.3.7 or higher)**
     * **CUDA toolkit 10.1/10.2 with cuDNN v7.6+(for multi card support, NCCL2.7 or higher)**
-    * **CUDA toolkit 11.0 with cuDNN v8.0.4(for multi card support, NCCL2.3.7 or higher)**
-    * **Hardware devices with GPU computing power over 1.0**
+    * **CUDA toolkit 11.2 with cuDNN v8.1.1(for multi card support, NCCL2.7 or higher)**
+    * **Hardware devices with GPU computing power over 3.5**
 
         You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -59,7 +58,7 @@
 
 There are two compilation methods under Linux system:
 
-* [Compile with Docker](#compile_from_docker)(GPU version doesn't support CentOS 6)
+* [Compile with Docker](#compile_from_docker) (no official support for compilation problems under CentOS 6)
 * [Local compilation](#compile_from_host) (no official support for compilation problems under CentOS 6)
 
 <a name="ct_docker"></a>
@@ -93,7 +92,7 @@ Please follow the steps below to install:
 
 
         ```
-        docker run --name paddle-test -v $PWD:/paddle --network=host -it hub.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
+        docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
         ```
 
         > --name paddle-test names the Docker container you created as paddle-test;
@@ -102,16 +101,16 @@ Please follow the steps below to install:
         > -v $PWD:/paddle mount the current directory to the /paddle directory in the docker container (PWD variable in Linux will be expanded to [absolute path](https://baike.baidu.com/item/绝对路径/481185) of the current path);
 
 
-        > -it keeps interaction with the host，`hub.baidubce.com/paddlepaddle/paddle:latest-dev` use the image named `hub.baidubce.com/paddlepaddle/paddle:latest-dev` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
+        > -it keeps interaction with the host，`registry.baidubce.com/paddlepaddle/paddle:latest-dev` use the image named `registry.baidubce.com/paddlepaddle/paddle:latest-dev` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
 
 
 
-    * Compile GPU version of PaddlePaddle (only supports CentOS 7):
+    * Compile GPU version of PaddlePaddle:
 
 
 
         ```
-        nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it hub.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
+        nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-gpu-cuda10.2-cudnn7-dev /bin/bash
         ```
 
         > --name paddle-test names the Docker container you created as paddle-test;
@@ -121,10 +120,11 @@ Please follow the steps below to install:
 
 
 
-        > -it keeps interaction with the host，`hub.baidubce.com/paddlepaddle/paddle:latest-dev` use the image named `hub.baidubce.com/paddlepaddle/paddle:latest-dev` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
+        > -it keeps interaction with the host，`registry.baidubce.com/paddlepaddle/paddle:latest-gpu-cuda10.2-cudnn7-dev` use the image named `registry.baidubce.com/paddlepaddle/paddle:latest-gpu-cuda10.2-cudnn7-dev` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
 
 
-        > Note: hub.baidubce.com/paddlepaddle/paddle:latest-dev internally install CUDA 10.0.
+        > Note: In the above example, `latest-gpu-cuda10.2-cudnn7-dev` is only for illustration, indicating that the GPU version of the image is installed. If you want to install another `cuda/cudnn` version of the image, you can replace it with `latest-dev-cuda11.2-cudnn8-gcc82`, `latest-gpu-cuda10.1-cudnn7-gcc82-dev`, `latest-gpu-cuda10.1-cudnn7-gcc54-dev` etc.
+        You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get the image that matches your machine.
 
 
 4. After entering Docker, go to the paddle directory:
@@ -140,7 +140,7 @@ Please follow the steps below to install:
     git checkout develop
     ```
 
-    Note: python3.6、python3.7 version started supporting from release/1.2 branch, python3.8 version started supporting from release/1.8 branch
+    Note: python3.6、python3.7 version started supporting from release/1.2 branch, python3.8 version started supporting from release/1.8 branch, python3.9 version started supporting from release/2.1 branch
 
 6. Create and enter the /paddle/build path:
 
@@ -151,16 +151,11 @@ Please follow the steps below to install:
 7. Use the following command to install the dependencies:
 
 
-    For Python2:
     ```
-    pip install protobuf
-    ```
-    For Python3:
-    ```
-    pip3.5 install protobuf
+    pip3.7 install protobuf
     ```
 
-    Note: We used Python3.5 command as an example above, if the version of your Python is 3.6/3.7/3.8, please change Python3.5 in the commands to Python3.6/Python3.7/Python3.8
+    Note: We used Python3.7 command as an example above, if the version of your Python is 3.6/3.8/3.9, please change pip3.7 in the commands to pip3.6/pip3.8/pip3.9
 
     > Install protobuf 3.1.0
 
@@ -173,17 +168,17 @@ Please follow the steps below to install:
 8. Execute cmake:
 
     > For details on the compilation options, see the [compilation options table](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile).
-    > Please attention to modify parameters `-DPY_VERSION` for the version of Python you want to compile with, for example `-DPY_VERSION=3.5` means the version of python is 3.5.x
+    > Please attention to modify parameters `-DPY_VERSION` for the version of Python you want to compile with, for example `-DPY_VERSION=3.7` means the version of python is 3.7
 
     * For users who need to compile the **CPU version PaddlePaddle**:
 
         ```
-        cmake .. -DPY_VERSION=3.5 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPY_VERSION=3.7 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
     * For users who need to compile the **GPU version PaddlePaddle**:
         ```
-        cmake .. -DPY_VERSION=3.5 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPY_VERSION=3.7 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
     > We currently do not support the compilation of the GPU version PaddlePaddle under CentOS 6.
@@ -203,16 +198,12 @@ Please follow the steps below to install:
 
 11. Install the compiled `.whl` package on the current machine or target machine:
 
-    For Python2:
-    ```
-    pip install -U (whl package name)
-    ```
     For Python3:
     ```
-    pip3.5 install -U (whl package name)
+    pip3.7 install -U (whl package name)
     ```
 
-    Note: For the command involving Python 3, we use Python 3.5 as an example above, if the version of your Python is 3.6/3.7/3.8, please change Python3.5 in the commands to Python3.6/Python3.7/Python3.8
+    Note: We used Python3.7 command as an example above, if the version of your Python is 3.6/3.8/3.9, please change pip3.7 in the commands to pip3.6/pip3.8/pip3.9
 
 Congratulations, now that you have successfully installed PaddlePaddle using Docker, you only need to run PaddlePaddle after entering the Docker container. For more Docker usage, please refer to the [official Docker documentation](https://docs.docker.com/).
 
@@ -326,31 +317,21 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
     * a. Install Python-dev:
 
-        For Python2:
-        ```
-        yum install python-devel
-        ```
-        For Python3: (Please refer to the official Python installation process)
+        (Please refer to the official Python installation process)
 
 
     * b. Install pip:
 
 
-        For Python2:
-        ```
-        yum install python-pip
-        ```
-        (please have a pip version of 20.2.2 and above)
+        (Please refer to the official Python installation process, and ensure that the pip3 version 20.2.2 and above, please note that in python3.6 and above, pip3 does not necessarily correspond to the python version, such as python3.7 default only Pip3.7)
 
-        For Python3: (Please refer to the official Python installation process, and ensure that the pip3 version 20.2.2 and above, please note that in python3.6 and above, pip3 does not necessarily correspond to the python version, such as python3.7 default only Pip3.7)
-
-    * c. (Only For Python3) set Python3 related environment variables, here is python3.5 version example, please replace with the version you use (3.6, 3.7,3.8):
+    * c. (Only For Python3) set Python3 related environment variables, here is python3.7 version example, please replace with the version you use (3.6, 3.8, 3.9):
 
         1. First find the path to the Python lib using
             ```
             find `dirname $(dirname $(which python3))` -name "libpython3.so"
             ```
-            If it is 3.6,3.7,3.8, change `python3` to `python3.6`,`python3.7`,python3.8, then replace [python-lib-path] in the following steps with the file path found.
+            If it is 3.6,3.7,3.8,3.9, change `python3` to `python3.6`,`python3.7`, `python3.8`, `python3.9`, then replace [python-lib-path] in the following steps with the file path found.
 
         2. Set PYTHON_LIBRARIES:
             ```
@@ -359,7 +340,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
         3. Secondly, use
             ```
-            find `dirname $(dirname $(which python3))`/include -name "python3.5m"
+            find `dirname $(dirname $(which python3))`/include -name "python3.7m"
             ```
             to find the path to Python Include, please pay attention to the python version, then replace the following [python-include-path] to the file path found.
 
@@ -374,7 +355,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
             ```
             (here replace the last two levels content of [python-lib-path] with /bin/)
 
-    * d. Install the virtual environment `virtualenv` and `virtualenvwrapper` and create a virtual environment called `paddle-venv`: (please note the pip3 commands corresponding to the python version, such as pip3.6, pip3.7, pip3.8)
+    * d. Install the virtual environment `virtualenv` and `virtualenvwrapper` and create a virtual environment called `paddle-venv`: (please note the pip3 commands corresponding to the python version, such as pip3.6, pip3.7, pip3.8, pip3.9)
 
         1. Install `virtualenv`:
             ```
@@ -442,7 +423,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
     cd Paddle
     ```
 
-8. Switch to `develop` branch for compilation (support for Python 3.6 and 3.7 is added from the 1.2 branch, support for Python 3.8 is added from the 1.8 branch):
+8. Switch to `develop` branch for compilation (support for Python 3.6 and 3.7 is added from the 1.2 branch, support for Python 3.8 is added from the 1.8 branch, support for Python 3.9 is added from the 2.1 branch):
 
     ```
     git checkout develop
@@ -460,14 +441,8 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
     * For users who need to compile the **CPU version PaddlePaddle**:
 
-
-        For Python2:
         ```
-        cmake .. -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-        ```
-        For Python3:
-        ```
-        cmake .. -DPY_VERSION=3.5 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
+        cmake .. -DPY_VERSION=3.7 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
         -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
@@ -494,18 +469,13 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
         2. If you have already installed `nccl2` correctly, you can start cmake: *(For Python3: Please configure the correct python version for the PY_VERSION parameter)*
 
-            For Python2:
-            ```
-            cmake .. -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-            ```
 
-            For Python3:
             ```
             cmake .. -DPYTHON_EXECUTABLE:FILEPATH=[您可执行的Python3的路径] -DPYTHON_INCLUDE_DIR:PATH=[之前的PYTHON_INCLUDE_DIRS] -DPYTHON_LIBRARY:FILEPATH=[之前的PYTHON_LIBRARY] -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
             ```
 
 
-    Note: For the command involving Python 3, we use Python 3.5 as an example above, if the version of your Python is 3.6/3.7/3.8, please change Python3.5 in the commands to Python3.6/Python3.7/Python3.8
+    Note: For the command involving Python 3, we use Python 3.7 as an example above, if the version of your Python is 3.6/3.8/3.9, please change Python3.7 in the commands to Python3.6/Python3.8/Python3.9
 
 
 

--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -3,8 +3,8 @@
 ## 环境准备
 
 * **MacOS 版本 10.11/10.12/10.13/10.14 (64 bit) (不支持GPU版本)**
-* **Python 版本 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
-* **pip 或 pip3 版本 20.2.2+ (64 bit)**
+* **Python 版本 3.6/3.7/3.8/3.9 (64 bit)**
+* **pip 或 pip3 版本 20.2.2或更高版本 (64 bit)**
 
 ## 选择CPU/GPU
 
@@ -45,10 +45,10 @@
 4. 创建并进入满足编译环境的Docker容器：
 
     ```
-    docker run --name paddle-test -v $PWD:/paddle --network=host -it hub.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
     ```
 
-    > --name paddle-test为您创建的Docker容器命名为paddle-test，-v $PWD:/paddle 将当前目录挂载到Docker容器中的/paddle目录下（Linux中PWD变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185)），-it 与宿主机保持交互状态，`hub.baidubce.com/paddlepaddle/paddle:latest-dev` 使用名为`hub.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建Docker容器，/bin/bash 进入容器后启动/bin/bash命令。
+    > --name paddle-test为您创建的Docker容器命名为paddle-test，-v $PWD:/paddle 将当前目录挂载到Docker容器中的/paddle目录下（Linux中PWD变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185)），-it 与宿主机保持交互状态，`registry.baidubce.com/paddlepaddle/paddle:latest-dev` 使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建Docker容器，/bin/bash 进入容器后启动/bin/bash命令。
 
 5. 进入Docker后进入paddle目录下：
 
@@ -62,7 +62,7 @@
     git checkout develop
     ```
 
-    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持
+    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持, python3.9版本从release/2.1分支开始支持
 
 7. 创建并进入/paddle/build路径下：
 
@@ -72,16 +72,11 @@
 
 8. 使用以下命令安装相关依赖：
 
-    For Python2:
     ```
-    pip install protobuf==3.1.0
-    ```
-    For Python3:
-    ```
-    pip3.5 install protobuf==3.1.0
+    pip3.7 install protobuf==3.1.0
     ```
 
-    注意：以上用Python3.5命令来举例，如您的Python版本为3.6/3.7/3.8，请将上述命令中的Python3.5改成Python3.6/Python3.7/Python3.8
+    注意：以上用Python3.7命令来举例，如您的Python版本为3.6/3.8/3.9，请将上述命令中的pip3.7改成pip3.6/pip3.8/pip3.9
 
     > 安装protobuf 3.1.0。
 
@@ -94,12 +89,12 @@
 9. 执行cmake：
 
     >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
-    >请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本,  例如`-DPY_VERSION=3.5`表示python版本为3.5.x
+    >请注意修改参数`-DPY_VERSION`为您希望编译使用的python版本,  例如`-DPY_VERSION=3.7`表示python版本为3.7
 
     *  对于需要编译**CPU版本PaddlePaddle**的用户：
 
         ```
-        cmake .. -DPY_VERSION=3.5 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DWITH_AVX=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPY_VERSION=3.7 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DWITH_AVX=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
         > 我们目前不支持MacOS下GPU版本PaddlePaddle的编译
@@ -107,7 +102,7 @@
 10. 执行编译：
 
     ```
-    make -j$(sysctl -n hw.logicalcpu)
+    make -j$(nproc)
     ```
 
     > 使用多核编译
@@ -119,16 +114,11 @@
 
 12. 在当前机器或目标机器安装编译好的`.whl`包：
 
-    For Python2:
     ```
-    pip install -U（whl包的名字）
-    ```
-    For Python3:
-    ```
-    pip3.5 install -U（whl包的名字)
+    pip3.7 install -U（whl包的名字)
     ```
 
-    注意：以上涉及Python3的命令，用Python3.5来举例，如您的Python版本为3.6/3.7/3.8，请将上述命令中的Python3.5改成Python3.6/Python3.7/Python3.8
+    注意：以上用Python3.7命令来举例，如您的Python版本为3.6/3.8/3.9，请将上述命令中的pip3.7改成pip3.6/pip3.8/pip3.9
 
 恭喜，至此您已完成PaddlePaddle的编译安装。您只需要进入Docker容器后运行PaddlePaddle，即可开始使用。更多Docker使用请参见[Docker官方文档](https://docs.docker.com)
 
@@ -148,28 +138,14 @@
 
 2. 安装Python以及pip：
 
-    > **请不要使用MacOS中自带Python**，我们强烈建议您使用[Homebrew](https://brew.sh)安装python(对于**Python3**请使用python[官方下载](https://www.python.org/downloads/mac-osx/)python3.5.x、python3.6.x、python3.7.x、python3.8), pip以及其他的依赖，这将会使您高效编译。
+    > **请不要使用MacOS中自带Python**，我们强烈建议您使用[Homebrew](https://brew.sh)安装python(对于**Python3**请使用python[官方下载](https://www.python.org/downloads/mac-osx/)python3.6.x、python3.7.x、python3.8、python3.9), pip以及其他的依赖，这将会使您高效编译。
 
-    For python2:
-    ```
-    brew install python@2
-    ```
-    For python3: 使用Python官网安装
+    使用Python官网安装
 
     > 请注意，当您的mac上安装有多个python时请保证您正在使用的python是您希望使用的python。
 
-3. (Only For Python2)设置Python相关的环境变量：
 
-    - 请使用
-        ```
-        find / -name libpython2.7.dylib
-        ```
-        找到您当前使用python的`libpython2.7.dylib`路径，并使用
-        ```
-        export LD_LIBRARY_PATH=[libpython2.7.dylib的路径] && export DYLD_LIBRARY_PATH=[libpython2.7.dylib所在的目录的上两级目录]
-        ```
-
-4. (Only For Python3)设置Python相关的环境变量：
+3. (Only For Python3)设置Python相关的环境变量：
 
     - a. 首先使用
         ```
@@ -182,7 +158,7 @@
         export PYTHON_LIBRARY=[python-lib-path]
         ```
 
-    - c. 其次使用找到PythonInclude的路径（通常是找到[python-lib-path]的上一级目录为同级目录的include,然后找到该目录下python3.x或者python2.x的路径），然后（下面[python-include-path]替换为找到路径）
+    - c. 其次使用找到PythonInclude的路径（通常是找到[python-lib-path]的上一级目录为同级目录的include,然后找到该目录下python3.x的路径），然后（下面[python-include-path]替换为找到路径）
     - d. 设置PYTHON_INCLUDE_DIR:
         ```
         export PYTHON_INCLUDE_DIRS=[python-include-path]
@@ -206,7 +182,7 @@
 
     - g. (可选）如果您是在MacOS 10.14上编译PaddlePaddle，请保证您已经安装了[对应版本](http://developer.apple.com/download)的Xcode。
 
-5. **执行编译前**请您确认您的环境中安装有[编译依赖表](../Tables.html#third_party)中提到的相关依赖，否则我们强烈推荐使用`Homebrew`安装相关依赖。
+4. **执行编译前**请您确认您的环境中安装有[编译依赖表](../Tables.html#third_party)中提到的相关依赖，否则我们强烈推荐使用`Homebrew`安装相关依赖。
 
     > MacOS下如果您未自行修改或安装过“编译依赖表”中提到的依赖，则仅需要使用`pip`安装`numpy，protobuf，wheel`，使用`homebrew`安装`wget，swig, unrar`，另外安装`cmake`即可
 
@@ -222,7 +198,7 @@
 
     - b. 如果您不想使用系统默认的blas而希望使用自己安装的OPENBLAS请参见[FAQ](../FAQ.html/#OPENBLAS)
 
-6. 将PaddlePaddle的源码clone在当下目录下的Paddle的文件夹中，并进入Padde目录下：
+5. 将PaddlePaddle的源码clone在当下目录下的Paddle的文件夹中，并进入Padde目录下：
 
     ```
     git clone https://github.com/PaddlePaddle/Paddle.git
@@ -232,50 +208,45 @@
     cd Paddle
     ```
 
-7. 切换到`develop`分支下进行编译：
+6. 切换到`develop`分支下进行编译：
 
     ```
     git checkout develop
     ```
 
-    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持
+    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持, python3.9版本从release/2.1分支开始支持
 
-8. 并且请创建并进入一个叫build的目录下：
+7. 并且请创建并进入一个叫build的目录下：
 
     ```
     mkdir build && cd build
     ```
 
-9. 执行cmake：
+8. 执行cmake：
 
     >具体编译选项含义请参见[编译选项表](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/install/Tables.html#Compile)
 
     *  对于需要编译**CPU版本PaddlePaddle**的用户：
 
-        For Python2:
         ```
-        cmake .. -DWITH_GPU=OFF -DWITH_TESTING=OFF  -DCMAKE_BUILD_TYPE=Release
-        ```
-        For Python3:
-        ```
-        cmake .. -DPY_VERSION=3.5 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
+        cmake .. -DPY_VERSION=3.7 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
         -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF -DWITH_TESTING=OFF  -DCMAKE_BUILD_TYPE=Release
         ```
 
-    >`-DPY_VERSION=3.5`请修改为安装环境的Python版本
+    >`-DPY_VERSION=3.7`请修改为安装环境的Python版本
 
-10. 使用以下命令来编译：
+9. 使用以下命令来编译：
 
     ```
     make -j4
     ```
 
-11. 编译成功后进入`/paddle/build/python/dist`目录下找到生成的`.whl`包：
+10. 编译成功后进入`/paddle/build/python/dist`目录下找到生成的`.whl`包：
     ```
     cd /paddle/build/python/dist
     ```
 
-12. 在当前机器或目标机器安装编译好的`.whl`包：
+11. 在当前机器或目标机器安装编译好的`.whl`包：
 
     ```
     pip install -U（whl包的名字）

--- a/docs/install/compile/macos-compile_en.md
+++ b/docs/install/compile/macos-compile_en.md
@@ -3,8 +3,8 @@
 ## Environment preparation
 
 * **MacOS version 10.11/10.12/10.13/10.14 (64 bit) (not support GPU version)**
-* **Python version 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
-* **pip or pip3 version 20.2.2+ (64 bit)**
+* **Python version 3.6/3.7/3.8/3.9 (64 bit)**
+* **pip or pip3 version 20.2.2 or above (64 bit)**
 
 ## Choose CPU/GPU
 
@@ -45,14 +45,14 @@ Please follow the steps below to install:
 4. Create and enter a Docker container that meets the compilation environment:
 
     ```
-    docker run --name paddle-test -v $PWD:/paddle --network=host -it hub.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
     ```
 
     > --name paddle-test name the Docker container you created as paddle-test,
 
     > -v $PWD:/paddle mount the current directory to the /paddle directory in the Docker container (the PWD variable in Linux will expand to the current path's [Absolute path](https://baike.baidu.com/item/绝对路径/481185)),
 
-    > -it keeps interacting with the host, `hub.baidubce.com/paddlepaddle/paddle:latest-dev` creates a Docker container with a mirror named `hub.baidubce.com/paddlepaddle/paddle:latest-dev`, /bin /bash starts the /bin/bash command after entering the container.
+    > -it keeps interacting with the host, `registry.baidubce.com/paddlepaddle/paddle:latest-dev` creates a Docker container with a mirror named `registry.baidubce.com/paddlepaddle/paddle:latest-dev`, /bin /bash starts the /bin/bash command after entering the container.
 
 5. After entering Docker, go to the paddle directory:
 
@@ -66,7 +66,7 @@ Please follow the steps below to install:
     git checkout develop
     ```
 
-    Note: python3.6、python3.7 version started supporting from release/1.2 branch, python3.8 version started supporting from release/1.8 branch
+    Note: python3.6、python3.7 version started supporting from release/1.2 branch, python3.8 version started supporting from release/1.8 branch, python3.9 version started supporting from release/2.1 branch
 
 7. Create and enter the /paddle/build path:
 
@@ -76,16 +76,11 @@ Please follow the steps below to install:
 
 8. Use the following command to install the dependencies:
 
-    For Python2:
     ```
-    pip install protobuf==3.1.0
-    ```
-    For Python3:
-    ```
-    pip3.5 install protobuf==3.1.0
+    pip3.7 install protobuf==3.1.0
     ```
 
-    Note: We used Python3.5 command as an example above, if the version of your Python is 3.6/3.7/3.8, please change Python3.5 in the commands to Python3.6/Python3.7/Python3.8
+    Note: We used Python3.7 command as an example above, if the version of your Python is 3.6/3.8/3.9, please change pip3.7 in the commands to pip3.6/pip3.8/pip3.9
 
     > Install protobuf 3.1.0.
 
@@ -98,12 +93,12 @@ Please follow the steps below to install:
 9. Execute cmake:
 
     > For details on the compilation options, see the [compilation options table](../Tables_en.html/#Compile).
-    > Please attention to modify parameters `-DPY_VERSION` for the version of Python you want to compile with, for example `-DPY_VERSION=3.5` means the version of python is 3.5.x
+    > Please attention to modify parameters `-DPY_VERSION` for the version of Python you want to compile with, for example `-DPY_VERSION=3.7` means the version of python is 3.7
 
     * For users who need to compile the **CPU version PaddlePaddle**:
 
         ```
-        cmake .. -DPY_VERSION=3.5 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DWITH_AVX=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPY_VERSION=3.7 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DWITH_AVX=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
         > We currently do not support the compilation of the GPU version PaddlePaddle under CentOS.
@@ -121,19 +116,15 @@ Please follow the steps below to install:
     cd /paddle/build/python/dist
     ```
 
-12. Install the compiled `.whl` package on the current machine or target machine: (For Python3: Please select the pip corresponding to the python version you wish to use, such as pip3.5, pip3.6)
+12. Install the compiled `.whl` package on the current machine or target machine: (For Python3: Please select the pip corresponding to the python version you wish to use, such as pip3.6)
 
 
-    For Python2:
-    ```
-    pip install -U (whl package name)
-    ```
     For Python3:
     ```
-    pip3.5 install -U (whl package name)
+    pip3.7 install -U (whl package name)
     ```
 
-    Note: We used Python3.5 command as an example above, if the version of your Python is 3.6/3.7/3.8, please change Python3.5 in the commands to Python3.6/Python3.7/Python3.8
+    Note: We used Python3.7 command as an example above, if the version of your Python is 3.6/3.8/3.9, please change pip3.7 in the commands to pip3.6/pip3.8/pip3.9
 
 Congratulations, now that you have successfully installed PaddlePaddle using Docker, you only need to run PaddlePaddle after entering the Docker container. For more Docker usage, please refer to the [official Docker documentation](https://docs.docker.com/).
 
@@ -149,29 +140,15 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
 2. Install python and pip:
 
-    > **Please do not use the Python initially given by MacOS**, we strongly recommend that you use [Homebrew](https://brew.sh/) to install python (for Python3 please use python [official download](https://www.python.org/downloads/mac-osx/) python3.5.x, python3.6.x, python3.7.x, python3.8), pip and other dependencies, This will greatly reduce the difficulty of installing and compiling.
+    > **Please do not use the Python initially given by MacOS**, we strongly recommend that you use [Homebrew](https://brew.sh/) to install python (for Python3 please use python [official download](https://www.python.org/downloads/mac-osx/) python3.6.x, python3.7.x, python3.8, python3.9), pip and other dependencies, This will greatly reduce the difficulty of installing and compiling.
 
-    For python2:
-    ```
-    brew install python@2
-    ```
-    For python3: Install using Python official website
+    Install using Python official website
 
 
     > Please note that when you have multiple pythons installed on your mac, make sure that the python you are using is the python you wish to use.
 
-3. (Only For Python2) Set Python-related environment variables:
 
-    - Use
-        ```
-        find / -name libpython2.7.dylib
-        ```
-        to find your current python `libpython2.7.dylib` path and use
-        ```
-        export LD_LIBRARY_PATH=[libpython2.7.dylib path] && export DYLD_LIBRARY_PATH=[libpython2.7.dylib  to the top two directories of the directory]
-        ```
-
-4. (Only For Python3) Set Python-related environment variables:
+3. (Only For Python3) Set Python-related environment variables:
 
     - a. First use
         ```
@@ -184,7 +161,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
         export PYTHON_LIBRARY=[python-lib-path]
         ```
 
-    - c. Secondly use the path to find PythonInclude (usually find the above directory of [python-lib-path] as the include of the same directory, then find the path of python3.x or python2.x in the directory), then (the [python-include-path] in the following commands should be replaced by the path found here)
+    - c. Secondly use the path to find PythonInclude (usually find the above directory of [python-lib-path] as the include of the same directory, then find the path of python3.x in the directory), then (the [python-include-path] in the following commands should be replaced by the path found here)
 
     - d. Set PYTHON_INCLUDE_DIR:
         ```
@@ -210,7 +187,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
     - g. (Optional) If you are compiling PaddlePaddle on MacOS 10.14, make sure you have the [appropriate version](http://developer.apple.com/download) of Xcode installed.
 
 
-5. Before **compilation**, please confirm that the relevant dependencies mentioned in the [compilation dependency table](h../Tables.html/#third_party) are installed in your environment, otherwise we strongly recommend using `Homebrew` to install related dependencies.
+4. Before **compilation**, please confirm that the relevant dependencies mentioned in the [compilation dependency table](h../Tables.html/#third_party) are installed in your environment, otherwise we strongly recommend using `Homebrew` to install related dependencies.
 
     > Under MacOS, if you have not modified or installed the dependencies mentioned in the "Compile Dependency Table", you only need to use `pip` to install `numpy`, `protobuf`, `wheel`, use `homebrew` to install `wget`, `swig`,then install `cmake`.
 
@@ -228,7 +205,7 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
 
     - b. If you do not want to use the system default blas and want to use your own installed OPENBLAS please read [FAQ](../FAQ.html/#OPENBLAS)
 
-6. Put the PaddlePaddle source cloned in the Paddle folder in the current directory and go to the Paddle directory:
+5. Put the PaddlePaddle source cloned in the Paddle folder in the current directory and go to the Paddle directory:
 
     ```
     git clone https://github.com/PaddlePaddle/Paddle.git
@@ -244,45 +221,37 @@ Congratulations, now that you have successfully installed PaddlePaddle using Doc
     git checkout develop
     ```
 
-    Note: python3.6、python3.7 version started supporting from release/1.2 branch, python3.8 version started supporting from release/1.8 branch
-
-8. And please create and enter a directory called build:
+7. And please create and enter a directory called build:
 
     ```
     mkdir build && cd build
     ```
 
-9. Execute cmake:
+8. Execute cmake:
 
     > For details on the compilation options, see the [compilation options table](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/install/Tables.html#Compile).
 
     * For users who need to compile the **CPU version PaddlePaddle**:
 
-
-        For Python2:
         ```
-        cmake .. -DWITH_FLUID_ONLY=ON -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-        ```
-        For Python3:
-        ```
-        cmake .. -DPY_VERSION=3.5 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
+        cmake .. -DPY_VERSION=3.7 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
         -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_FLUID_ONLY=ON -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
-    > ``-DPY_VERSION=3.5`` Please change to the Python version of the installation environment.
+    > ``-DPY_VERSION=3.7`` Please change to the Python version of the installation environment.
 
-10. Compile with the following command:
+9. Compile with the following command:
 
     ```
     make -j4
     ```
 
-11. After compiling successfully, go to the `/paddle/build/python/dist `directory and find the generated `.whl` package:
+10. After compiling successfully, go to the `/paddle/build/python/dist `directory and find the generated `.whl` package:
     ```
     cd /paddle/build/python/dist
     ```
 
-12. Install the compiled `.whl` package on the current machine or target machine:
+11. Install the compiled `.whl` package on the current machine or target machine:
 
     ```
     pip install -U (whl package name)

--- a/docs/install/compile/windows-compile.md
+++ b/docs/install/compile/windows-compile.md
@@ -3,19 +3,19 @@
 ## 环境准备
 
 * **Windows 7/8/10 专业版/企业版 (64bit)**
-* **GPU版本支持CUDA 9.0/10.0/10.1/10.2/11.0，且仅支持单卡**
-* **Python 版本 2.7.15+/3.5.1+/3.6+/3.7+/3.8+ (64 bit)**
-* **pip 版本 20.2.2+ (64 bit)**
-* **Visual Studio 2017**
+* **GPU版本支持CUDA 10.1/10.2/11.2，且仅支持单卡**
+* **Python 版本 3.6+/3.7+/3.8+/3.9+ (64 bit)**
+* **pip 版本 20.2.2或更高版本 (64 bit)**
+* **Visual Studio 2015 Update3**
 
 ## 选择CPU/GPU
 
 * 如果您的计算机没有 NVIDIA® GPU，请编译CPU版的PaddlePaddle
 
 * 如果您的计算机有NVIDIA® GPU，并且满足以下条件，推荐编译GPU版的PaddlePaddle
-    * **CUDA 工具包 9.0/10.0/10.1/10.2 配合 cuDNN v7.6.5+**
-    * **CUDA 工具包 11.0 配合 cuDNN v8.0.4**
-    * **GPU运算能力超过3.0的硬件设备**
+    * **CUDA 工具包 10.1/10.2 配合 cuDNN v7.6.5+**
+    * **CUDA 工具包 11.2 配合 cuDNN v8.1.1**
+    * **GPU运算能力超过3.5的硬件设备**
 
 ## 安装步骤
 
@@ -28,9 +28,9 @@
 
 1. 安装必要的工具 cmake，git 以及 python：
 
-    > cmake我们支持3.15以上版本,我们建议您使用CMake3.16版本, 可在官网[下载](https://cmake.org/download/)，并添加到环境变量中。
+    > cmake我们支持3.15以上版本,但GPU编译时3.12/3.13/3.14版本存在官方[Bug](https://cmake.org/pipermail/cmake/2018-September/068195.html),我们建议您使用CMake3.16版本, 可在官网[下载](https://cmake.org/download/)，并添加到环境变量中。
 
-    > python 需要 2.7 及以上版本, 可在官网[下载](https://www.python.org/download/releases/2.7/)。
+    > python 需要 3.6 及以上版本, 可在官网[下载](https://www.python.org/downloads/release/python-3610/)。
 
     * 安装完python 后请通过 `python --version` 检查python版本是否是预期版本，因为您的计算机可能安装有多个python，您可通过修改环境变量的顺序来处理多个python时的冲突。
 
@@ -66,7 +66,7 @@
     git checkout develop
     ```
 
-    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持
+    注意：python3.6、python3.7版本从release/1.2分支开始支持, python3.8版本从release/1.8分支开始支持, python3.9版本从release/2.1分支开始支持
 
 4. 创建名为build的目录并进入：
 
@@ -84,18 +84,18 @@
     *  编译**CPU版本PaddlePaddle**：
 
         ```
-        cmake .. -G "Visual Studio 15 2017 Win64" -T host=x64 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -G "Visual Studio 14 2015 Win64" -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
     *  编译**GPU版本PaddlePaddle**：
 
         ```
-        cmake .. -G "Visual Studio 15 2017 Win64" -T host=x64 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -G "Visual Studio 14 2015 Win64" -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
-    默认为Python2，Python3请添加：
+    Python3请添加：
 
-    > -DPY_VERSION=3（或3.5、3.6、3.7、3.8）
+    > -DPY_VERSION=3（或3.6、3.7、3.8、3.9）
 
     如果你的设备信息包含多个Python或CUDA版本，你也可以通过设置路径变量，来指定特定版本的Python或CUDA：
 
@@ -106,10 +106,10 @@
     例如：（仅作示例，请根据你的设备路径信息进行设置）
 
     ```
-    cmake .. -G "Visual Studio 15 2017 Win64" -T host=x64 -DCMAKE_BUILD_TYPE=Release -DWITH_GPU=ON -DWITH_TESTING=OFF -DPYTHON_EXECUTABLE=C:\\Python36\\python.exe -DCUDA_TOOLKIT_ROOT_DIR="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\v10.0"
+    cmake .. -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release -DWITH_GPU=ON -DWITH_TESTING=OFF -DPYTHON_EXECUTABLE=C:\\Python36\\python.exe -DCUDA_TOOLKIT_ROOT_DIR="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\v10.0"
     ```
 
-6. 使用Visual Studio 2017 打开 `paddle.sln` 文件，选择平台为 `x64`，配置为 `Release`，开始编译。
+6. 使用Visual Studio 2015 打开 `paddle.sln` 文件，选择平台为 `x64`，配置为 `Release`，开始编译。
 
 7. 编译成功后进入 `\Paddle\build\python\dist` 目录下找到生成的 `.whl` 包：
 

--- a/docs/install/compile/windows-compile_en.md
+++ b/docs/install/compile/windows-compile_en.md
@@ -3,10 +3,10 @@
 ## Environment preparation
 
 * **Windows 7/8/10 Pro/Enterprise(64bit)**
-* **GPU Version support CUDA 9.0/10.0/10.1/10.2/11.0, and only support single GPU**
-* **Python version 2.7.15+/3.5.1+/3.6+/3.7+/3.8+(64bit)**
-* **pip version 20.2.2+ (64bit)**
-* **Visual Studio 2017**
+* **GPU Version support CUDA 10.1/10.2/11.2, and only support single GPU**
+* **Python version 3.6+/3.7+/3.8+/3.9+(64bit)**
+* **pip version 20.2.2 or above (64bit)**
+* **Visual Studio 2015 Update3**
 
 ## Choose CPU/GPU
 
@@ -14,7 +14,7 @@
 
 * If your computer has NVIDIA® GPU, and the following conditions are met，GPU version of PaddlePaddle is recommended.
     * **CUDA toolkit 9.0/10.0/10.1/10.2 with cuDNN v7.6.5+**
-    * **CUDA toolkit 11.0 with cuDNN v8.0.4**
+    * **CUDA toolkit 11.2 with cuDNN v8.1.1**
     * **GPU's computing capability exceeds 3.0**
 
 ## Installation steps
@@ -30,9 +30,9 @@ There is one compilation methods in Windows system:
 
 1. Install the necessary tools i.e. cmake, git and python:
 
-    > CMake requires version 3.15 and above, we recommend that you use CMake3. 16 version, available on the official website [download] (https://cmake.org/download/), and add to the ring Environment variables.
+    > CMake requires version 3.15 and above, but there are official [Bug](https://cmake.org/pipermail/cmake/2018-September/068195.html) versions of 3.12/3.13/3.14 when the GPU is compiled, we recommend that you use CMake3. 16 version, available on the official website [download] (https://cmake.org/download/), and add to the ring Environment variables.
 
-    > Python requires version 2.7 and above,  which can be downloaded from the [official website](https://www.python.org/download/releases/2.7/).
+    > Python requires version 3.6 and above,  which can be downloaded from the [official website](https://www.python.org/downloads/release/python-3610/).
 
     * After installing python, please check whether the python version is the expected version by `python-version`, because you may have more than one python installed on your computer. You can handle conflicts of multiple pythons by changing the order of the environment variables.
 
@@ -70,7 +70,7 @@ There is one compilation methods in Windows system:
     git checkout develop
     ```
 
-    Note: python3.6、python3.7 version started supporting from release/1.2, python3.8 version started supporting from release/1.8
+    Note: python3.6、python3.7 version started supporting from release/1.2, python3.8 version started supporting from release/1.8, python3.9 version started supporting from release/2.1
 
 4. Create a directory called build and enter it:
 
@@ -87,18 +87,18 @@ There is one compilation methods in Windows system:
     * For users who need to compile **the CPU version PaddlePaddle**:
 
         ```
-        cmake .. -G "Visual Studio 15 2017 Win64" -T host=x64 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -G "Visual Studio 14 2015 Win64" -DWITH_GPU=OFF -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
     * For users who need to compile **the GPU version PaddlePaddle**:
 
         ```
-        cmake .. -G "Visual Studio 15 2017 Win64" -T host=x64 -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake .. -G "Visual Studio 14 2015 Win64" -DWITH_GPU=ON -DWITH_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
         ```
 
-    Python2 by default，Python3 please add：
+    Python3 please add：
 
-    > -DPY_VERSION=3 (or 3.5、3.6、3.7、3.8)
+    > -DPY_VERSION=3 (or 3.6、3.7、3.8、3.9)
 
     If your device information contains multiple Python or CUDA, you can also specify a specific version of Python or CUDA by setting the corresponding compile options:
 
@@ -109,10 +109,10 @@ There is one compilation methods in Windows system:
     For example: (for instance only, please set it according to your actual installation path)
 
     ```
-    cmake .. -G "Visual Studio 15 2017 Win64" -T host=x64 -DCMAKE_BUILD_TYPE=Release -DWITH_GPU=ON -DWITH_TESTING=OFF -DPYTHON_EXECUTABLE=C:\\Python36\\python.exe -DCUDA_TOOLKIT_ROOT_DIR="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\v10.0"
+    cmake .. -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release -DWITH_GPU=ON -DWITH_TESTING=OFF -DPYTHON_EXECUTABLE=C:\\Python36\\python.exe -DCUDA_TOOLKIT_ROOT_DIR="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\v10.0"
     ```
 
-6. Use Visual Studio 2017 to open `paddle.sln` file, select the platform `x64`, configure with `Release`, then begin to compile
+6. Use Visual Studio 2015 to open `paddle.sln` file, select the platform `x64`, configure with `Release`, then begin to compile
 
 7. After compilation successfully, go to the `\paddle\build\python\dist` directory and find the generated `.whl` package:
 

--- a/docs/install/conda/linux-conda.md
+++ b/docs/install/conda/linux-conda.md
@@ -16,17 +16,6 @@
 
 首先根据具体的Python版本创建Anaconda虚拟环境，PaddlePaddle的Anaconda安装支持以下五种Python安装环境。
 
-如果您想使用的python版本为2.7:
-
-```
-conda create -n paddle_env python=2.7
-```
-
-如果您想使用的python版本为3.5:
-
-```
-conda create -n paddle_env python=3.5
-```
 
 如果您想使用的python版本为3.6:
 
@@ -46,6 +35,11 @@ conda create -n paddle_env python=3.7
 conda create -n paddle_env python=3.8
 ```
 
+如果您想使用的python版本为3.9:
+
+```
+conda create -n paddle_env python=3.9
+```
 
 
 #### 1.1.2进入Anaconda虚拟环境
@@ -53,7 +47,7 @@ conda create -n paddle_env python=3.8
 for Windows
 
 ```
-conda activate paddle_env
+activate paddle_env
 ```
 
 for MacOS/Linux
@@ -76,69 +70,29 @@ where python
 
 在 MacOS/Linux 环境下，输出 Python 路径的命令为:
 
-如果您使用python2：
 
 ```
 which python
 ```
 
-如果您使用python3：
-
-```
-which python3
-```
-
-根据您的环境，您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+根据您的环境，您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
 
 
 
 1.2.2 检查Python版本
 
-在 Windows 环境下，使用以下命令确认版本(Python2 应对应 2.7.15+，Python3 应对应 3.5.1+/3.6/3.7/3.8)
+使用以下命令确认版本(Python应对应 3.6/3.7/3.8/3.9)
 
 ```
 python --version
 ```
-
-在 MacOS/Linux 环境下
-
-如果您是使用 Python 2，使用以下命令确认是 2.7.15+:
-
-```
-python --version
-```
-
-如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8:
-
-```
-python3 --version
-```
-
 
 
 1.2.3 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64（或x64、AMD64）"即可：
 
-在 Windows 环境下
-
 ```
 python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 ```
-
-在 MacOS/Linux 环境下
-
-如果您使用Python2:
-
-```
-python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-如果您使用Python3:
-
-```
-python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-
 
 
 
@@ -152,15 +106,13 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 * 如果您的计算机有NVIDIA® GPU，请确保满足以下条件并且安装[GPU版PaddlePaddle](#gpu)
 
-  * **CUDA 工具包9.0/10.0配合cuDNN v7.6+(如需多卡支持，需配合NCCL2.3.7及更高)**
-
   * **CUDA 工具包10.1/10.2配合cuDNN v7.6+(如需多卡支持，需配合NCCL2.7及更高)**
 
-  * **CUDA 工具包11.0配合cuDNN v8.0.4(如需多卡支持，需配合NCCL2.7及更高)**
+  * **CUDA 工具包11.2配合cuDNN v8.1.1(如需多卡支持，需配合NCCL2.7及更高)**
 
-  * **GPU运算能力超过1.0的硬件设备**
+  * **GPU运算能力超过3.5的硬件设备**
 
-    您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](
+    您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 
 
@@ -168,55 +120,35 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 确定您的环境满足条件后可以开始安装了，选择下面您要安装的PaddlePaddle
 
-* [CPU版的PaddlePaddle](#cpu)
 
-* [GPU版的PaddlePaddle](#gpu)
-  * [CUDA9.0的PaddlePaddle](#cuda9)
-  * [CUDA10.0的PaddlePaddle](#cuda10)
-  * [CUDA10.1的PaddlePaddle](#cuda10.1)
-  * [CUDA10.2的PaddlePaddle](#cuda10.2)
-  * [CUDA11.0的PaddlePaddle](#cuda11)
-
-#### 2.1 <span id="cpu">CPU版的PaddlePaddle</span>
+#### 2.1 CPU版的PaddlePaddle
 
 ```
-conda install paddlepaddle==2.0.2 -c paddle
+conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
 
-#### 2.2<span id="gpu"> GPU版的PaddlePaddle</span>
+#### 2.2 GPU版的PaddlePaddle
 
-*  <span id="cuda9">如果您是使用 CUDA 9，cuDNN 7.6+，安装GPU版本的命令为:</span>
 
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=9.0 -c paddle
-  ```
-
-*  <span id="cuda10">如果您是使用 CUDA 10.0，cuDNN 7.6+，安装GPU版本的命令为:</span>
+*  如果您是使用 CUDA 10.1，cuDNN 7.6+，安装GPU版本的命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-
-*  <span id="cuda10.1">如果您是使用 CUDA 10.1，cuDNN 7.6+，安装GPU版本的命令为:</span>
-
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.1 -c paddle
-  ```
-
-*  <span id="cuda10.2">如果您是使用 CUDA 10.2，cuDNN 7.6+，安装GPU版本的命令为:</span>
+*  如果您是使用 CUDA 10.2，cuDNN 7.6+，安装GPU版本的命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.2 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 
-*  <span id="cuda11">如果您是使用 CUDA 11，cuDNN 8.0.4+，安装GPU版本的命令为:</span>
+*  如果您是使用 CUDA 11.2，cuDNN 8.1.1+，安装GPU版本的命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=11.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 
@@ -232,7 +164,8 @@ conda install paddlepaddle==2.0.2 -c paddle
 
 ## 注意
 
-对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源进行安装。
+对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源。
+
 
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
@@ -242,12 +175,4 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/m
 ```
 ```
 conda config --set show_channel_urls yes
-```
-cpu：
-```
-conda install paddlepaddle==2.0.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-```
-gpu：
-```
-conda install paddlepaddle-gpu==2.0.2 cudatoolkit=[cuda版本号] --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```

--- a/docs/install/conda/linux-conda_en.md
+++ b/docs/install/conda/linux-conda_en.md
@@ -15,17 +15,6 @@ Before performing PaddlePaddle installation, please make sure that your Anaconda
 
 Create virtual environment First create the Anaconda virtual environment according to the specific Python version. The Anaconda installation of PaddlePaddle supports the following four Python installation environments.
 
-If you want to use python version 2.7:
-
-```
-conda create -n paddle_env python=2.7
-```
-
-If you want to use python version 3.5:
-
-```
-conda create -n paddle_env python=3.5
-```
 
 If you want to use python version 3.6:
 
@@ -45,14 +34,18 @@ If you want to use python version 3.8:
 conda create -n paddle_env python=3.8
 ```
 
+If you want to use python version 3.9:
 
+```
+conda create -n paddle_env python=3.9
+```
 
 #### 1.1.2 Enter the Anaconda Virtual Environment
 
 for Windows
 
 ```
-conda activate paddle_env
+activate paddle_env
 ```
 
 for MacOS/Linux
@@ -67,7 +60,7 @@ conda activate paddle_env
 
 Confirm that your conda virtual environment and the Python loaction which is preapared to install PaddlePaddle are where you expected them for your computer may have multiple Pythons environments. Enter Anaconda's command line terminal and enter the following command to confirm the Python location.
 
-1.2.1 If you are using Python 2, use the following command to get the Python path. Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
+1.2.1 Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
 
 In a Windows environment, the command to get the Python path is:
 
@@ -83,50 +76,22 @@ which python
 
 
 
-If you are using Python 3, use the following command to get the Python path. Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
-
-In a Windows environment, the command to get the Python path is:
-
-```
-where python3
-```
-
-In a MacOS/Linux environment, the command to get the Python path is:
-
-```
-which python3
-```
-
-
-
 1.2.2 Check the version of Python
 
-If you are using Python 2, use the following command to confirm it's version is 2.7.15+
+
+Use the following command to confirm it's version is 3.6/3.7/3.8/3.9
 
 ```
 python --version
-```
-
-If you are using Python 3, use the following command to confirm it's version is 3.5.1+/3.6/3.7/3.8
-
-```
-python3 --version
 ```
 
 
 
 1.2.3 Confirm that Python and pip are 64bit, and the processor architecture is x86_64 (or x64, Intel 64, AMD64) architecture. Currently PaddlePaddle does not support arm64 architecture. The first line below print "64bit", the second line prints "x86_64 (or x64, AMD64)."
 
-If you are using Python2:
 
 ```
 python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-If you are using Python3:
-
-```
-python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 ```
 
 
@@ -141,13 +106,11 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 * If your computer has NVIDIA® GPU, please make sure that the following conditions are met and install [the GPU Version of PaddlePaddle](#gpu)
 
-  * **CUDA toolkit 9.0/10.0/10.1/10.2 with cuDNN v7.6+(for multi card support, NCCL2.3.7 or higher)**
+  * **CUDA toolkit 10.1/10.2 with cuDNN v7.6+(for multi card support, NCCL2.7 or higher)**
 
-  * **CUDA toolkit 10.1/10.2 with cuDNN v7.6+(for multi card support, NCCL2.3.7 or higher)**
+  * **CUDA toolkit 11.2 with cuDNN v8.1.1(for multi card support, NCCL2.7 or higher)**
 
-  * **CUDA toolkit 11.0 with cuDNN v8.0.4(for multi card support, NCCL2.3.7 or higher)**
-
-  * **Hardware devices with GPU computing power over 1.0**
+  * **Hardware devices with GPU computing power over 3.5**
 
     You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -189,54 +152,35 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 You can choose the following version of PaddlePaddle to start installation:
 
-* [CPU Version of PaddlePaddle](#cpu)
-* [GPU Version of PaddlePaddle](#gpu)
-  * [CUDA9.0 PaddlePaddle](#cuda9)
-  * [CUDA10.0 PaddlePaddle](#cuda10)
-  * [CUDA10.1 PaddlePaddle](#cuda10.1)
-  * [CUDA10.2 PaddlePaddle](#cuda10.2)
-  * [CUDA11.0 PaddlePaddle](#cuda11)
 
 
-
-#### 2.1 <span id="cpu">CPU version of PaddlePaddle</span>
+#### 2.1 CPU version of PaddlePaddle
 
 ```
-conda install paddlepaddle==2.0.2 -c paddle
+conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
 
-#### 2.2<span id="gpu"> GPU version of PaddlePaddle</span>
+#### 2.2 GPU version of PaddlePaddle
 
-*  <span id="cuda9">If you are using CUDA 9，cuDNN 7.6+:</span>
 
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=9.0 -c paddle
-  ```
-
-* <span id="cuda10">If you are using CUDA 10.0，cuDNN 7.6+</span>
+*  If you are using CUDA 10.1，cuDNN 7.6+
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  <span id="cuda10.1">If you are using CUDA 10.1，cuDNN 7.6+</span>
+*  If you are usingCUDA 10.2，cuDNN 7.6+:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.1 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  <span id="cuda10.2">If you are usingCUDA 10.2，cuDNN 7.6+:</span>
+*  If you are using CUDA 11.2，cuDNN 8.1.1+:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.2 -c paddle
-  ```
-
-*  <span id="cuda11">If you are using CUDA 11，cuDNN 8.0.4+:</span>
-
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=11.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 
@@ -251,7 +195,8 @@ If `PaddlePaddle is installed successfully!` appears, to verify that the install
 
 ## Notice
 
-For domestic users who cannot connect to the Anaconda official source, you can add Tsinghua source to install it according to the following command.
+For domestic users who cannot connect to the Anaconda official source, you can add Tsinghua source according to the following command.
+
 
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
@@ -261,12 +206,4 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/m
 ```
 ```
 conda config --set show_channel_urls yes
-```
-cpu：
-```
-conda install paddlepaddle==2.0.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-```
-gpu：
-```
-conda install paddlepaddle-gpu==2.0.2 cudatoolkit=[cuda版本号] --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```

--- a/docs/install/conda/macos-conda.md
+++ b/docs/install/conda/macos-conda.md
@@ -15,17 +15,6 @@
 
 首先根据具体的Python版本创建Anaconda虚拟环境，PaddlePaddle的Anaconda安装支持以下五种Python安装环境。
 
-如果您想使用的python版本为2.7:
-
-```
-conda create -n paddle_env python=2.7
-```
-
-如果您想使用的python版本为3.5:
-
-```
-conda create -n paddle_env python=3.5
-```
 
 如果您想使用的python版本为3.6:
 
@@ -45,13 +34,19 @@ conda create -n paddle_env python=3.7
 conda create -n paddle_env python=3.8
 ```
 
+如果您想使用的python版本为3.9:
+
+```
+conda create -n paddle_env python=3.9
+```
+
 
 #### 1.1.2进入Anaconda虚拟环境
 
 for Windows
 
 ```
-conda activate paddle_env
+activate paddle_env
 ```
 
 for MacOS/Linux
@@ -74,66 +69,29 @@ where python
 
 在 MacOS/Linux 环境下，输出 Python 路径的命令为:
 
-如果您使用python2：
-
 ```
 which python
 ```
 
-如果您使用python3：
-
-```
-which python3
-```
-
-根据您的环境，您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+根据您的环境，您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
 
 
 
 1.2.2 检查Python版本
 
-在 Windows 环境下，使用以下命令确认版本(Python2 应对应 2.7.15+，Python3 应对应 3.5.1+/3.6/3.7/3.8)
+在 Windows 环境下，使用以下命令确认版本(Python 应对应 3.6/3.7/3.8/3.9)
 
 ```
 python --version
-```
-
-在 MacOS/Linux 环境下
-
-如果您是使用 Python 2，使用以下命令确认是 2.7.15+:
-
-```
-python --version
-```
-
-如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8:
-
-```
-python3 --version
 ```
 
 
 
 1.2.3 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64（或x64、AMD64）"即可：
 
-在 Windows 环境下
 
 ```
 python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-在 MacOS/Linux 环境下
-
-如果您使用Python2:
-
-```
-python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-如果您使用Python3:
-
-```
-python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 ```
 
 
@@ -152,7 +110,7 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 * 请参考如下命令安装:
 
   ```
-  conda install paddlepaddle==2.0.2 -c paddle
+  conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 ## **三、验证安装**
@@ -166,7 +124,8 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 ## 注意
 
-对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源进行安装。
+对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源。
+
 
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
@@ -176,12 +135,4 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/m
 ```
 ```
 conda config --set show_channel_urls yes
-```
-cpu：
-```
-conda install paddlepaddle==2.0.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-```
-gpu：
-```
-conda install paddlepaddle-gpu==2.0.2 cudatoolkit=[cuda版本号] --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```

--- a/docs/install/conda/macos-conda_en.md
+++ b/docs/install/conda/macos-conda_en.md
@@ -19,17 +19,6 @@ Before performing PaddlePaddle installation, please make sure that your Anaconda
 
 Create virtual environment First create the Anaconda virtual environment according to the specific Python version. The Anaconda installation of PaddlePaddle supports the following four Python installation environments.
 
-If you want to use python version 2.7:
-
-```
-conda create -n paddle_env python=2.7
-```
-
-If you want to use python version 3.5:
-
-```
-conda create -n paddle_env python=3.5
-```
 
 If you want to use python version 3.6:
 
@@ -49,6 +38,12 @@ If you want to use python version 3.8:
 conda create -n paddle_env python=3.8
 ```
 
+If you want to use python version 3.9:
+
+```
+conda create -n paddle_env python=3.9
+```
+
 
 
 #### 1.1.2 Enter the Anaconda Virtual Environment
@@ -56,7 +51,7 @@ conda create -n paddle_env python=3.8
 for Windows
 
 ```
-conda activate paddle_env
+activate paddle_env
 ```
 
 for MacOS/Linux
@@ -71,7 +66,7 @@ conda activate paddle_env
 
 Confirm that your conda virtual environment and the Python loaction which is preapared to install PaddlePaddle are where you expected them for your computer may have multiple Pythons environments. Enter Anaconda's command line terminal and enter the following command to confirm the Python location.
 
-1.2.1 If you are using Python 2, use the following command to get the Python path. Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
+1.2.1 Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
 
 In a Windows environment, the command to get the Python path is:
 
@@ -86,54 +81,22 @@ which python
 ```
 
 
-
-If you are using Python 3, use the following command to get the Python path. Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
-
-In a Windows environment, the command to get the Python path is:
-
-```
-where python3
-```
-
-In a MacOS/Linux environment, the command to get the Python path is:
-
-```
-which python3
-```
-
-
-
 1.2.2 Check the version of Python
 
-If you are using Python 2, use the following command to confirm it's version is 2.7.15+
+Use the following command to confirm it's version is 3.6/3.7/3.8/3.9
 
 ```
 python --version
-```
-
-If you are using Python 3, use the following command to confirm it's version is 3.5.1+/3.6/3.7/3.8
-
-```
-python3 --version
 ```
 
 
 
 1.2.3 Confirm that Python and pip are 64bit, and the processor architecture is x86_64 (or x64, Intel 64, AMD64) architecture. Currently PaddlePaddle does not support arm64 architecture. The first line below print "64bit", the second line prints "x86_64 (or x64, AMD64)."
 
-If you are using Python2:
 
 ```
 python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 ```
-
-If you are using Python3:
-
-```
-python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-
 
 
 
@@ -152,7 +115,7 @@ You can choose the following version of PaddlePaddle to start installation:
 * Please use the following command to install PaddlePaddle：
 
   ```
-  conda install paddlepaddle==2.0.2 -c paddle
+  conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 
@@ -167,7 +130,8 @@ If `PaddlePaddle is installed successfully!` appears, to verify that the install
 
 ## Notice
 
-For domestic users who cannot connect to the Anaconda official source, you can add Tsinghua source to install it according to the following command.
+For domestic users who cannot connect to the Anaconda official source, you can add Tsinghua source according to the following command.
+
 
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
@@ -177,12 +141,4 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/m
 ```
 ```
 conda config --set show_channel_urls yes
-```
-cpu：
-```
-conda install paddlepaddle==2.0.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-```
-gpu：
-```
-conda install paddlepaddle-gpu==2.0.2 cudatoolkit=[cuda版本号] --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```

--- a/docs/install/conda/windows-conda.md
+++ b/docs/install/conda/windows-conda.md
@@ -3,12 +3,13 @@
 [Anaconda](https://www.anaconda.com/)是一个免费开源的Python和R语言的发行版本，用于计算科学，Anaconda致力于简化包管理和部署。Anaconda的包使用软件包管理系统Conda进行管理。Conda是一个开源包管理系统和环境管理系统，可在Windows、macOS和Linux上运行。
 
 
+
 ## 一、环境准备
 
 在进行PaddlePaddle安装之前请确保您的Anaconda软件环境已经正确安装。软件下载和安装参见Anaconda官网(https://www.anaconda.com/)。在您已经正确安装Anaconda的情况下请按照下列步骤安装PaddlePaddle。
 
 * Windows 7/8/10 专业版/企业版 (64bit)
-  * GPU版本支持CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0，且仅支持单卡
+  * GPU版本支持CUDA 10.1/10.2/11.2，且仅支持单卡
 * conda 版本 4.8.3+ (64 bit)
 
 
@@ -18,17 +19,6 @@
 
 首先根据具体的Python版本创建Anaconda虚拟环境，PaddlePaddle的Anaconda安装支持以下五种Python安装环境。
 
-如果您想使用的python版本为2.7:
-
-```
-conda create -n paddle_env python=2.7
-```
-
-如果您想使用的python版本为3.5:
-
-```
-conda create -n paddle_env python=3.5
-```
 
 如果您想使用的python版本为3.6:
 
@@ -48,6 +38,12 @@ conda create -n paddle_env python=3.7
 conda create -n paddle_env python=3.8
 ```
 
+如果您想使用的python版本为3.9:
+
+```
+conda create -n paddle_env python=3.9
+```
+
 
 
 #### 1.1.2进入Anaconda虚拟环境
@@ -55,7 +51,7 @@ conda create -n paddle_env python=3.8
 for Windows
 
 ```
-conda activate paddle_env
+activate paddle_env
 ```
 
 for MacOS/Linux
@@ -78,69 +74,32 @@ where python
 
 在 MacOS/Linux 环境下，输出 Python 路径的命令为:
 
-如果您使用python2：
 
 ```
 which python
 ```
 
-如果您使用python3：
 
-```
-which python3
-```
-
-根据您的环境，您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
+根据您的环境，您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
 
 
 
 1.2.2 检查Python版本
 
-在 Windows 环境下，使用以下命令确认版本(Python2 应对应 2.7.15+，Python3 应对应 3.5.1+/3.6/3.7/3.8)
+使用以下命令确认版本(应对应 3.6/3.7/3.8/3.9)
 
 ```
 python --version
-```
-
-在 MacOS/Linux 环境下
-
-如果您是使用 Python 2，使用以下命令确认是 2.7.15+:
-
-```
-python --version
-```
-
-如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8:
-
-```
-python3 --version
 ```
 
 
 
 1.2.3 确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64（或x64、AMD64）"即可：
 
-在 Windows 环境下
 
 ```
 python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 ```
-
-在 MacOS/Linux 环境下
-
-如果您使用Python2:
-
-```
-python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-如果您使用Python3:
-
-```
-python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-
 
 
 
@@ -154,10 +113,10 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 * 如果您的计算机有NVIDIA® GPU，请确保满足以下条件并且安装[GPU版PaddlePaddle](#gpu)
 
-  * **CUDA 工具包9.0/10.0/10.1/10.2配合cuDNN v7.6+**
-  * **CUDA 工具包11.0配合cuDNN v8.0.4**
+  * **CUDA 工具包10.1/10.2配合cuDNN v7.6+**
+  * **CUDA 工具包11.2配合cuDNN v8.1.1**
 
-  * **GPU运算能力超过1.0的硬件设备**
+  * **GPU运算能力超过3.5的硬件设备**
 
     您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](
 
@@ -167,54 +126,34 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 
 确定您的环境满足条件后可以开始安装了，选择下面您要安装的PaddlePaddle
 
-* [CPU版的PaddlePaddle](#cpu)
 
-* [GPU版的PaddlePaddle](#gpu)
-  * [CUDA9.0的PaddlePaddle](#cuda9)
-  * [CUDA10.0的PaddlePaddle](#cuda10)
-  * [CUDA10.1的PaddlePaddle](#cuda10.1)
-  * [CUDA10.2的PaddlePaddle](#cuda10.2)
-  * [CUDA11.0的PaddlePaddle](#cuda11)
-
-#### 2.1 <span id="cpu">CPU版的PaddlePaddle</span>
+#### 2.1 CPU版的PaddlePaddle
 
 ```
-conda install paddlepaddle==2.0.2 -c paddle
+conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
 
-#### 2.2<span id="gpu"> GPU版的PaddlePaddle</span>
+#### 2.2 GPU版的PaddlePaddle
 
-*  <span id="cuda9">如果您是使用 CUDA 9，cuDNN 7.6+，安装GPU版本的命令为:</span>
 
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=9.0 -c paddle
-  ```
-
-*  <span id="cuda10">如果您是使用 CUDA 10.0，cuDNN 7.6+，安装GPU版本的命令为:</span>
+*  如果您是使用 CUDA 10.1，cuDNN 7.6+，安装GPU版本的命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-
-*  <span id="cuda10.1">如果您是使用 CUDA 10.1，cuDNN 7.6+，安装GPU版本的命令为:</span>
-
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.1 -c paddle
-  ```
-
-*  <span id="cuda10.2">如果您是使用 CUDA 10.2，cuDNN 7.6+，安装GPU版本的命令为:</span>
+*  如果您是使用 CUDA 10.2，cuDNN 7.6+，安装GPU版本的命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.2 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  <span id="cuda11">如果您是使用 CUDA 11，cuDNN 8.0.4+，安装GPU版本的命令为:</span>
+*  如果您是使用 CUDA 11.2，cuDNN 8.1.1+，安装GPU版本的命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=11.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 
@@ -229,7 +168,8 @@ conda install paddlepaddle==2.0.2 -c paddle
 
 ## 注意
 
-对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源进行安装。
+对于国内用户无法连接到Anaconda官方源的可以按照以下命令添加清华源。
+
 
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
@@ -239,12 +179,4 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/m
 ```
 ```
 conda config --set show_channel_urls yes
-```
-cpu：
-```
-conda install paddlepaddle==2.0.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-```
-gpu：
-```
-conda install paddlepaddle-gpu==2.0.2 cudatoolkit=[cuda版本号] --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```

--- a/docs/install/conda/windows-conda_en.md
+++ b/docs/install/conda/windows-conda_en.md
@@ -9,7 +9,7 @@
 Before performing PaddlePaddle installation, please make sure that your Anaconda software environment is properly installed. For software download and installation, see Anaconda's official website (https://www.anaconda.com/). If you have installed Anaconda correctly, follow these steps to install PaddlePaddle.
 
 * Windows 7/8/10 Pro/Enterprise (64bit)
-  * GPU Version supportCUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0，且仅支持单卡
+  * GPU Version supportCUDA 10.1/10.2/11.2，且仅支持单卡
 * conda version 4.8.3+ (64 bit)
 
 
@@ -20,17 +20,6 @@ Before performing PaddlePaddle installation, please make sure that your Anaconda
 
 Create virtual environment First create the Anaconda virtual environment according to the specific Python version. The Anaconda installation of PaddlePaddle supports the following four Python installation environments.
 
-If you want to use python version 2.7:
-
-```
-conda create -n paddle_env python=2.7
-```
-
-If you want to use python version 3.5:
-
-```
-conda create -n paddle_env python=3.5
-```
 
 If you want to use python version 3.6:
 
@@ -50,6 +39,12 @@ If you want to use python version 3.8:
 conda create -n paddle_env python=3.8
 ```
 
+If you want to use python version 3.9:
+
+```
+conda create -n paddle_env python=3.9
+```
+
 
 
 #### 1.1.2 Enter the Anaconda Virtual Environment
@@ -57,7 +52,7 @@ conda create -n paddle_env python=3.8
 for Windows
 
 ```
-conda activate paddle_env
+activate paddle_env
 ```
 
 for MacOS/Linux
@@ -72,7 +67,7 @@ conda activate paddle_env
 
 Confirm that your conda virtual environment and the Python loaction which is preapared to install PaddlePaddle are where you expected them for your computer may have multiple Pythons environments. Enter Anaconda's command line terminal and enter the following command to confirm the Python location.
 
-1.2.1 If you are using Python 2, use the following command to get the Python path. Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
+1.2.1 Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
 
 In a Windows environment, the command to get the Python path is:
 
@@ -88,50 +83,21 @@ which python
 
 
 
-If you are using Python 3, use the following command to get the Python path. Depending on your environment, you may need to replace python in all command lines in the instructions with specific Python path.
-
-In a Windows environment, the command to get the Python path is:
-
-```
-where python3
-```
-
-In a MacOS/Linux environment, the command to get the Python path is:
-
-```
-which python3
-```
-
-
-
 1.2.2 Check the version of Python
 
-If you are using Python 2, use the following command to confirm it's version is 2.7.15+
+Use the following command to confirm it's version is 3.6/3.7/3.8/3.9
 
 ```
 python --version
-```
-
-If you are using Python 3, use the following command to confirm it's version is 3.5.1+/3.6/3.7/3.8
-
-```
-python3 --version
 ```
 
 
 
 1.2.3 Confirm that Python and pip are 64bit, and the processor architecture is x86_64 (or x64, Intel 64, AMD64) architecture. Currently PaddlePaddle does not support arm64 architecture. The first line below print "64bit", the second line prints "x86_64 (or x64, AMD64)."
 
-If you are using Python2:
 
 ```
 python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-```
-
-If you are using Python3:
-
-```
-python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 ```
 
 
@@ -148,11 +114,11 @@ We will introduce conda installation here.
 
 * If your computer has NVIDIA® GPU, please make sure that the following conditions are met and install [the GPU Version of PaddlePaddle](#gpu)
 
-  * **CUDA toolkit 9.0/10.0/10.1/10.2 with cuDNN v7.6+**
+  * **CUDA toolkit 10.1/10.2 with cuDNN v7.6+**
 
-  * **CUDA toolkit 11.0 with cuDNN v8.0.4(**
+  * **CUDA toolkit 11.2 with cuDNN v8.1.1(**
 
-  * **Hardware devices with GPU computing power over 1.0**
+  * **Hardware devices with GPU computing power over 3.5**
 
     You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -161,57 +127,37 @@ We will introduce conda installation here.
 
 You can choose the following version of PaddlePaddle to start installation:
 
-* [CPU Version of PaddlePaddle](#cpu)
-* [GPU Version of PaddlePaddle](#gpu)
-  * [CUDA9.0 PaddlePaddle](#cuda9)
-  * [CUDA10.0 PaddlePaddle](#cuda10)
-  * [CUDA10.1 PaddlePaddle](#cuda10.1)
-  * [CUDA10.2 PaddlePaddle](#cuda10.2)
-  * [CUDA11.0 PaddlePaddle](#cuda11)
 
 
-
-#### 2.1 <span id="cpu">CPU version of PaddlePaddle</span>
+#### 2.1 CPU version of PaddlePaddle
 
 ```
-conda install paddlepaddle==2.0.2 -c paddle
+conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
 
 
-#### 2.2<span id="gpu"> GPU version of PaddlePaddle</span>
+#### 2.2 GPU version of PaddlePaddle
 
-*  <span id="cuda9">If you are using CUDA 9，cuDNN 7.6+:</span>
 
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=9.0 -c paddle
-  ```
-
-* <span id="cuda10">If you are using CUDA 10.0，cuDNN 7.6+</span>
+*  If you are using CUDA 10.1，cuDNN 7.6+
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.0 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  <span id="cuda10.1">If you are using CUDA 10.1，cuDNN 7.6+</span>
+*  If you are usingCUDA 10.2，cuDNN 7.6+:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.1 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  <span id="cuda10.2">If you are usingCUDA 10.2，cuDNN 7.6+:</span>
+*  If you are using CUDA 11.2，cuDNN 8.1.1+:
 
   ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=10.2 -c paddle
+  conda install paddlepaddle-gpu==2.1.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
-
-*  <span id="cuda11">If you are using CUDA 11，cuDNN 8.0.4+:</span>
-
-  ```
-  conda install paddlepaddle-gpu==2.0.2 cudatoolkit=11.0 -c paddle
-  ```
-
 
 
 ## Verify installation
@@ -224,7 +170,8 @@ If `PaddlePaddle is installed successfully!` appears, to verify that the install
 
 ## Notice
 
-For domestic users who cannot connect to the Anaconda official source, you can add Tsinghua source to install it according to the following command.
+For domestic users who cannot connect to the Anaconda official source, you can add Tsinghua source according to the following command.
+
 
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
@@ -234,12 +181,4 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/m
 ```
 ```
 conda config --set show_channel_urls yes
-```
-cpu：
-```
-conda install paddlepaddle==2.0.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-```
-gpu：
-```
-conda install paddlepaddle-gpu==2.0.2 cudatoolkit=[cuda版本号] --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```

--- a/docs/install/docker/linux-docker.md
+++ b/docs/install/docker/linux-docker.md
@@ -4,7 +4,7 @@
 
 ## 环境准备
 
-- 目前支持的系统类型，请见[安装说明](./index_cn.html)，请注意目前暂不支持在CentOS 6使用Docker
+- 目前支持的系统类型，请见[安装说明](../index_cn.html)，请注意目前暂不支持在CentOS 6使用Docker
 
 - 在本地主机上[安装Docker](https://hub.docker.com/search/?type=edition&offering=community)
 
@@ -16,12 +16,17 @@
 
     * CPU版的PaddlePaddle：
         ```
-        docker pull hub.baidubce.com/paddlepaddle/paddle:[版本号]
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[版本号]
+        ```
+
+    * CPU版的PaddlePaddle，且镜像中预装好了 jupyter：
+        ```
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[版本号]-jupyter
         ```
 
     * GPU版的PaddlePaddle：
         ```
-        docker pull hub.baidubce.com/paddlepaddle/paddle:[版本号]-gpu-cuda9.0-cudnn7
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[版本号]-gpu-cuda10.2-cudnn7
         ```
 
     如果您的机器不在中国大陆地区，可以直接从DockerHub拉取镜像：
@@ -31,12 +36,21 @@
         docker pull paddlepaddle/paddle:[版本号]
         ```
 
-    * GPU版的PaddlePaddle：
+    * CPU版的PaddlePaddle，且镜像中预装好了 jupyter：
         ```
-        docker pull paddlepaddle/paddle:[版本号]-gpu-cuda9.0-cudnn7
+        docker pull paddlepaddle/paddle:[版本号]-jupyter
         ```
 
-    在`:`后请您填写PaddlePaddle版本号，例如当前版本，更多请见[镜像简介](#dockers)，上例中，`cuda9.0-cudnn7` 也仅作示意用，您可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取与您机器适配的镜像。
+    * GPU版的PaddlePaddle：
+        ```
+        docker pull paddlepaddle/paddle:[版本号]-gpu-cuda10.2-cudnn7
+        ```
+
+    在`:`后请您填写PaddlePaddle版本号，例如当前版本`2.1.0`，更多请见[镜像简介](#dockers)。
+
+    上例中，`cuda10.2-cudnn7` 也仅作示意用，表示安装GPU版的镜像。如果您还想安装其他cuda/cudnn版本的镜像，可以将其替换成`cuda11.2-cudnn8`等。
+
+    您可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取与您机器适配的镜像。
 
 2. 构建、进入Docker容器
 
@@ -59,6 +73,30 @@
         > `<imagename>` 指定需要使用的image名称，您可以通过`docker images`命令查看；/bin/bash是在Docker中要执行的命令
 
 
+    * 使用CPU版本的PaddlePaddle，且镜像中预装好了 jupyter：
+
+        ```
+        mkdir ./jupyter_docker
+        ```
+        ```
+        chmod 777 ./jupyter_docker
+        ```
+        ```
+        cd ./jupyter_docker
+        ```
+        ```
+        docker run -p 80:80 --rm --env USER_PASSWD=[password you set] -v $PWD:/home/paddle <imagename>
+        ```
+
+        > --rm 关闭容器后删除容器；
+
+
+        > --env USER_PASSWD=[password you set] 为 jupyter 设置登录密码，[password you set] 是自己设置的密码；
+
+
+        > -v $PWD:/home/paddle 指定将当前路径（PWD变量会展开为当前路径的绝对路径）挂载到容器内部的 /home/paddle 目录；
+
+        > `<imagename>` 指定需要使用的image名称，您可以通过`docker images`命令查看
 
     * 使用GPU版本的PaddlePaddle：
 
@@ -95,20 +133,20 @@
     </thead>
     <tbody>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:[Version] </td>
-        <td> 安装了指定版本PaddlePaddle </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0 </td>
+        <td> 安装了2.1.0版本paddle的CPU镜像 </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest </td>
-        <td> 安装了开发版PaddlePaddle。注意：此版本可能包含尚未发布的特性和不稳定的功能，因此不推荐常规用户或在生产环境中使用。 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-jupyter </td>
+        <td> 安装了2.1.0版本paddle的CPU镜像，且镜像中预装好了jupyter，启动docker即运行jupyter服务 </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-gpu </td>
-        <td> 安装了开发版PaddlePaddle（支持GPU）。注意：此版本可能包含尚未发布的特性和不稳定的功能，因此不推荐常规用户或在生产环境中使用。 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda11.2-cudnn8 </td>
+        <td> 安装了2.1.0版本paddle的GPU镜像，cuda版本为11.2，cudnn版本为8.1 </td>
     </tr>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-dev </td>
-        <td> 安装了PaddlePaddle最新的开发环境 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda10.2-cudnn7 </td>
+        <td> 安装了2.1.0版本paddle的GPU镜像，cuda版本为10.2，cudnn版本为7 </td>
     </tr>
    </tbody>
 </table>
@@ -118,8 +156,7 @@
 
 ### 注意事项
 
-* 镜像中Python版本为2.7
-* PaddlePaddle Docker镜像为了减小体积，默认没有安装`vim`，您可以在容器中执行 `apt-get install -y vim` 安装后，在容器中编辑代码
+* 镜像中Python版本为3.7
 
 ### 补充说明
 

--- a/docs/install/docker/linux-docker_en.md
+++ b/docs/install/docker/linux-docker_en.md
@@ -4,7 +4,7 @@
 
 ## Environment preparation
 
-- Currently supported system types, please see [Installation instruction](./index_cn.html), please note that Docker is not currently supported in CentOS 6
+- Currently supported system types, please see [Installation instruction](../index_en.html), please note that Docker is not currently supported in CentOS 6
 
 - On the local host [Install Docker](https://hub.docker.com/search/?type=edition&offering=community)
 
@@ -16,12 +16,17 @@
 
     * CPU version of PaddlePaddle：
         ```
-        docker pull hub.baidubce.com/paddlepaddle/paddle:[version number]
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[version number]
+        ```
+
+    * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
+        ```
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[version number]-jupyter
         ```
 
     * GPU version of PaddlePaddle：
         ```
-        docker pull hub.baidubce.com/paddlepaddle/paddle:[version number]-gpu-cuda9.0-cudnn7
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[version number]-gpu-cuda10.2-cudnn7
         ```
 
     If your machine is not in mainland China, you can pull the image directly from DockerHub:
@@ -31,12 +36,21 @@
         docker pull paddlepaddle/paddle:[version number]
         ```
 
-    * GPU version of PaddlePaddle：
+    * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
         ```
-        docker pull paddlepaddle/paddle:[version number]-gpu-cuda9.0-cudnn7
+        docker pull paddlepaddle/paddle:[version number]-jupyter
         ```
 
-    After `:', please fill in the PaddlePaddle version number, such as the current version. For more details, please refer to [image profile](#dockers), in the above example, `cuda9.0-cudnn7` is only for illustration. you can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get the image that matches your machine.
+    * GPU version of PaddlePaddle：
+        ```
+        docker pull paddlepaddle/paddle:[version number]-gpu-cuda10.2-cudnn7
+        ```
+
+    After `:`, please fill in the PaddlePaddle version number, such as the current version `2.1.0`. For more details, please refer to [image profile](#dockers).
+
+    In the above example, `cuda10.2-cudnn7` is only for illustration, indicating that the GPU version of the image is installed. If you want to install another `cuda/cudnn` version of the image, you can replace it with `cuda11.2-cudnn8` etc.
+
+    You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get the image that matches your machine.
 
 2. Build and enter Docker container
 
@@ -77,6 +91,32 @@
 
         > `<imagename>` Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
 
+    * Use CPU version of PaddlePaddle：
+
+
+        ```
+        mkdir ./jupyter_docker
+        ```
+        ```
+        chmod 777 ./jupyter_docker
+        ```
+        ```
+        cd ./jupyter_docker
+        ```
+        ```
+        docker run -p 80:80 --rm --env USER_PASSWD=[password you set] -v $PWD:/home/paddle <imagename>
+        ```
+
+        > --rm Delete the container after closing it;
+
+
+        > --env USER_PASSWD=[password you set] Set the login password for jupyter, [password you set] is the password you set;
+
+
+        > -v $PWD:/home/paddle Specifies to mount the current path (the PWD variable will be expanded to the absolute path of the current path) to the /home/paddle directory inside the container;
+
+        > `<imagename>` Specify the name of the image to be used, you can view it through the `docker images` command
+
 
 Now you have successfully used Docker to install PaddlePaddle. For more information about using Docker, see[Docker official documents](https://docs.docker.com)
 
@@ -93,30 +133,31 @@ Now you have successfully used Docker to install PaddlePaddle. For more informat
     </thead>
     <tbody>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:[Version] </td>
-        <td> Install pecified version of PaddlePaddle </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0 </td>
+        <td> CPU image with 2.1.0 version of paddle installed </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest </td>
-        <td> Install development version of PaddlePaddle。Note: This release may contain features and unstable features that have not yet been released, so it is not recommended for regular users or production environments. </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-jupyter </td>
+        <td> CPU image of paddle version 2.1.0 is installed, and jupyter is pre-installed in the image. Start the docker to run the jupyter service </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-gpu </td>
-        <td> Install development of PaddlePaddle(support GPU). Note: This release may contain features and unstable features that have not yet been released, so it is not recommended for regular users or production environments. </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda11.2-cudnn8 </td>
+        <td> GPU image of paddle version 2.1.0 is installed, cuda version is 11.2, cudnn version is 8.1 </td>
     </tr>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-dev </td>
-        <td> Install the latest development environment of PaddlePaddle </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda10.2-cudnn7 </td>
+        <td> GPU image of paddle version 2.1.0 is installed, cuda version is 10.2, cudnn version is 7 </td>
     </tr>
    </tbody>
 </table>
 </p>
 
 You can find the docker mirroring of the published versions of PaddlePaddle in [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/).
+
+
 ### Note
 
-* Python version in the image is 2.7
-* In order to reduce the size, `vim` is not installed in PaddlePaddle Docker image by default. You can edit the code in the container after executing `apt-get install -y vim` in the container.
+* Python version in the image is 3.7
 
 ### 补充说明
 

--- a/docs/install/docker/macos-docker.md
+++ b/docs/install/docker/macos-docker.md
@@ -14,7 +14,12 @@
 
     * CPU版的PaddlePaddle：
         ```
-        docker pull hub.baidubce.com/paddlepaddle/paddle:[版本号]
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[版本号]
+        ```
+
+    * CPU版的PaddlePaddle，且镜像中预装好了 jupyter：
+        ```
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[版本号]-jupyter
         ```
 
     如果您的机器不在中国大陆地区，可以直接从DockerHub拉取镜像：
@@ -22,6 +27,11 @@
     * CPU版的PaddlePaddle：
         ```
         docker pull paddlepaddle/paddle:[版本号]
+        ```
+
+    * CPU版的PaddlePaddle，且镜像中预装好了 jupyter：
+        ```
+        docker pull paddlepaddle/paddle:[版本号]-jupyter
         ```
 
     在`:`后请您填写PaddlePaddle版本号，您可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取与您机器适配的镜像。
@@ -46,6 +56,31 @@
 
         > `<imagename>` 指定需要使用的image名称，您可以通过`docker images`命令查看；/bin/bash是在Docker中要执行的命令
 
+    * 使用CPU版本的PaddlePaddle，且镜像中预装好了 jupyter：
+
+        ```
+        mkdir ./jupyter_docker
+        ```
+        ```
+        chmod 777 ./jupyter_docker
+        ```
+        ```
+        cd ./jupyter_docker
+        ```
+        ```
+        docker run -p 80:80 --rm --env USER_PASSWD=[password you set] -v $PWD:/home/paddle <imagename>
+        ```
+
+        > --rm 关闭容器后删除容器；
+
+
+        > --env USER_PASSWD=[password you set] 为 jupyter 设置登录密码，[password you set] 是自己设置的密码；
+
+
+        > -v $PWD:/home/paddle 指定将当前路径（PWD变量会展开为当前路径的绝对路径）挂载到容器内部的 /home/paddle 目录；
+
+        > `<imagename>` 指定需要使用的image名称，您可以通过`docker images`命令查看
+
 
 
 
@@ -64,20 +99,20 @@
     </thead>
     <tbody>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:[Version] </td>
-        <td> 安装了指定版本PaddlePaddle </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0 </td>
+        <td> 安装了2.1.0版本paddle的CPU镜像 </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest </td>
-        <td> 安装了开发版PaddlePaddle。注意：此版本可能包含尚未发布的特性和不稳定的功能，因此不推荐常规用户或在生产环境中使用。 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-jupyter </td>
+        <td> 安装了2.1.0版本paddle的CPU镜像，且镜像中预装好了jupyter，启动docker即运行jupyter服务 </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-gpu </td>
-        <td> 安装了开发版PaddlePaddle（支持GPU）。注意：此版本可能包含尚未发布的特性和不稳定的功能，因此不推荐常规用户或在生产环境中使用。 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda11.2-cudnn8 </td>
+        <td> 安装了2.1.0版本paddle的GPU镜像，cuda版本为11.2，cudnn版本为8.1 </td>
     </tr>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-dev </td>
-        <td> 安装了PaddlePaddle最新的开发环境 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda10.2-cudnn7 </td>
+        <td> 安装了2.1.0版本paddle的GPU镜像，cuda版本为10.2，cudnn版本为7 </td>
     </tr>
    </tbody>
 </table>
@@ -85,10 +120,10 @@
 
 您可以在 [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) 中找到PaddlePaddle的各个发行的版本的docker镜像。
 
+
 ### 注意事项
 
-* 镜像中Python版本为2.7
-* PaddlePaddle Docker镜像为了减小体积，默认没有安装`vim`，您可以在容器中执行 `apt-get install -y vim` 安装后，在容器中编辑代码
+* 镜像中Python版本为3.7
 
 ### 补充说明
 

--- a/docs/install/docker/macos-docker_en.md
+++ b/docs/install/docker/macos-docker_en.md
@@ -14,7 +14,12 @@
 
     * CPU version of PaddlePaddle：
         ```
-        docker pull hub.baidubce.com/paddlepaddle/paddle:[version number]
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[version number]
+        ```
+
+    * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
+        ```
+        docker pull registry.baidubce.com/paddlepaddle/paddle:[version number]-jupyter
         ```
 
     If your machine is not in mainland China, you can pull the image directly from DockerHub:
@@ -23,6 +28,10 @@
         ```
         docker pull paddlepaddle/paddle:[version number]
         ```
+
+    * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
+        ```
+        docker pull paddlepaddle/paddle:[version number]-jupyter
 
     After `:`please fill in the PaddlePaddle version number, you can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get the image that matches your machine.
 
@@ -46,6 +55,32 @@
 
         > `<imagename>` Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
 
+    * Use CPU version of PaddlePaddle：
+
+
+        ```
+        mkdir ./jupyter_docker
+        ```
+        ```
+        chmod 777 ./jupyter_docker
+        ```
+        ```
+        cd ./jupyter_docker
+        ```
+        ```
+        docker run -p 80:80 --rm --env USER_PASSWD=[password you set] -v $PWD:/home/paddle <imagename>
+        ```
+
+        > --rm Delete the container after closing it;
+
+
+        > --env USER_PASSWD=[password you set] Set the login password for jupyter, [password you set] is the password you set;
+
+
+        > -v $PWD:/home/paddle Specifies to mount the current path (the PWD variable will be expanded to the absolute path of the current path) to the /home/paddle directory inside the container;
+
+        > `<imagename>` Specify the name of the image to be used, you can view it through the `docker images` command
+
 
 
 Now you have successfully used Docker to install PaddlePaddle. For more information about using Docker, see[Docker official documents](https://docs.docker.com)
@@ -63,30 +98,31 @@ Now you have successfully used Docker to install PaddlePaddle. For more informat
     </thead>
     <tbody>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:[Version] </td>
-        <td> Install pecified version of PaddlePaddle </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0 </td>
+        <td> CPU image with 2.1.0 version of paddle installed </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest </td>
-        <td> Install development version of PaddlePaddle。Note: This release may contain features and unstable features that have not yet been released, so it is not recommended for regular users or production environments. </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-jupyter </td>
+        <td> CPU image of paddle version 2.1.0 is installed, and jupyter is pre-installed in the image. Start the docker to run the jupyter service </td>
     </tr>
     <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-gpu </td>
-        <td> Install development of PaddlePaddle(support GPU). Note: This release may contain features and unstable features that have not yet been released, so it is not recommended for regular users or production environments. </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda11.2-cudnn8 </td>
+        <td> GPU image of paddle version 2.1.0 is installed, cuda version is 11.2, cudnn version is 8.1 </td>
     </tr>
         <tr>
-        <td> hub.baidubce.com/paddlepaddle/paddle:latest-dev </td>
-        <td> Install the latest development environment of PaddlePaddle </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.1.0-gpu-cuda10.2-cudnn7 </td>
+        <td> GPU image of paddle version 2.1.0 is installed, cuda version is 10.2, cudnn version is 7 </td>
     </tr>
    </tbody>
 </table>
 </p>
 
 You can find the docker mirroring of the published versions of PaddlePaddle in [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/).
+
+
 ### Note
 
-* Python version in the image is 2.7
-* In order to reduce the size, `vim` is not installed in PaddlePaddle Docker image by default. You can edit the code in the container after executing `apt-get install -y vim` in the container.
+* Python version in the image is 3.7
 
 ### 补充说明
 

--- a/docs/install/index_cn.rst
+++ b/docs/install/index_cn.rst
@@ -1,15 +1,33 @@
 ..  _install_introduction:
 
-#########
- 安装说明
-#########
+=========
+ 安装指南
+=========
+
+
+-----------
+  重要更新
+-----------
+
+* 新增对 python3.9 的支持，并不再支持 python2.7 和 python3.5
+* 新增对 CUDA 11.2 的支持，并不再支持 CUDA 9.0、CUDA 10.0 和 CUDA 11.0
+* 新增对 ROCm 平台的支持（2.1 中飞桨对 ROCm 平台的支持是 experimental 的）
+* Linux系统相关的包已被拆分为 avx 和 noavx 两种类型的包（大部分机器都使用 avx 指令集，可使用 `Linux下的PIP安装 <pip/linux-pip.html>`_ 页面中的命令查看您的机器是否支持）
+* 新增预装好 jupyter 的 CPU 镜像，启动镜像后即启动 jupyter 服务
+* 新增支持 Windows Visual Studio 2017 编译，由 VS2015 全面升级至 VS2017
+
+
+-----------
+  安装说明
+-----------
+
 本说明将指导您在64位操作系统编译和安装PaddlePaddle
 
 **1. 操作系统要求：**
 
 * Windows 7 / 8 / 10，专业版 / 企业版
-* Ubuntu 14.04 / 16.04 / 18.04
-* CentOS 6 / 7
+* Ubuntu 16.04 / 18.04
+* CentOS 7
 * MacOS 10.11 / 10.12 / 10.13 / 10.14
 * 操作系统要求是 64 位版本
 
@@ -20,15 +38,14 @@
 
 **3. Python 和 pip 版本要求：**
 
-* Python 2 的版本要求 2.7.15+
-* Python 3 的版本要求 3.5.1+/3.6/3.7/3.8
+* Python 的版本要求 3.6/3.7/3.8/3.9
 * Python 具有 pip, 且 pip 的版本要求 20.2.2+
 * Python 和 pip 要求是 64 位版本
 
 **4. PaddlePaddle 对 GPU 支持情况：**
 
-* 目前 **PaddlePaddle** 仅支持 **NVIDIA** 显卡的 **CUDA** 驱动
-* 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.6+(For CUDA9/10)
+* 目前 **PaddlePaddle** 支持 **NVIDIA** 显卡的 **CUDA** 驱动和 **AMD** 显卡的 **ROCm** 架构
+* 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.6+(For CUDA10.1/10.2)
 * 如果您需要 GPU 多卡模式，需要安装 `NCCL 2 <https://developer.nvidia.com/nccl/>`_
 
     * 仅 Ubuntu/CentOS 支持 NCCL 2 技术
@@ -36,28 +53,26 @@
 
     * Windows 安装 GPU 版本
 
-        * Windows 7/8/10 支持 CUDA 9.0/10.0 单卡模式，不支持 CUDA 9.1/9.2/10.1	 
+        * Windows 7/8/10 支持 CUDA 10.1/10.2/11.2 单卡模式 
         * 不支持 **nvidia-docker** 方式安装
     * Ubuntu 安装 GPU 版本
 
-        * Ubuntu 14.04 支持 CUDA 10.0/10.1，不支持CUDA 9.0/9.1/9.2
-        * Ubuntu 16.04 支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2
-        * Ubuntu 18.04 支持 CUDA 10.0/10.1/10.2/11.0，不支持CUDA 9.0/9.1/9.2
-        * 如果您是使用 **nvidia-docker** 安装，支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0
+        * Ubuntu 16.04 支持 CUDA 10.1/10.2/11.2
+        * Ubuntu 18.04 支持 CUDA 10.1/10.2/11.2
+        * 如果您是使用 **nvidia-docker** 安装，支持 CUDA 10.2/11.2
     * CentOS 安装 GPU 版本
 
         * 如果您是使用本机 **pip** 安装：
 
-            * CentOS 7 支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0，CUDA 9.1 仅支持单卡模式
-            * CentOS 6 支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2 单卡模式
+            * CentOS 7 支持 CUDA 10.1/10.2/11.2
         * 如果您是使用本机源码编译安装：
 
-            * CentOS 7 支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0，CUDA 9.1 仅支持单卡模式
+            * CentOS 7 支持 CUDA 10.1/10.2/11.2
             * CentOS 6 不推荐，不提供编译出现问题时的官方支持
-        * 如果您是使用 **nvidia-docker** 安装，在CentOS 7 下支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0
-    * MacOS 不支持：PaddlePaddle 在 MacOS 平台没有 GPU 支持
+        * 如果您是使用 **nvidia-docker** 安装，在CentOS 7 下支持 CUDA 10.2/11.2
+    * MacOS 不支持：MacOS 平台不支持 GPU 安装
 
-请确保您的环境满足以上条件。如您有其他需求，请参考 `多版本whl包安装列表 <Tables.html#ciwhls>`_ .
+请确保您的环境满足以上条件。如您有其他需求，请参考 `多版本whl包安装列表 <Tables.html#ciwhls-release>`_ .
 
 **5. PaddlePaddle 对 NCCL 支持情况：**
 
@@ -66,26 +81,18 @@
     * 不支持NCCL
 * Ubuntu 支持情况
 
-    * Ubuntu 14.04：
-
-        * CUDA10.1 下支持NCCL v2.4.2-v2.4.8
-        * CUDA10.0 下支持NCCL v2.3.7-v2.4.8
     * Ubuntu 16.04:
 
         * CUDA10.1 下支持NCCL v2.4.2-v2.4.8
-        * CUDA10.0/9.2/9.0 下支持NCCL v2.3.7-v2.4.8        
-        * CUDA9.1 下支持NCCL v2.1.15
     * Ubuntu 18.04：
 
         * CUDA10.1 下支持NCCL v2.4.2-v2.4.8
-        * CUDA10.0 下支持NCCL v2.3.7-v2.4.8
 * CentOS 支持情况
 
     * CentOS 6：不支持NCCL
     * CentOS 7：
 
         * CUDA10.1 下支持NCCL v2.4.2-v2.4.8
-        * CUDA10.0/9.2/9.0 下支持NCCL v2.3.7-v2.4.8
 * MacOS 支持情况
 
     * 不支持NCCL
@@ -102,7 +109,7 @@
 
 3. 确认您需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
 
-    如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+    使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
     
         在 Windows 环境下，输出 Python 路径的命令为：
         
@@ -116,57 +123,28 @@
 
             which python
 
-    如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
-
-        在 Windows 环境下，输出 Python 路径的命令为：
-
-        ::
-
-            where python3
-
-        在 MacOS/Linux 环境下，输出 Python 路径的命令为：
-
-        ::
-
-            which python3
 
 4. 检查 Python 的版本
 
-    如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+    使用以下命令确认是 3.6/3.7/3.8/3.9
     ::
     
         python --version
 
-    如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8
-    ::
-    
-        python3 --version
-    
 5. 检查 pip 的版本，确认是 20.2.2+  
 
-    如果您是使用 Python 2
     ::
     
         python -m ensurepip 
         python -m pip --version
 
-    如果您是使用 Python 3
-    ::
-    
-        python3 -m ensurepip
-        python3 -m pip --version
 
 6. 确认 Python 和 pip 是 64 bit，并且处理器架构是x86_64（或称作 x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是 "64bit" ，第二行输出的是 "x86_64" 、 "x64" 或 "AMD64" 即可：
 
-    如果您是使用 Python 2
     ::
 
         python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
-    如果您是使用 Python 3
-    ::
-    
-        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
 7. 如果您希望使用 `pip <https://pypi.org/project/pip/>`_ 进行安装PaddlePaddle可以直接使用以下命令:
 
@@ -175,7 +153,12 @@
         安装CPU版本的命令为：
         ::
     
-            python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/develop.html
+            python -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple
+
+            或
+
+            python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple
+
 
     (2). **GPU版本** ：如果您想使用GPU版本请参考如下命令安装 
 
@@ -186,14 +169,18 @@
         请注意用以下指令安装的PaddlePaddle在Windows、Ubuntu、CentOS下只支持CUDA10.2：
         ::
 
-            python -m pip install paddlepaddle-gpu==2.1.0-dev0.post102 -f https://paddlepaddle.org.cn/whl/develop.html
+            python -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple
+
+            或
+
+            python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple
+
         
-    
-    请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为 python3 或者替换为具体的 Python 路径。
+    请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径。
 
 8. 验证安装
 
-    使用 python 或 python3 进入python解释器，输入import paddle ，再输入 paddle.utils.run_check()。
+    使用 python 进入python解释器，输入import paddle ，再输入 paddle.utils.run_check()。
 
     如果出现 PaddlePaddle is installed successfully!，说明您已成功安装。
 

--- a/docs/install/index_en.rst
+++ b/docs/install/index_en.rst
@@ -1,39 +1,56 @@
 ..  _install_introduction_:
 
-============================
- Installation Manuals
-============================
+=======================
+ Installation Guide
+=======================
+
+
+----------------------
+  Important updates
+----------------------
+
+* Add support for python3.9, and no longer supports python2.7 and python3.5
+* Add support for CUDA 11.2, and no longer supports CUDA 9.0, CUDA 10.0 and CUDA 11.0
+* Add support for ROCm platform (2.1 Paddle's support for ROCm platform is experimental)
+* Linux system-related packages have been split into two types of packages, avx and noavx (Most machines use the avx instruction set. You can check whether your machine supports it through commands on the `PIP installation under Linux <pip/linux-pip.html>`_ page )
+* Add a CPU image with jupyter pre-installed. Jupyter service will be started after starting the image
+* Added support for Windows Visual Studio 2017 compilation, fully upgraded from VS2015 to VS2017 
+
+
+------------------------
+  Installation Manuals
+------------------------
+
 
 The manuals will guide you to build and install PaddlePaddle on your 64-bit desktop or laptop.
 
 1. Operating system requirements:
-=================================
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 * Windows 7 / 8 / 10, Pro/Enterprise
-* Ubuntu 14.04 / 16.04 / 18.04
-* CentOS 6 / 7
+* Ubuntu 16.04 / 18.04
+* CentOS 7
 * MacOS 10.11 / 10.12 / 10.13 / 10.14
 * 64-bit operating system is required
 
 2. Processor requirements:
-==========================
+>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 * Processor supports MKL
 * The processor architecture is x86_64(or called x64, Intel 64, AMD64). Currently, PaddlePaddle does not support arm64.
 
 3. Version requirements of python and pip:
-==========================================
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-* Python 2 requires version 2.7.15+
-* Python 3 requires version 3.5.1+/3.6/3.7/3.8
-* Python needs pip, and pip requires version 20.2.2+
+* Python requires version 3.6/3.7/3.8/3.9
+* Python needs pip, and pip requires version 20.2.2 or above
 * Python and pip requires 64-bit
 
 4. PaddlePaddle's support for GPU:
-==================================
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-* Currently, **PaddlePaddle** only supports **CUDA** driver of **NVIDIA** graphics card.
-* You need to install `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ , and version 7.6+ is required(For CUDA9/10) 
+* Currently, **PaddlePaddle** supports **CUDA** driver of **NVIDIA** graphics card and **ROCm** driver of **AMD** card.
+* You need to install `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ , and version 7.6+ is required(For CUDA10.1/10.2) 
 * If you need GPU multi-card mode, you need to install `NCCL 2 <https://developer.nvidia.com/nccl/>`_
 
     * Only Ubuntu/CentOS support NCCL 2
@@ -41,64 +58,53 @@ The manuals will guide you to build and install PaddlePaddle on your 64-bit desk
 
     * Windows install GPU version
 
-        * Windows 7 / 8 / 10 support CUDA 9.0 / 10.0 single-card mode, but don't support CUDA 9.1/9.2/10.1		
+        * Windows 7 / 8 / 10 support CUDA 10.1/10.2/11.2 single-card mode, but don't support CUDA 9.1/9.2/10.1		
         * don't support install using **nvidia-docker** 
     * Ubuntu install GPU version
 
-        * Ubuntu 14.04 supports CUDA 10.0/10.1, but doesn't support CUDA 9.0/9.1/9.2
-        * Ubuntu 16.04 supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2
-        * Ubuntu 18.04 supports CUDA 10.0/10.1/10.2/11.0, but doesn't support CUDA 9.0/9.1/9.2
-        * If you install using **nvidia-docker** , it supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0
+        * Ubuntu 16.04 supports CUDA 10.1/10.2/11.2
+        * Ubuntu 18.04 supports CUDA 10.1/10.2/11.2
+        * If you install using **nvidia-docker** , it supports CUDA 10.2/11.2
     * CentOS install GPU version
 
         * If you install using native **pip** :
 
-            * CentOS 7 supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0, CUDA 9.1 supports single-card mode only
-            * CentOS 6 supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2 single-card mode
+            * CentOS 7 supports CUDA 10.1/10.2/11.2
         * If you compile and install using native source code:
 
-            * CentOS 7 supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0, CUDA 9.1 supports single-card mode only
-            * CentOS 6 is not recommended, we don't provide official support in case of compilation problems
-        * If you install using  **nvidia-docker** , CentOS 7 supports CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0
+            * CentOS 7 supports CUDA 10.1/10.2/11.2
+        * If you install using  **nvidia-docker** , CentOS 7 supports CUDA 10.2/11.2
     * MacOS isn't supported: PaddlePaddle has no GPU support in Mac OS platform
 
-Please make sure your environment meets the above conditions. If you have other requirements, please refer to `Appendix <Tables_en.html#ciwhls>`_ .
+Please make sure your environment meets the above conditions. If you have other requirements, please refer to `Appendix <Tables_en.html#ciwhls-release>`_ .
 
 5. PaddlePaddle's support for NCCL:
-===================================
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 * Support for Windows
 
     * not support NCCL
 * Support for Ubuntu
 
-    * Ubuntu 14.04:
-
-        * support NCCL v2.4.2-v2.4.8 under CUDA10.1 
-        * support NCCL v2.3.7-v2.4.8 under CUDA10.0
     * Ubuntu 16.04:
 
         * support NCCL v2.4.2-v2.4.8 under CUDA10.1
-        * support NCCL v2.3.7-v2.4.8 under CUDA10.0/9.2/9.0        
-        * support NCCL v2.1.15 under CUDA9.1
     * Ubuntu 18.04:
 
         * support v2.4.2-v2.4.8 under CUDA10.1 
-        * support NCCL v2.3.7-v2.4.8 under CUDA10.0 
 * Support for CentOS
 
     * CentOS 6: not support NCCL
     * CentOS 7:
 
         * support NCCL v2.4.2-v2.4.8 under CUDA10.1 
-        * support NCCL v2.3.7-v2.4.8 under CUDA10.0/9.2/9.0 
 * Support for MacOS
 
     * not support NCCL
 
 
 The first way to install: use pip to install
-============================================
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 You can choose any of the four ways to install: "use pip to install", "use Conda to install", "use Docker to install", "compiling from the source code"
 
@@ -110,7 +116,7 @@ This section describes how to use pip to install.
 
 3. Confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python
 
-    If you are using Python 2, use the following command to output Python path. Depending on your environment, you may need to replace Python in all command lines in the description with specific Python path
+    Use the following command to output Python path. Depending on your environment, you may need to replace Python in all command lines in the description with specific Python path
     
         In the Windows environment, the command to output Python path is:
         
@@ -124,57 +130,28 @@ This section describes how to use pip to install.
 
             which python
 
-    If you are using Python 3, use the following command to output Python path. Depending on your environment, you may need to replace Python in all command lines in the description with specific Python path
-
-        In the Windows environment, the command to output Python path is:
-
-        ::
-
-            where python3
-
-        In the MacOS/Linux environment, the command to output Python path is:
-
-        ::
-
-            which python3
 
 4. Check the version of Python
 
-    If you are using Python 2，confirm it is 2.7.15+ using command
+    Confirm the Python is 3.6/3.7/3.8/3.9 using command
     ::
     
         python --version
-
-    If you are using Python 3，confirm it is 3.5.1+/3.6/3.7/3.8 using command
-    ::
     
-        python3 --version
-    
-5. Check the version of pip and confirm it is 20.2.2+  
+5. Check the version of pip and confirm it is 20.2.2 or above  
 
-    If you are using Python 2
     ::
     
         python -m ensurepip 
         python -m pip --version
 
-    If you are using Python 3
-    ::
-    
-        python3 -m ensurepip
-        python3 -m pip --version
 
 6. Confirm that Python and pip is 64 bit，and the processor architecture is x86_64(or called x64、Intel 64、AMD64)architecture. Currently, PaddlePaddle doesn't support arm64 architecture. The first line below outputs "64bit", and the second line outputs "x86_64", "x64" or "AMD64" :
 
-    If you use Python 2
     ::
 
         python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
-    If you use Python 3
-    ::
-    
-        python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
 
 7. If you want to use `pip <https://pypi.org/project/pip/>`_ to install PaddlePaddle, you can use the command below directly:
 
@@ -183,8 +160,11 @@ This section describes how to use pip to install.
         Command to install CPU version is:
         ::
     
-            python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/develop.html
+            python -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple
 
+            or
+
+            python -m pip install paddlepaddle -i https://pypi.tuna.tsinghua.edu.cn/simple
         
 
     (2). **GPU version** : If you only want to install GPU version, please refer to command below
@@ -197,13 +177,18 @@ This section describes how to use pip to install.
         Please attention that PaddlePaddle installed through command below only supports CUDA10.2 under Windows、Ubuntu、CentOS:
         ::
 
-            python -m pip install paddlepaddle-gpu==2.1.0-dev0.post102 -f https://paddlepaddle.org.cn/whl/develop.html
+            python -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple
+
+            or
+
+            python -m pip install paddlepaddle-gpu -i https://pypi.tuna.tsinghua.edu.cn/simple
+
         
     Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with Python 3 or specific Python path.
 
 8. Verify installation
 
-    After the installation is complete, you can use `python` or `python3` to enter the Python interpreter and then use `import paddle` and then  `paddle.utils.run_check()` to verify that the installation was successful.
+    After the installation is complete, you can use `python` to enter the Python interpreter and then use `import paddle` and then  `paddle.utils.run_check()` to verify that the installation was successful.
 
     If `PaddlePaddle is installed successfully!` appears, it means the installation was successful.
 
@@ -218,7 +203,7 @@ This section describes how to use pip to install.
 
 
 The second way to install: compile and install with source code
-===============================================================
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 - If you use PaddlePaddle only, we suggest you installation methods **pip** to install.
 - If you need to develop PaddlePaddle, please refer to `compile from source code <compile/fromsource_en.html>`_

--- a/docs/install/install_script.md
+++ b/docs/install/install_script.md
@@ -17,7 +17,7 @@
 
 	检测您的机器是否安装我们支持的CUDA，cuDNN，具体地：
 
-	1. 在`/usr/local/` 及其子目录下寻找 `cuda/cuda8/cuda9/cuda10` 目录下的`version.txt`文件（通常如果您以默认方式安装了CUDA）。 如果提示未找到CUDA请使用命令`find / -name version.txt`找到您所需要的CUDA目录下的“version.txt”路径，然后按照提示输入。
+	1. 在`/usr/local/` 及其子目录下寻找 `cuda10.1/cuda10.2/cuda11.0/cuda11.2` 目录下的`version.txt`文件（通常如果您以默认方式安装了CUDA）。 如果提示未找到CUDA请使用命令`find / -name version.txt`找到您所需要的CUDA目录下的“version.txt”路径，然后按照提示输入。
 	2.  在`/usr` 及其子目录下寻找文件 `cudnn.h`  , 如果您的cuDNN未安装在默认路径请使用命令`find / -name cudnn.h`寻找您希望使用的cuDNN版本的`cudnn.h`路径并按提示输入
 
    如果未找到相应文件，则会安装CPU版本的PaddlePaddle

--- a/docs/install/pip/linux-pip.md
+++ b/docs/install/pip/linux-pip.md
@@ -6,16 +6,13 @@
 
 * **Linux 版本 (64 bit)**
 
-  * **CentOS 6 (GPU版本支持CUDA 9.0/9.1/9.2/10.0/10.1/10.2, 仅支持单卡)**
+  * **CentOS 7 (GPU版本支持CUDA 10.1/10.2/11.2)**
+  * **Ubuntu 16.04 (GPU 版本支持 CUDA 10.1/10.2/11.2)**
+  * **Ubuntu 18.04 (GPU 版本支持 CUDA 10.1/10.2/11.2)**
 
-  * **CentOS 7 (GPU版本支持CUDA 9.0/9.1/9.2/10.0/10.1/10.2/11.0, 其中CUDA 9.1仅支持单卡)**
-  * **Ubuntu 14.04 (GPU 版本支持 CUDA 10.0/10.1)**
-  * **Ubuntu 16.04 (GPU 版本支持 CUDA 9.0/9.1/9.2/10.0/10.1/10.2)**
-  * **Ubuntu 18.04 (GPU 版本支持 CUDA 10.0/10.1/10.2/11.0)**
+* **Python 版本 3.6/3.7/3.8/3.9 (64 bit)**
 
-* **Python 版本 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
-
-* **pip 或 pip3 版本 20.2.2+ (64 bit)**
+* **pip 或 pip3 版本 20.2.2或更高版本 (64 bit)**
 
 ### 1.2如何查看您的环境
 
@@ -29,35 +26,20 @@
 
 * 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
 
-  * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+  * 根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
 
     ```
     which python
     ```
 
 
-
-  * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
-
-    ```
-    which python3
-    ```
-
-
-
 * 需要确认python的版本是否满足要求
 
-  * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+  * 使用以下命令确认是 3.6/3.7/3.8/3.9
 
         python --version
 
-  * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8
-
-        python3 --version
-
-* 需要确认pip的版本是否满足要求，要求pip版本为20.2.2+
-
-  * 如果您是使用 Python2
+* 需要确认pip的版本是否满足要求，要求pip版本为20.2.2或更高版本
 
     ```
     python -m ensurepip
@@ -67,30 +49,13 @@
     python -m pip --version
     ```
 
-  * 如果您是使用 Python 3
-
-    ```
-    python3 -m ensurepip
-    ```
-
-    ```
-    python3 -m pip --version
-    ```
-
 
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
-  * 如果您是使用 Python 2
 
     ```
     python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-    ```
-
-  * 如果您是使用 Python 3
-
-    ```
-    python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
     ```
 
 
@@ -111,13 +76,11 @@
 
 * 如果您的计算机有NVIDIA® GPU，请确保满足以下条件并且安装[GPU版PaddlePaddle](#gpu)
 
-  * **CUDA 工具包9.0/10.0配合cuDNN v7.6+(如需多卡支持，需配合NCCL2.3.7及更高)**
-
   * **CUDA 工具包10.1/10.2配合cuDNN v7.6+(如需多卡支持，需配合NCCL2.7及更高)**
 
-  * **CUDA 工具包11.0配合cuDNN v8.0.4(如需多卡支持，需配合NCCL2.7及更高)**
+  * **CUDA 工具包11.2配合cuDNN v8.1.1(如需多卡支持，需配合NCCL2.7及更高)**
 
-  * **GPU运算能力超过1.0的硬件设备**
+  * **GPU运算能力超过3.5的硬件设备**
 
     您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -153,80 +116,50 @@
     sudo apt-get install -y libnccl2=2.3.7-1+cuda9.0 libnccl-dev=2.3.7-1+cuda9.0
     ```
 
-* [CPU版的PaddlePaddle](#cpu)
 
-* [GPU版的PaddlePaddle](#gpu)
-  * [CUDA9.0的PaddlePaddle](#cuda9)
-  * [CUDA10.0的PaddlePaddle](#cuda10)
-  * [CUDA10.1的PaddlePaddle](#cuda10.1)
-  * [CUDA10.2的PaddlePaddle](#cuda10.2)
-  * [CUDA11.0的PaddlePaddle](#cuda11)
-
-
-
-#### 2.1 <span id="cpu">CPU版的PaddlePaddle</span>
+#### 2.1 CPU版的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/cpu/mkl/develop.html
+  python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
   ```
 
 
 
-#### 2.2<span id="gpu"> GPU版的PaddlePaddle</span>
+#### 2.2 GPU版的PaddlePaddle
 
 
 
-2.2.1 <span id="cuda9">CUDA9.0的PaddlePaddle</span>
-
-
-  ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post90 -f https://paddlepaddle.org.cn/whl/cu90/mkl/develop.html
-  ```
-
-
-
-2.2.2 <span id="cuda10">CUDA10.0的PaddlePaddle</span>
-
+2.2.1 CUDA10.1的PaddlePaddle
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post100 -f https://paddlepaddle.org.cn/whl/cu100/mkl/develop.html
-  ```
-
-
-2.2.3 <span id="cuda10.1">CUDA10.1的PaddlePaddle</span>
-
-
-  ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post101 -f https://paddlepaddle.org.cn/whl/cu101/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post101 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
   ```
 
 
 
-2.2.4 <span id="cuda10.2">CUDA10.2的PaddlePaddle</span>
+2.2.2 CUDA10.2的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post102 -f https://paddlepaddle.org.cn/whl/cu102/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post102 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
   ```
 
 
-
-2.2.5 <span id="cuda11">CUDA11.0的PaddlePaddle</span>
+2.2.3 CUDA11.2的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post110 -f https://paddlepaddle.org.cn/whl/cu110/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
   ```
 
 
 
 注：
 
+* 如果你使用的是安培架构的GPU，推荐使用CUDA11.2。如果你使用的是非安培架构的GPU，推荐使用CUDA10.2，性能更优。
+
 * 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为 python3 或者替换为具体的 Python 路径。
-
-
-
 
 
 
@@ -243,6 +176,6 @@
 
 请使用以下命令卸载PaddlePaddle：
 
-* **CPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`
+* **CPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle`
 
-* **GPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle-gpu` 或 `python3 -m pip uninstall paddlepaddle-gpu`
+* **GPU版本的PaddlePaddle**: `python -m pip uninstall paddlepaddle-gpu`

--- a/docs/install/pip/linux-pip_en.md
+++ b/docs/install/pip/linux-pip_en.md
@@ -5,16 +5,13 @@
 ### 1.1 PREQUISITES
 
 * **Linux Version (64 bit)**
-  * **CentOS 6 (GPU Version Supports CUDA 9.0/9.1/9.2/10.0/10.1, only supports single card**)**
+  * **CentOS 7 (GPUVersion Supports CUDA 10.1/10.2/11.2**)**
+  * **Ubuntu 16.04 (GPUVersion Supports CUDA 10.1/10.2/11.2)**
+  * **Ubuntu 18.04 (GPUVersion Supports CUDA 10.1/10.2/11.2)**
 
-  * **CentOS 7 (GPUVersion Supports CUDA 9.0/9.1/9.2/10.0/10.1, CUDA 9.1 only supports single card**)**
-  * **Ubuntu 14.04 (GPUVersion Supports CUDA 10.0/10.1)**
-  * **Ubuntu 16.04 (GPUVersion Supports CUDA 9.0/9.1/9.2/10.0/10.1)**
-  * **Ubuntu 18.04 (GPUVersion Supports CUDA 10.0/10.1)**
+* **Python Version: 3.6/3.7/3.8/3.9 (64 bit)**
 
-* **Python Version: 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
-
-* **pip or pip3 Version 20.2.2+ (64 bit)**
+* **pip or pip3 Version 20.2.2 or above (64 bit)**
 
 ### 1.2 How to check your environment
 
@@ -28,33 +25,22 @@
 
 * Confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python
 
-  * If you are using Python 2, use the following command to output Python path. Depending on the environment, you may need to replace Python in all command lines in the description with specific Python path
+  * Use the following command to output Python path. Depending on the environment, you may need to replace Python in all command lines in the description with specific Python path
 
     ```
     which python
-    ```
-
-  * If you are using Python 3, use the following command to output Python path. Depending on your environment, you may need to replace Python 3 in all command lines in the instructions with Python or specific Python path
-
-    ```
-    which python3
     ```
 
 
 
 * You need to confirm whether the version of Python meets the requirements
 
-  * If you are using Python 2, use the following command to confirm that it is 2.7.15+
+  * Use the following command to confirm that it is 3.6/3.7/3.8/3.9
 
         python --version
 
-  * If you are using Python 3, use the following command to confirm that it is 3.5.1+/3.6/3.7/3.8
+* It is required to confirm whether the version of pip meets the requirements. The version of pip is required to be 20.2.2 or above
 
-        python3 --version
-
-* It is required to confirm whether the version of pip meets the requirements. The version of pip is required to be 20.2.2+
-
-  * If you are using Python 2
 
     ```
     python -m ensurepip
@@ -64,30 +50,12 @@
     python -m pip --version
     ```
 
-  * If you are using Python 3
-
-    ```
-    python3 -m ensurepip
-    ```
-
-    ```
-    python3 -m pip --version
-    ```
-
 
 
 * You need to confirm that Python and pip are 64bit, and the processor architecture is x86_64(or called x64、Intel 64、AMD64). Currently, paddlepaddle does not support arm64 architecture. The first line below outputs "64bit", and the second line outputs "x86_64", "x64" or "AMD64"
 
-  * If you are using Python 2
-
     ```
     python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-    ```
-
-  * If you are using Python 3
-
-    ```
-    python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
     ```
 
 
@@ -108,13 +76,11 @@ If you installed Python via Homebrew or the Python website, `pip` was installed 
 
 * If your computer has NVIDIA® GPU, please make sure that the following conditions are met and install [the GPU Version of PaddlePaddle](#gpu)
 
-  * **CUDA toolkit 9.0/10.0 with cuDNN v7.6+(for multi card support, NCCL2.3.7 or higher)**
+  * **CUDA toolkit 10.1/10.2 with cuDNN v7.6+(for multi card support, NCCL2.7 or higher)**
 
-  * **CUDA toolkit 10.1/10.2 with cuDNN v7.6+(for multi card support, NCCL2.3.7 or higher)**
+  * **CUDA toolkit 11.2 with cuDNN v8.1.1(for multi card support, NCCL2.7 or higher)**
 
-  * **CUDA toolkit 11.0 with cuDNN v8.0.4(for multi card support, NCCL2.3.7 or higher)**
-
-  * **Hardware devices with GPU computing power over 1.0**
+  * **Hardware devices with GPU computing power over 3.5**
 
     You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -156,77 +122,52 @@ If you installed Python via Homebrew or the Python website, `pip` was installed 
 
 You can choose the following version of PaddlePaddle to start installation:
 
-* [CPU Version of PaddlePaddle](#cpu)
-
-* [GPU Version of PaddlePaddle](#gpu)
-  * [CUDA9.0 PaddlePaddle](#cuda9)
-  * [CUDA10.0 PaddlePaddle](#cuda10)
-  * [CUDA10.1 PaddlePaddle](#cuda10.1)
-  * [CUDA10.2 PaddlePaddle](#cuda10.2)
-  * [CUDA11.0 PaddlePaddle](#cuda11)
 
 
-
-#### 2.1 <span id="cpu">CPU Versoion of PaddlePaddle</span>
-
-  ```
-  python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/cpu/mkl/develop.html
-  ```
-
-
-#### 2.2<span id="gpu"> GPU Version of PaddlePaddle</span>
-
-
-
-2.2.1 <span id="cuda9">CUDA9.0 PaddlePaddle</span>
+#### 2.1 CPU Versoion of PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post90 -f https://paddlepaddle.org.cn/whl/cu90/mkl/develop.html
+  python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
   ```
 
 
 
-2.2.2 <span id="cuda10">CUDA10.0 PaddlePaddle</span>
+#### 2.2 GPU Version of PaddlePaddle
+
+
+
+2.2.1 CUDA10.1的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post100 -f https://paddlepaddle.org.cn/whl/cu100/mkl/develop.html
-  ```
-
-
-
-2.2.3 <span id="cuda10.1">CUDA10.1 PaddlePaddle</span>
-
-
-  ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post101 -f https://paddlepaddle.org.cn/whl/cu101/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post101 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
   ```
 
 
 
-2.2.4 <span id="cuda10.2">CUDA10.2 PaddlePaddle</span>
+2.2.2 CUDA10.2的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post102 -f https://paddlepaddle.org.cn/whl/cu102/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post102 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
   ```
 
 
-
-2.2.5 <span id="cuda11">CUDA11.0 PaddlePaddle</span>
+2.2.3 CUDA11.2的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post110 -f https://paddlepaddle.org.cn/whl/cu110/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
   ```
 
 
 
 Note：
 
-* Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with Python 3 or specific Python path.
+* If you are using ampere-based GPU, CUDA 11.2 is recommended; otherwise CUDA 10.2 is recommended for better performance.
 
+* Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with Python 3 or specific Python path.
 
 
 
@@ -240,5 +181,5 @@ If `PaddlePaddle is installed successfully!` appears, to verify that the install
 
 Please use the following command to uninstall PaddlePaddle:
 
-- ***CPU version of PaddlePaddle\***: `python -m pip uninstall paddlepaddle` or `python3 -m pip uninstall paddlepaddle`
-- ***GPU version of PaddlePaddle\***: `python -m pip uninstall paddlepaddle-gpu` or `python3 -m pip uninstall paddlepaddle-gpu`
+- ***CPU version of PaddlePaddle\***: `python -m pip uninstall paddlepaddle`
+- ***GPU version of PaddlePaddle\***: `python -m pip uninstall paddlepaddle-gpu`

--- a/docs/install/pip/macos-pip.md
+++ b/docs/install/pip/macos-pip.md
@@ -6,9 +6,9 @@
 
 * **macOS 版本 10.11/10.12/10.13/10.14 (64 bit) (不支持GPU版本)**
 
-* **Python 版本 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
+* **Python 版本 3.6/3.7/3.8/3.9 (64 bit)**
 
-* **pip 或 pip3 版本 20.2.2+ (64 bit)**
+* **pip 或 pip3 版本 20.2.2或更高版本 (64 bit)**
 
 
 ### 1.2如何查看您的环境
@@ -23,37 +23,24 @@
 
 * 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
 
-  * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+  * 使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
 
     ```
     which python
-    ```
-
-  * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
-
-    ```
-    which python3
     ```
 
 
 
 * 需要确认python的版本是否满足要求
 
-  * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+  * 使用以下命令确认是 3.6/3.7/3.8/3.9
 
     ```
     python --version
     ```
 
-  * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8
+* 需要确认pip的版本是否满足要求，要求pip版本为20.2.2或更高版本
 
-    ```
-    python3 --version
-    ```
-
-* 需要确认pip的版本是否满足要求，要求pip版本为20.2.2+
-
-  * 如果您是使用 Python2
 
     ```
     python -m ensurepip
@@ -63,30 +50,12 @@
     python -m pip --version
     ```
 
-  * 如果您是使用 Python 3
-
-    ```
-    python3 -m ensurepip
-    ```
-
-    ```
-    python3 -m pip --version
-    ```
-
 
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
 
-  * 如果您是使用 Python 2
-
     ```
     python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-    ```
-
-  * 如果您是使用 Python 3
-
-    ```
-    python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
     ```
 
 
@@ -110,19 +79,21 @@
 
 确定您的环境满足条件后可以开始安装了，选择下面您要安装的PaddlePaddle
 
+
   ```
-  python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/cpu/openblas/develop.html
+  python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/mac/cpu/develop.html
   ```
+
 
 * 注:
 * MacOS上您需要安装unrar以支持PaddlePaddle，可以使用命令`brew install unrar`
-* 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为 python3 或者替换为具体的 Python 路径。
+* 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径。
 * 默认下载最新稳定版的安装包，如需获取开发版安装包，请参考[这里](https://www.paddlepaddle.org.cn/install/quick/zh/1.8.5-windows-pip)
-* 使用MacOS中自带Python可能会导致安装失败。对于Python2，建议您使用[Homebrew](https://brew.sh)或[Python.org](https://www.paddlepaddle.org.cn/install/quick/zh/2.0rc-macos-pip)提供的python2.7.15；对于Python3，请使用[Python.org](https://www.python.org/downloads/mac-osx/)提供的python3.5.x、python3.6.x、python3.7.x或python3.8.x。
+* 使用MacOS中自带Python可能会导致安装失败。请使用[Python.org](https://www.python.org/downloads/mac-osx/)提供的python3.6.x、python3.7.x、python3.8.x 或python3.9.x。
 
 ## **三、验证安装**
 
-安装完成后您可以使用 `python` 或 `python3` 进入python解释器，输入`import paddle` ，再输入
+安装完成后您可以使用 `python` 进入python解释器，输入`import paddle` ，再输入
  `paddle.utils.run_check()`
 
 如果出现`PaddlePaddle is installed successfully!`，说明您已成功安装。
@@ -131,4 +102,4 @@
 
 请使用以下命令卸载PaddlePaddle：
 
-* `python -m pip uninstall paddlepaddle` 或 `python3 -m pip uninstall paddlepaddle`
+* `python -m pip uninstall paddlepaddle`

--- a/docs/install/pip/macos-pip_en.md
+++ b/docs/install/pip/macos-pip_en.md
@@ -6,9 +6,9 @@
 
 * **MacOS version 10.11/10.12/10.13/10.14 (64 bit) (not support GPU version)**
 
-* **Python version 2.7.15+/3.5.1+/3.6/3.7/3.8 (64 bit)**
+* **Python version 3.6/3.7/3.8/3.9 (64 bit)**
 
-* **pip or pip3 版本 20.2.2+ (64 bit)**
+* **pip or pip3 版本 20.2.2 or above (64 bit)**
 
 
 ### 1.2 How to check your environment
@@ -23,33 +23,21 @@
 
 * Confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python
 
-  * If you are using Python 2, use the following command to output Python path. Depending on the environment, you may need to replace Python in all command lines in the description with specific Python path
+  * Use the following command to output Python path. Depending on the environment, you may need to replace Python in all command lines in the description with specific Python path
 
     ```
     which python
-    ```
-
-  * If you are using Python 3, use the following command to output Python path. Depending on your environment, you may need to replace Python 3 in all command lines in the instructions with Python or specific Python path
-
-    ```
-    which python3
     ```
 
 
 
 * You need to confirm whether the version of Python meets the requirements
 
-  * If you are using Python 2, use the following command to confirm that it is 2.7.15+
+  * Use the following command to confirm that it is 3.6/3.7/3.8/3.9
 
         python --version
 
-  * If you are using Python 3, use the following command to confirm that it is 3.5.1+/3.6/3.7/3.8
-
-        python3 --version
-
-* It is required to confirm whether the version of pip meets the requirements. The version of pip is required to be 20.2.2+
-
-  * If you are using Python 2
+* It is required to confirm whether the version of pip meets the requirements. The version of pip is required to be 20.2.2 or above
 
     ```
     python -m ensurepip
@@ -59,32 +47,13 @@
     python -m pip --version
     ```
 
-  * If you are using Python 3
-
-    ```
-    python3 -m ensurepip
-    ```
-
-    ```
-    python3 -m pip --version
-    ```
-
-
 
 * You need to confirm that Python and pip are 64bit, and the processor architecture is x86_64(or called x64、Intel 64、AMD64). Currently, paddlepaddle does not support arm64 architecture. The first line below outputs "64bit", and the second line outputs "x86_64", "x64" or "AMD64"
 
-  * If you are using Python 2
 
     ```
     python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
     ```
-
-  * If you are using Python 3
-
-    ```
-    python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-    ```
-
 
 
 * The installation package provided by default requires computer support for MKL
@@ -108,19 +77,21 @@ You can choose the following version of PaddlePaddle to start installation:
 
 * Please use the following command to install PaddlePaddle：
 
-  ```
-  python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/cpu/openblas/develop.html
-  ```
+
+```
+python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/mac/cpu/develop.html
+```
 
 Note：
 
-* Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with Python 3 or specific Python path.
+
+* Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with specific Python path.
 
 
 
 ## Verify installation
 
-After the installation is complete, you can use `python` or `python3` to enter the Python interpreter and then use `import paddle` and `paddle.utils.run_check()`
+After the installation is complete, you can use `python` to enter the Python interpreter and then use `import paddle` and `paddle.utils.run_check()`
 
 If `PaddlePaddle is installed successfully!` appears, to verify that the installation was successful.
 
@@ -130,8 +101,4 @@ Please use the following command to uninstall PaddlePaddle:
 
 ```
 python -m pip uninstall paddlepaddle
-```
-
-```
-python3 -m pip uninstall paddlepaddle
 ```

--- a/docs/install/pip/windows-pip.md
+++ b/docs/install/pip/windows-pip.md
@@ -5,55 +5,36 @@
 ### 1.1目前飞桨支持的环境
 
 * **Windows 7/8/10 专业版/企业版 (64bit)**
-  * **GPU版本支持CUDA 9.0/10.0/10.1/10.2/11.0，且仅支持单卡**
+  * **GPU版本支持CUDA 10.1/10.2/11.2，且仅支持单卡**
 
-* **Python 版本 2.7.15+/3.5.1+/3.6+/3.7+/3.8+ (64 bit)**
+* **Python 版本 3.6+/3.7+/3.8+/3.9+ (64 bit)**
 
-* **pip 版本 20.2.2+ (64 bit)**
+* **pip 版本 20.2.2或更高版本 (64 bit)**
 
 ### 1.2如何查看您的环境
 
-* 可以使用以下命令查看本机的操作系统和位数信息：
-
-  ```
-  uname -m && cat /etc/*release
-  ```
-
+* 可以通过【控制面板】-【系统和安全】-【系统】查看本机的操作系统和位数信息：
 
 
 * 确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python
 
-  * 如果您是使用 Python 2，使用以下命令输出 Python 路径，根据的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径
+  ```
+  where python
+  ```
 
-    ```
-    which python
-    ```
-
-  * 如果您是使用 Python 3，使用以下命令输出 Python 路径，根据您的环境您可能需要将说明中所有命令行中的 python3 替换为 python 或者替换为具体的 Python 路径
-
-    ```
-    which python3
-    ```
 
 
 
 * 需要确认python的版本是否满足要求
 
-  * 如果您是使用 Python 2，使用以下命令确认是 2.7.15+
+
+  * 使用以下命令确认是 3.6/3.7/3.8/3.9
 
     ```
     python --version
     ```
 
-  * 如果您是使用 Python 3，使用以下命令确认是 3.5.1+/3.6/3.7/3.8
-
-    ```
-    python3 --version
-    ```
-
-* 需要确认pip的版本是否满足要求，要求pip版本为20.2.2+
-
-  * 如果您是使用 Python2
+* 需要确认pip的版本是否满足要求，要求pip版本为20.2.2或更高版本
 
     ```
     python -m ensurepip
@@ -63,31 +44,12 @@
     python -m pip --version
     ```
 
-  * 如果您是使用 Python 3
-
-    ```
-    python3 -m ensurepip
-    ```
-
-    ```
-    python3 -m pip --version
-    ```
-
 
 * 需要确认Python和pip是64bit，并且处理器架构是x86_64（或称作x64、Intel 64、AMD64）架构，目前PaddlePaddle不支持arm64架构。下面的第一行输出的是"64bit"，第二行输出的是"x86_64"、"x64"或"AMD64"即可：
-
-  * 如果您是使用 Python 2
 
     ```
     python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
     ```
-
-  * 如果您是使用 Python 3
-
-    ```
-    python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-    ```
-
 
 
 * 默认提供的安装包需要计算机支持MKL
@@ -107,47 +69,65 @@
 
 * 如果您的计算机有NVIDIA® GPU，请确保满足以下条件并且安装GPU版PaddlePaddle
 
-  * **CUDA 工具包9.0/10.0/10.1/10.2 配合 cuDNN v7.6.5+**
+  * **CUDA 工具包10.1/10.2 配合 cuDNN v7.6.5+**
 
-  * **CUDA 工具包11.0配合cuDNN v8.0.4**
+  * **CUDA 工具包11.2配合cuDNN v8.1.1**
 
-  * **GPU运算能力超过3.0的硬件设备**
+  * **GPU运算能力超过3.5的硬件设备**
 
-  * 注：目前官方发布的windows安装包仅包含 CUDA 9.0/10.0/10.1/10.2/11.0，不包含 CUDA 9.1/9.2，如需使用，请通过源码自行编译。您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
+  * 注：目前官方发布的windows安装包仅包含 CUDA 10.1/10.2/11.2，如需使用其他cuda版本，请通过源码自行编译。您可参考NVIDIA官方文档了解CUDA和CUDNN的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 
 
 ### 根据版本进行安装
 确定您的环境满足条件后可以开始安装了，选择下面您要安装的PaddlePaddle
 
-#### 2.1 <span id="cpu">CPU版的PaddlePaddle</span>
+
+
+#### 2.1 CPU版的PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/cpu/mkl/develop.html
+  python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
+  ```
+
+#### 2.2 GPU版的PaddlePaddle
+
+
+
+2.2.1 CUDA10.1的PaddlePaddle
+
+
+  ```
+  python -m pip install paddlepaddle-gpu==0.0.0.post101 -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
   ```
 
 
+2.2.2 CUDA10.2的PaddlePaddle
 
-#### 2.2<span id="gpu"> GPU版的PaddlePaddle</span>
-
-Windows的develop版本安装只支持CUDA10.2
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post102 -f https://paddlepaddle.org.cn/whl/cu102/mkl/develop.html
+  python -m pip install paddlepaddle-gpu==0.0.0.post102 -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
   ```
 
 
+2.2.3 CUDA11.2的PaddlePaddle
+
+  ```
+  python -m pip install paddlepaddle-gpu==0.0.0.post112 -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
+  ```
 
 
 注：
 
-* 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为 python3 或者替换为具体的 Python 路径。
+* 如果你使用的是安培架构的GPU，推荐使用CUDA11.2。如果你使用的是非安培架构的GPU，推荐使用CUDA10.2，性能更优。
+
+* 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径。
 
 
 ## **三、验证安装**
 
-安装完成后您可以使用 `python` 或 `python3` 进入python解释器，输入`import paddle` ，再输入
+安装完成后您可以使用 `python` 进入python解释器，输入`import paddle` ，再输入
  `paddle.utils.run_check()`
 
 如果出现`PaddlePaddle is installed successfully!`，说明您已成功安装。

--- a/docs/install/pip/windows-pip_en.md
+++ b/docs/install/pip/windows-pip_en.md
@@ -5,52 +5,33 @@
 ### 1.1 PREQUISITES
 
 * **Windows 7/8/10 Pro/Enterprise (64bit)**
-  * **GPU version support CUDA 9.0/10.0/10.1/10.2/11.0，only support single card**
+  * **GPU version support CUDA 10.1/10.2/11.2，only support single card**
 
-* **Python version 2.7.15+/3.5.1+/3.6+/3.7+/3.8+ (64 bit)**
+* **Python version 3.6+/3.7+/3.8+/3.9+ (64 bit)**
 
-* **pip version 20.2.2+ (64 bit)**
+* **pip version 20.2.2 or above (64 bit)**
 
 ### 1.2 How to check your environment
 
-* You can use the following commands to view the local operating system and bit information
-
-  ```
-  uname -m && cat /etc/*release
-  ```
-
+* Confirm the local operating system and bit information
 
 
 * Confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python
 
-  * If you are using Python 2, use the following command to output Python path. Depending on the environment, you may need to replace Python in all command lines in the description with specific Python path
-
-    ```
-    which python
-    ```
-
-  * If you are using Python 3, use the following command to output Python path. Depending on your environment, you may need to replace Python 3 in all command lines in the instructions with Python or specific Python path
-
-    ```
-    which python3
-    ```
+  ```
+  where python
+  ```
 
 
 
 * You need to confirm whether the version of Python meets the requirements
 
-  * If you are using Python 2, use the following command to confirm that it is 2.7.15+
+  * Use the following command to confirm that it is 3.6/3.7/3.8/3.9
 
         python --version
 
-  * If you are using Python 3, use the following command to confirm that it is 3.5.1+/3.6/3.7/3.8
 
-        python3 --version
-
-
-* It is required to confirm whether the version of pip meets the requirements. The version of pip is required to be 20.2.2+
-
-  * If you are using Python 2
+* It is required to confirm whether the version of pip meets the requirements. The version of pip is required to be 20.2.2 or above
 
     ```
     python -m ensurepip
@@ -60,30 +41,12 @@
     python -m pip --version
     ```
 
-  * If you are using Python 3
-
-    ```
-    python3 -m ensurepip
-    ```
-
-    ```
-    python3 -m pip --version
-    ```
-
 
 
 * You need to confirm that Python and pip are 64bit, and the processor architecture is x86_64(or called x64、Intel 64、AMD64). Currently, paddlepaddle does not support arm64 architecture. The first line below outputs "64bit", and the second line outputs "x86_64", "x64" or "AMD64"
 
-  * If you are using Python 2
-
     ```
     python -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
-    ```
-
-  * If you are using Python 3
-
-    ```
-    python3 -c "import platform;print(platform.architecture()[0]);print(platform.machine())"
     ```
 
 
@@ -104,11 +67,11 @@ If you installed Python via Homebrew or the Python website, `pip` was installed 
 
 * If your computer has NVIDIA® GPU, please make sure that the following conditions are met and install [the GPU Version of PaddlePaddle](#gpu)
 
-  * **CUDA toolkit 9.0/10.0/10.1/10.2 with cuDNN v7.6.5+**
+  * **CUDA toolkit 10.1/10.2 with cuDNN v7.6.5+**
 
-  * **CUDA toolkit 11.0 with cuDNN v8.0.4**
+  * **CUDA toolkit 11.2 with cuDNN v8.1.1**
 
-  * **Hardware devices with GPU computing power over 3.0**
+  * **Hardware devices with GPU computing power over 3.5**
 
     You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
@@ -118,35 +81,51 @@ If you installed Python via Homebrew or the Python website, `pip` was installed 
 You can choose the following version of PaddlePaddle to start installation:
 
 
-#### 2.1 <span id="cpu">CPU Versoion of PaddlePaddle</span>
-
-  ```
-  python -m pip install --pre paddlepaddle -f https://paddlepaddle.org.cn/whl/cpu/mkl/develop.html
-  ```
 
 
-#### 2.2<span id="gpu"> GPU Version of PaddlePaddle</span>
-
-GPU only support CUDA10.2
+#### 2.1 CPU Versoion of PaddlePaddle
 
 
   ```
-  python -m pip install --pre paddlepaddle-gpu==2.1.0.dev0.post102 -f https://paddlepaddle.org.cn/whl/cu102/mkl/develop.html
+  python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
   ```
 
 
 
+#### 2.2 GPU Version of PaddlePaddle
+
+
+2.2.1 CUDA10.1的PaddlePaddle
+
+
+  ```
+  python -m pip install paddlepaddle-gpu==0.0.0.post101 -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
+  ```
+
+
+2.2.2 CUDA10.2的PaddlePaddle
+
+  ```
+  python -m pip install paddlepaddle-gpu==0.0.0.post102 -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
+  ```
+
+
+2.2.3 CUDA11.2的PaddlePaddle
+
+  ```
+  python -m pip install paddlepaddle-gpu==0.0.0.post112 -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
+  ```
 
 Note：
 
-* Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with Python 3 or specific Python path.
+* If you are using ampere-based GPU, CUDA 11.2 is recommended; otherwise CUDA 10.2 is recommended for better performance.
 
-
+* Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with specific Python path.
 
 
 ## Verify installation
 
-After the installation is complete, you can use `python` or `python3` to enter the Python interpreter and then use `import paddle` and `paddle.utils.run_check()`
+After the installation is complete, you can use `python` to enter the Python interpreter and then use `import paddle` and `paddle.utils.run_check()`
 
 If `PaddlePaddle is installed successfully!` appears, to verify that the installation was successful.
 


### PR DESCRIPTION
更新了nightly build (develop) 的paddle安装包的安装方式。
按2.1版本的文档，删除了python2.7、python3.5，新增python3.9。cuda不支持cuda9、cuda10。
2.1版本的文档见 PR https://github.com/PaddlePaddle/docs/pull/3507


预览链接：http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-892
