### PR TITLE
[install doc] Fix noavx link in install doc

### DIFF
--- a/docs/install/pip/linux-pip.md
+++ b/docs/install/pip/linux-pip.md
@@ -181,7 +181,7 @@
   * cpu、mkl版本noavx机器安装：
 
   ```
-  python -m pip install paddlepaddle==2.1.1 -f http://www.paddlepaddle.org.cn/whl/mkl/stable/noavx/html --no-index
+  python -m pip install paddlepaddle==2.1.1 -f https://www.paddlepaddle.org.cn/whl/mkl/stable/noavx.html --no-index
   ```
 
   * cpu、openblas版本noavx机器安装：

--- a/docs/install/pip/linux-pip_en.md
+++ b/docs/install/pip/linux-pip_en.md
@@ -189,7 +189,7 @@ Note：
    * cpu and mkl version installed on noavx machine：
 
    ```
-   python -m pip install paddlepaddle==2.1.1 -f http://www.paddlepaddle.org.cn/whl/mkl/stable/noavx/html --no-index
+   python -m pip install paddlepaddle==2.1.1 -f https://www.paddlepaddle.org.cn/whl/mkl/stable/noavx.html --no-index
    ```
 
    * cpu and openblas version installed on noavx machine：

--- a/docs/install/pip/windows-pip.md
+++ b/docs/install/pip/windows-pip.md
@@ -137,7 +137,7 @@
   * cpu、mkl版本noavx机器安装：
 
   ```
-  python -m pip install paddlepaddle==2.1.1 -f http://www.paddlepaddle.org.cn/whl/mkl/stable/noavx/html --no-index
+  python -m pip install paddlepaddle==2.1.1 -f https://www.paddlepaddle.org.cn/whl/mkl/stable/noavx.html --no-index
   ```
 
   * cpu、openblas版本noavx机器安装：

--- a/docs/install/pip/windows-pip_en.md
+++ b/docs/install/pip/windows-pip_en.md
@@ -136,7 +136,7 @@ Note：
    * cpu and mkl version installed on noavx machine：
 
    ```
-   python -m pip install paddlepaddle==2.1.1 -f http://www.paddlepaddle.org.cn/whl/mkl/stable/noavx/html --no-index
+   python -m pip install paddlepaddle==2.1.1 -f https://www.paddlepaddle.org.cn/whl/mkl/stable/noavx.html --no-index
    ```
 
    * cpu and openblas version installed on noavx machine：


### PR DESCRIPTION
原文档里的是
http://www.paddlepaddle.org.cn/whl/mkl/stable/noavx/html
正确的应该是
https://www.paddlepaddle.org.cn/whl/mkl/stable/noavx.html