### PR TITLE
新增算子: paddle.linalg.multi_dot

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -245,6 +245,7 @@ tensor线性代数相关
     " :ref:`paddle.t <cn_api_paddle_tensor_t>` ", "对小于等于2维的Tensor进行数据转置"
     " :ref:`paddle.tril <cn_api_tensor_tril>` ", "返回输入矩阵 input 的下三角部分，其余部分被设为0"
     " :ref:`paddle.triu <cn_api_tensor_triu>` ", "返回输入矩阵 input 的上三角部分，其余部分被设为0"
+    " :ref:`paddle.multi_dot<cn_api_tensor_multi_dot>` ", "计算多个矩阵相乘"
 
 .. _tensor_manipulation:
 

--- a/docs/api/paddle/Tensor_cn.rst
+++ b/docs/api/paddle/Tensor_cn.rst
@@ -1894,3 +1894,12 @@ where(y, name=None)
 返回类型：Tensor
 
 请参考 :ref:`cn_api_tensor_where`
+
+multi_dot(x, name=None)
+:::::::::
+
+返回：多个矩阵相乘后的Tensor
+
+返回类型：Tensor
+
+请参考 :ref:`cn_api_tensor_multi_dot`

--- a/docs/api/paddle/multi_dot_cn.rst
+++ b/docs/api/paddle/multi_dot_cn.rst
@@ -33,6 +33,7 @@ Multi_dot会选择计算量最小的乘法顺序进行计算。(a, b)和(b, c)�
 ::::::::::
 
 .. code-block:: python
+
     import paddle
     import numpy as np
     # A * B

--- a/docs/api/paddle/multi_dot_cn.rst
+++ b/docs/api/paddle/multi_dot_cn.rst
@@ -1,0 +1,55 @@
+.. _cn_api_tensor_multi_dot:
+
+multi_dot
+-------------------------------
+
+.. py:function:: paddle.multi_dot(x, name=None)
+
+Multi_dot是一个计算多个矩阵乘法的算子。
+
+算子支持float，double和float16三种类型。该算子不支持批量输入。
+
+输入[x]的每个tensor的shape必须是二维的，除了第一个和做后一个tensor可以是一维的。如果第一个tensor是shape为(n, )的一维向量，该tensor将被当作是shape为(1, n)的行向量处理，同样的，如果最后一个tensor的shape是(n, )，将被当作是shape为(n, 1)的列向量处理。
+
+如果第一个和最后一个tensor是二维矩阵，那么输出也是一个二维矩阵，否则输出是一维的向量。
+
+Multi_dot会选择计算量最小的乘法顺序进行计算。(a, b)和(b, c)这样两个矩阵相乘的计算量是a * b * c。给定矩阵A, B, C的shape分别为(20, 5)， (5, 100)，(100, 10)，我们可以计算不同乘法顺序的计算量：
+
+- Cost((AB)C) = 20x5x100 + 20x100x10 = 30000
+- Cost(A(BC)) = 5x100x10 + 20x5x10 = 6000
+
+在这个例子中，先算B乘以C再乘A的计算量比按顺序乘少5被。
+
+参数
+:::::::::
+    - **x** ([tensor]): 输出的是一个tensor列表。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
+
+返回：
+:::::::::
+    - Tensor，输出Tensor
+
+代码示例
+::::::::::
+
+.. code-block:: python
+    import paddle
+    import numpy as np
+    # A * B
+    A_data = np.random.random([3, 4]).astype(np.float32)
+    B_data = np.random.random([4, 5]).astype(np.float32)
+    A = paddle.to_tensor(A_data)
+    B = paddle.to_tensor(B_data)
+    out = paddle.multi_dot([A, B])
+    print(out.numpy().shape)
+    # [3, 5]
+    # A * B * C
+    A_data = np.random.random([10, 5]).astype(np.float32)
+    B_data = np.random.random([5, 8]).astype(np.float32)
+    C_data = np.random.random([8, 7]).astype(np.float32)
+    A = paddle.to_tensor(A_data)
+    B = paddle.to_tensor(B_data)
+    C = paddle.to_tensor(C_data)
+    out = paddle.multi_dot([A, B, C])
+    print(out.numpy().shape)
+    # [10, 7]


### PR DESCRIPTION
给paddle线性代数库添加算子：multi_dot
- 例子:
```
>>> x0_data = np.random.random((3,2)).astype("float32")
>>> x1_data = np.random.random((2,4)).astype("float32")
>>> x1_data = np.random.random((4,5)).astype("float32")
>>> x0_data = np.random.random((3,2)).astype("float32")
>>> x1_data = np.random.random((2,4)).astype("float32")
>>> x2_data = np.random.random((4,5)).astype("float32")
>>> x0 = paddle.to_tensor(x0_data)
>>> x1 = paddle.to_tensor(x1_data)
>>> x2 = paddle.to_tensor(x2_data)
>>> out = paddle.linalg.multi_dot([x0, x1, x2])
>>> out
Tensor(shape=[3, 5], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       [[1.47845721, 1.24809611, 1.35647595, 2.11938763, 1.63790154],
        [1.39540243, 0.84205949, 1.09351981, 1.72926235, 1.36388993],
        [1.40417647, 1.54325879, 1.48727894, 2.30167985, 1.74950039]])
>>>
```