### PR TITLE
fix the bug in split demo

### DIFF
--- a/docs/api/paddle/distributed/split_cn.rst
+++ b/docs/api/paddle/distributed/split_cn.rst
@@ -42,13 +42,15 @@ Tensor
 .. code-block:: python
 
         import paddle
-        from paddle.distributed import init_parallel_env
-
+        import paddle.distributed.fleet as fleet
+        
+        paddle.enable_static()
         paddle.set_device('gpu:%d'%paddle.distributed.ParallelEnv().dev_id)
-        init_parallel_env()
+        fleet.init(is_collective=True)
         data = paddle.randint(0, 8, shape=[10,4])
-        emb_out = padle.distributed.split(
+        emb_out = paddle.distributed.split(
             data,
             (8, 8),
             operation="embedding",
             num_partitions=2)
+


### PR DESCRIPTION
Fix the bug in paddle.distributed.split demo. The paddle.distributed.split op just can be used in static mode.