### PR TITLE
fix input shape description for nn.GroupNorm

### DIFF
--- a/docs/api/paddle/nn/GroupNorm_cn.rst
+++ b/docs/api/paddle/nn/GroupNorm_cn.rst
@@ -21,7 +21,7 @@ GroupNorm
 返回：无
 
 形状：
-    - input: 形状为（批大小，通道数, 高度，宽度）的4-D Tensor。
+    - input: 形状为(批大小, 通道数, \*) 的Tensor。
     - output: 和输入形状一样。
 
 **代码示例**


### PR DESCRIPTION
Update the description of input tensor's shape.
Paddle pr: [#34773](https://github.com/PaddlePaddle/Paddle/pull/34773)
<img width="925" alt="gn" src="https://user-images.githubusercontent.com/15810355/129660316-a428ea73-b8b1-4b27-ab4c-1b4d37c3c4f9.png">