### PR TITLE
[install doc] add version in conda install（2.1.3）

### DIFF
--- a/docs/install/conda/linux-conda.md
+++ b/docs/install/conda/linux-conda.md
@@ -124,7 +124,7 @@ python -c "import platform;print(platform.architecture()[0]);print(platform.mach
 #### 2.1 <span id="cpu">CPU版的PaddlePaddle</span>
 
 ```
-conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.1.3 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 

--- a/docs/install/conda/linux-conda_en.md
+++ b/docs/install/conda/linux-conda_en.md
@@ -157,7 +157,7 @@ You can choose the following version of PaddlePaddle to start installation:
 #### 2.1 <span id="cpu">CPU Version of PaddlePaddle</span>
 
 ```
-conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.1.3 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 

--- a/docs/install/conda/macos-conda.md
+++ b/docs/install/conda/macos-conda.md
@@ -110,7 +110,7 @@ python -c "import platform;print(platform.architecture()[0]);print(platform.mach
 * 请参考如下命令安装:
 
   ```
-  conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle==2.1.3 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 ## **三、验证安装**

--- a/docs/install/conda/macos-conda_en.md
+++ b/docs/install/conda/macos-conda_en.md
@@ -115,7 +115,7 @@ You can choose the following version of PaddlePaddle to start installation:
 * Please use the following command to install PaddlePaddle：
 
   ```
-  conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle==2.1.3 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 

--- a/docs/install/conda/windows-conda.md
+++ b/docs/install/conda/windows-conda.md
@@ -130,7 +130,7 @@ python -c "import platform;print(platform.architecture()[0]);print(platform.mach
 #### 2.1 <span id="cpu">CPU版的PaddlePaddle</span>
 
 ```
-conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.1.3 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 

--- a/docs/install/conda/windows-conda_en.md
+++ b/docs/install/conda/windows-conda_en.md
@@ -132,7 +132,7 @@ You can choose the following version of PaddlePaddle to start installation:
 #### 2.1 <span id="cpu">CPU Version of PaddlePaddle</span>
 
 ```
-conda install paddlepaddle --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.1.3 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 


### PR DESCRIPTION
预览链接：
http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1480

rc版本，pip安装默认是2.1.3，conda安装默认是2.2.0rc0。
因此在2.1.3的文档里conda安装加上了版本号。