### PR TITLE
add necessary pre-step before running ninja cmake

### DIFF
--- a/docs/install/compile/windows-compile.md
+++ b/docs/install/compile/windows-compile.md
@@ -88,6 +88,7 @@
         ```
         pip install ninja
         ```
+        然后在搜索栏中搜索 "x64 Native Tools Command Prompt for VS 2017" 或 "适用于VS 2017 的x64本机工具命令提示符"，以管理员身份运行，再输入以下cmake命令。
 
         * **CPU版本PaddlePaddle**：
 


### PR DESCRIPTION
run "x64 Native Tools Command Prompt for VS 2017" to initialize environment before running ninja cmake
![image](https://user-images.githubusercontent.com/51314274/130756512-8ca481ae-ecd3-43bc-98b5-191cc64c8152.png)
