### PR TITLE
[install doc] fix link with relative path

### DIFF
--- a/docs/install/compile/linux-compile.md
+++ b/docs/install/compile/linux-compile.md
@@ -73,7 +73,7 @@
 
 使用Docker编译PaddlePaddle，您需要：
 
-- 在本地主机上[安装Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- 在本地主机上[安装Docker](https://docs.docker.com/engine/install/)
 
 - 如需在Linux开启GPU支持，请[安装nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
 

--- a/docs/install/compile/linux-compile_en.md
+++ b/docs/install/compile/linux-compile_en.md
@@ -69,7 +69,7 @@ There are two compilation methods under Linux system:
 
 Compiling PaddlePaddle with Docker，you need:
 
-- On the local host [Install Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- On the local host [Install Docker](https://docs.docker.com/engine/install/)
 
 - To enable GPU support on Linux, please [Install nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
 

--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -23,7 +23,7 @@
 
 使用Docker编译PaddlePaddle，您需要：
 
-- 在本地主机上[安装Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- 在本地主机上[安装Docker](https://docs.docker.com/engine/install/)
 
 - 使用Docker ID登陆Docker，以避免出现`Authenticate Failed`错误
 

--- a/docs/install/compile/macos-compile_en.md
+++ b/docs/install/compile/macos-compile_en.md
@@ -23,7 +23,7 @@ There are two compilation methods in MacOS system:
 
 Compiling PaddlePaddle with Docker，you need:
 
-- On the local host [Install Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- On the local host [Install Docker](https://docs.docker.com/engine/install/)
 
 - Log in to Docker with Docker ID to avoid `Authenticate Failed` error
 

--- a/docs/install/docker/linux-docker.md
+++ b/docs/install/docker/linux-docker.md
@@ -4,9 +4,9 @@
 
 ## 环境准备
 
-- 目前支持的系统类型，请见[安装说明](../index_cn.html)，请注意目前暂不支持在CentOS 6使用Docker
+- 目前支持的系统类型，请见[安装说明](/documentation/docs/zh/install/index_cn.html)，请注意目前暂不支持在CentOS 6使用Docker
 
-- 在本地主机上[安装Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- 在本地主机上[安装Docker](https://docs.docker.com/engine/install/)
 
 - 如需在Linux开启GPU支持，请[安装nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
 

--- a/docs/install/docker/linux-docker_en.md
+++ b/docs/install/docker/linux-docker_en.md
@@ -4,7 +4,7 @@
 
 ## Environment preparation
 
-- Currently supported system types, please see [Installation instruction](/documentation/docs/zh/install/index_en.html), please note that Docker is not currently supported in CentOS 6
+- Currently supported system types, please see [Installation instruction](/documentation/docs/en/install/index_en.html), please note that Docker is not currently supported in CentOS 6
 
 - On the local host [Install Docker](https://docs.docker.com/engine/install/)
 

--- a/docs/install/docker/linux-docker_en.md
+++ b/docs/install/docker/linux-docker_en.md
@@ -4,9 +4,9 @@
 
 ## Environment preparation
 
-- Currently supported system types, please see [Installation instruction](../index_en.html), please note that Docker is not currently supported in CentOS 6
+- Currently supported system types, please see [Installation instruction](/documentation/docs/zh/install/index_en.html), please note that Docker is not currently supported in CentOS 6
 
-- On the local host [Install Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- On the local host [Install Docker](https://docs.docker.com/engine/install/)
 
 - To enable GPU support on Linux, please [Install nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
 

--- a/docs/install/docker/macos-docker.md
+++ b/docs/install/docker/macos-docker.md
@@ -6,7 +6,7 @@
 
 - MacOS 版本 10.11/10.12/10.13/10.14 (64 bit) (不支持GPU版本)
 
-- 在本地主机上[安装Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- 在本地主机上[安装Docker](https://docs.docker.com/engine/install/)
 
 ## 安装步骤
 

--- a/docs/install/docker/macos-docker_en.md
+++ b/docs/install/docker/macos-docker_en.md
@@ -6,7 +6,7 @@
 
 - MacOS version 10.11/10.12/10.13/10.14 (64 bit)(not support GPU version)
 
-- On the local host [Install Docker](https://hub.docker.com/search/?type=edition&offering=community)
+- On the local host [Install Docker](https://docs.docker.com/engine/install/)
 
 ## Installation steps
 


### PR DESCRIPTION
- 文档里相对路径的链接改为绝对路径
- 安装docker的链接更新为 https://docs.docker.com/engine/install/

预览链接：
http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1722
