### PR TITLE
[AMP] add pure fp16 introduction in amp

### DIFF
--- a/docs/guides/01_paddle2.0_introduction/basic_concept/amp_cn.md
+++ b/docs/guides/01_paddle2.0_introduction/basic_concept/amp_cn.md
@@ -17,7 +17,11 @@
 - FP16可以充分利用英伟达Volta及Turing架构GPU提供的Tensor Cores技术。在相同的GPU硬件上，Tensor Cores的FP16计算吞吐量是FP32的8倍。
 
 ## 三、使用飞桨框架实现自动混合精度
-使用飞桨框架提供的API，``paddle.amp.auto_cast`` 和 ``paddle.amp.GradScaler`` 能够实现自动混合精度训练（Automatic Mixed Precision，AMP），即在相关OP的计算中，自动选择FP16或FP32计算。开启AMP模式后，使用FP16与FP32进行计算的OP列表可见该[文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/amp/Overview_cn.html)。下面来看一个具体的例子，来了解如果使用飞桨框架实现混合精度训练。
+使用飞桨框架提供的API，``paddle.amp.auto_cast`` 和 ``paddle.amp.decorate`` 和 ``paddle.amp.GradScaler`` 能够实现自动混合精度训练（Automatic Mixed Precision，AMP），即在相关OP的计算中，根据一定的规则，自动选择FP16或FP32计算。飞桨的AMP为用户提供了两种模式：
+- level=’O1‘：采用黑名名单策略的混合精度训练，使用FP16与FP32进行计算的OP列表可见该[文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/amp/Overview_cn.html)。
+- level=’O2‘：纯FP16训练，除用户自定义黑名单中指定的OP和不支持FP16计算的OP之外，全部使用FP16计算。
+
+下面来看一个具体的例子，来了解如果使用飞桨框架实现混合精度训练。
 
 ### 3.1 辅助函数
 首先定义辅助函数，用来计算训练时间。
@@ -116,20 +120,23 @@ end_timer_and_print("默认耗时:") # 获取结束时间并打印相关信息
 ```
 
     Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-           [1.25010288])
+           [1.24609220])
 
     默认耗时:
-    共计耗时 = 2.943 sec
+    共计耗时 = 2.819 sec
 
 
 ### 3.4 使用AMP训练模型
 
-在飞桨框架中，使用自动混合精度训练，需要进行三个步骤：
+在飞桨框架中，使用自动混合精度训练，需要进行四个步骤：
 
 - Step1： 定义 ``GradScaler`` ，用于缩放 ``loss`` 比例，避免浮点数下溢
-- Step2： 使用 ``auto_cast`` 用于创建AMP上下文环境，该上下文中自动会确定每个OP的输入数据类型（FP16或FP32）
-- Step3： 使用 Step1中定义的 ``GradScaler`` 完成 ``loss`` 的缩放，用缩放后的 ``loss`` 进行反向传播，完成训练
+- Step2： 使用 ``decorate`` 在level=’O1‘模式下不做任何处理，无需调用该api，在level=’O2‘模式下，将网络参数从FP32转换为FP16
+- Step3： 使用 ``auto_cast`` 用于创建AMP上下文环境，该上下文中自动会确定每个OP的输入数据类型（FP16或FP32）
+- Step4： 使用 Step1中定义的 ``GradScaler`` 完成 ``loss`` 的缩放，用缩放后的 ``loss`` 进行反向传播，完成训练
 
+
+采用level=’O1‘模式训练：
 
 ```python
 model = SimpleNet(input_size, output_size)  # 定义模型
@@ -159,14 +166,57 @@ for epoch in range(epochs):
         optimizer.clear_grad()
 
 print(loss)
-end_timer_and_print("使用AMP模式耗时:")
+end_timer_and_print("使用AMP-O1模式耗时:")
 ```
 
     Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-           [1.23644269])
+           [1.24609900])
 
-    使用AMP模式耗时:
-    共计耗时 = 1.222 sec
+    使用AMP-O1模式耗时:
+    共计耗时 = 1.324 sec
+
+
+采用level=’O2‘模式训练：
+
+```python
+model = SimpleNet(input_size, output_size)  # 定义模型
+
+optimizer = paddle.optimizer.SGD(learning_rate=0.0001, parameters=model.parameters())  # 定义优化器
+
+# Step1：定义 GradScaler，用于缩放loss比例，避免浮点数溢出
+scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
+
+# Step2：在level=’O2‘模式下，将网络参数从FP32转换为FP16
+model, optimizer = paddle.amp.decorate(models=model, optimizers=optimizer, level='O2', master_weight=None, save_dtype=None)
+
+start_timer() # 获取训练开始时间
+
+for epoch in range(epochs):
+    datas = zip(train_data, labels)
+    for i, (data, label) in enumerate(datas):
+
+        # Step3：创建AMP上下文环境，开启自动混合精度训练
+        with paddle.amp.auto_cast(enable=True, custom_white_list=None, custom_black_list=None, level='O2'):
+            output = model(data)
+            loss = mse(output, label)
+
+        # Step4：使用 Step1中定义的 GradScaler 完成 loss 的缩放，用缩放后的 loss 进行反向传播
+        scaled = scaler.scale(loss)
+        scaled.backward()
+
+        # 训练模型
+        scaler.minimize(optimizer, scaled)
+        optimizer.clear_grad()
+
+print(loss)
+end_timer_and_print("使用AMP-O2模式耗时:")
+```
+
+    Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
+           [1.24997652])
+
+    使用AMP-O2模式耗时:
+    共计耗时 = 0.933 sec
 
 
 ## 四、进阶用法
@@ -213,10 +263,10 @@ end_timer_and_print("使用AMP模式耗时:")
 ```
 
     Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-           [1.25127280])
+           [1.24623466])
 
     使用AMP模式耗时:
-    共计耗时 = 1.006 sec
+    共计耗时 = 1.020 sec
 
 ## 五、总结
-从上面的示例中可以看出，使用自动混合精度训练，共计耗时约 1.222s，而普通的训练方式则耗时 2.943s，训练速度提升约为 2.4倍。如需更多使用混合精度训练的示例，请参考飞桨模型库： [paddlepaddle/models](https://github.com/PaddlePaddle/models)。
+从上面的示例中可以看出，使用自动混合精度训练，O1模式共计耗时约 1.324s，O2模式共计耗时约 0.933s，而普通的训练方式则耗时 2.819s，O1模式训练速度提升约为 2.1倍，O2模式训练速度提升约为 3.0倍。如需更多使用混合精度训练的示例，请参考飞桨模型库： [paddlepaddle/models](https://github.com/PaddlePaddle/models)。


### PR DESCRIPTION
Now AMP has added new training mode pure fp16 (https://github.com/PaddlePaddle/docs/pull/3898).
This pr adds pure fp16 introduction in amp.