### PR TITLE
Remove deprecated doc

### DIFF
--- a/docs/guides/07_new_op/op_notes_cn.md
+++ b/docs/guides/07_new_op/op_notes_cn.md
@@ -335,9 +335,6 @@ Op的计算速度与输入的数据量有关，对于某些Op可以根据输入�
 
 为此Paddle中添加了一些FLAGS，比如使用FLAGS_cudnn_deterministic来强制cudnn使用确定性算法、FLAGS_cpu_deterministic强制CPU端的计算使用确定性方法。
 
-### 2.WITH_FAST_MATH的开与关
-如果WITH_FAST_MATH是ON，NVCC在编译Paddle和Egien的时候会使用--use_fast_math，这样可能会使CUDA中的一些操作在损失一定精度的情况下变快，比如log、exp、tanh等，但也会使一些操作的计算结果是错的，比如pow操作，具体原因请查看[torch/DEPRECEATED-torch7-distro#132](https://github.com/torch/DEPRECEATED-torch7-distro/issues/132)。
-
 ## 其他
 ### 1.报错信息
 Enforce提示信息不能为空，并且需要写明，因为报错信息可以更快更方便地分析出错误的原因。

--- a/docs/guides/07_new_op/op_notes_en.md
+++ b/docs/guides/07_new_op/op_notes_en.md
@@ -160,9 +160,6 @@ At present, it is found that the result of the convolution operation in cudnn, M
 
 For this purpose, some FLAGS is added to the Fluid. For example, FLAGS_cudnn_deterministic is used to force cudnn to use the deterministic algorithm, and FLAGS_cpu_deterministic to force the CPU-side calculation to use the deterministic method.
 
-### 2.On/Off of WITH_FAST_MATH
-If WITH_FAST_MATH is ON, NVCC will use --use_fast_math when compiling Paddle and Egien. This may cause some operations in CUDA to get faster on the condition that they lose some precision, such as log, exp, tanh. But it may lead to wrong results of some operations, such as pow operation, please read [torch/DEPRECEATED-torch7-distro#132](https://github.com/torch/DEPRECEATED-torch7-distro/issues/132) for specific reasons.
-
 ## Other
 ### 1. Error message
 The Enforce prompt message cannot be empty and needs to be written, because the error message can analyze the cause of the error more quickly and conveniently.


### PR DESCRIPTION
The compilation option of "WITH_FAST_MATH" is removed from paddle, so update the doc.

![image](https://user-images.githubusercontent.com/6888866/133201778-508fdee9-d006-43c4-a292-65c43d90fca6.png)
