### PR TITLE
fix examples of to_tensor cn_doc

### DIFF
--- a/docs/api/paddle/to_tensor_cn.rst
+++ b/docs/api/paddle/to_tensor_cn.rst
@@ -42,40 +42,25 @@ to_tensor
         # <class 'paddle.Tensor'>
 
         paddle.to_tensor(1)
-        # Tensor: generated_tensor_0
-        # - place: CUDAPlace(0)   # allocate on global default place CPU:0
-        # - shape: [1]
-        # - layout: NCHW
-        # - dtype: int64_t
-        # - data: [1]
+        # Tensor(shape=[1], dtype=int64, place=CUDAPlace(0), stop_gradient=True, # allocate on global default place CUDA:0
+        #        [1])
 
         x = paddle.to_tensor(1)
         paddle.to_tensor(x, dtype='int32', place=paddle.CPUPlace()) # A new tensor will be constructed due to different dtype or place
-        # Tensor: generated_tensor_01
-        # - place: CPUPlace
-        # - shape: [1]
-        # - layout: NCHW
-        # - dtype: int
-        # - data: [1]
+        # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True,
+        #        [1])
 
         paddle.to_tensor((1.1, 2.2), place=paddle.CUDAPinnedPlace())
-        # Tensor: generated_tensor_1
-        #   - place: CUDAPinnedPlace
-        #   - shape: [2]
-        #   - layout: NCHW
-        #   - dtype: double
-        #   - data: [1.1 2.2]
+        # Tensor(shape=[2], dtype=float32, place=CUDAPinnedPlace, stop_gradient=True,
+        #        [1.10000002, 2.20000005])
 
         paddle.to_tensor([[0.1, 0.2], [0.3, 0.4]], place=paddle.CUDAPlace(0), stop_gradient=False)
-        # Tensor: generated_tensor_2
-        #   - place: CUDAPlace(0)
-        #   - shape: [2, 2]
-        #   - layout: NCHW
-        #   - dtype: double
-        #   - data: [0.1 0.2 0.3 0.4]
+        # Tensor(shape=[2, 2], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
+        #        [[0.10000000, 0.20000000],
+        #         [0.30000001, 0.40000001]])
 
         type(paddle.to_tensor([[1+1j, 2], [3+2j, 4]], dtype='complex64'))
-        # <class 'paddle.VarBase'
+        # <class 'paddle.Tensor'>
 
         paddle.to_tensor([[1+1j, 2], [3+2j, 4]], dtype='complex64')
         # Tensor(shape=[2, 2], dtype=complex64, place=CUDAPlace(0), stop_gradient=True,

--- a/docs/api/paddle/to_tensor_cn.rst
+++ b/docs/api/paddle/to_tensor_cn.rst
@@ -41,8 +41,8 @@ to_tensor
         type(paddle.to_tensor(1))
         # <class 'paddle.Tensor'>
 
-        paddle.to_tensor(1)
-        # Tensor(shape=[1], dtype=int64, place=CUDAPlace(0), stop_gradient=True, # allocate on global default place CUDA:0
+        paddle.to_tensor(1)  # allocate on global default place CUDA:0
+        # Tensor(shape=[1], dtype=int64, place=CUDAPlace(0), stop_gradient=True,
         #        [1])
 
         x = paddle.to_tensor(1)


### PR DESCRIPTION
fix some incorrect places in examples of to_tensor cn_doc

preview is as follows:
![image](https://user-images.githubusercontent.com/51314274/129336951-c0f6ac55-5fc0-42d6-8e62-29a3e2b27400.png)
