### PR TITLE
add doc for paddle.version.cuda, paddle.version.cudnn, paddle.version.show API

### DIFF
--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -436,7 +436,8 @@ def set_api_sketch():
         paddle.device,
         paddle.device.cuda,
         paddle.linalg,
-        paddle.fft
+        paddle.fft,
+        paddle.version
     ]
 
     alldict = {}

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -13,7 +13,7 @@ paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本
     :header: "API名称", "API功能"
     :widths: 10, 30
 
-    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的cuda版本"
-    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cudnn版本"
-    " :ref:`show <cn_api_paddle_version_show>` ", "打印paddle版本、cuda版本、cudnn版本等信息"
+    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的CUDA版本"
+    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cuDNN版本"
+    " :ref:`show <cn_api_paddle_version_show>` ", "打印paddle版本、CUDA版本、cuDNN版本等信息"
 

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -13,7 +13,7 @@ paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本
     :header: "API名称", "API功能"
     :widths: 10, 30
 
-    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的CUDA版本"
-    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cuDNN版本"
+    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle wheel包编译时使用的CUDA版本"
+    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle wheel包编译时使用的cuDNN版本"
     " :ref:`show <cn_api_paddle_version_show>` ", "打印paddle版本、CUDA版本、cuDNN版本等信息"
 

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -1,0 +1,24 @@
+.. _cn_overview_version:
+
+paddle.version
+---------------------
+
+paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本信息。具体如下：
+
+-  :ref:`配置版本相关API <about_version>`
+
+
+
+.. _about_version:
+
+配置版本相关API
+::::::::::::::::::::
+
+.. csv-table::
+    :header: "API名称", "API功能"
+    :widths: 10, 30
+
+    " :ref:`cuda <cn_api_version_cuda>` ", "获取paddle包使用的cuda版本"
+    " :ref:`cudnn <cn_api_version_cudnn>` ", "获取paddle包使用的cudnn版本"
+    " :ref:`show <cn_api_version_show>` ", "打印paddle版本、cuda版本、cudnn版本等信息"
+

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -5,11 +5,6 @@ paddle.version
 
 paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本信息。具体如下：
 
--  :ref:`配置版本相关API <about_version>`
-
-
-
-.. _about_version:
 
 配置版本相关API
 ::::::::::::::::::::
@@ -18,7 +13,7 @@ paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本
     :header: "API名称", "API功能"
     :widths: 10, 30
 
-    " :ref:`cuda <cn_api_version_cuda>` ", "获取paddle包使用的cuda版本"
-    " :ref:`cudnn <cn_api_version_cudnn>` ", "获取paddle包使用的cudnn版本"
-    " :ref:`show <cn_api_version_show>` ", "打印paddle版本、cuda版本、cudnn版本等信息"
+    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的cuda版本"
+    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cudnn版本"
+    " :ref:`show <cn_api_paddle_version_show>` ", "打印paddle版本、cuda版本、cudnn版本等信息"
 

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -5,12 +5,12 @@ cuda
 
 .. py:function:: paddle.version.cuda()
 
-获取 paddle 安装包使用的 cuda 版本号。
+获取 paddle 安装包使用的 CUDA 版本号。
 
 
 返回：
 :::::::::
-返回cuda的版本信息。若paddle wheel包为GPU版本，则返回cuda具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+返回CUDA的版本信息。若paddle wheel包为GPU版本，则返回CUDA具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -1,0 +1,24 @@
+.. _cn_api_paddle_version_cuda:
+
+cuda
+-------------------------------
+
+.. py:function:: paddle.version.cuda()
+
+获取 paddle 安装包使用的 cuda 版本号。
+
+
+返回：
+:::::::::
+返回cuda的版本信息。若paddle包为CPU版本，则返回``False``。
+
+代码示例：
+::::::::::
+
+.. code-block:: python
+
+    import paddle
+
+    paddle.version.cuda()
+    # '10.2'
+

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -10,7 +10,7 @@ cuda
 
 返回：
 :::::::::
-返回cuda的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
+返回cuda的版本信息。若paddle wheel包为GPU版本，则返回cuda具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -10,7 +10,7 @@ cuda
 
 返回：
 :::::::::
-返回cuda的版本信息。若paddle包为CPU版本，则返回``False``。
+返回cuda的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -5,12 +5,12 @@ cuda
 
 .. py:function:: paddle.version.cuda()
 
-获取 paddle 安装包使用的 CUDA 版本号。
+获取 paddle 安装包编译时使用的 CUDA 版本号。
 
 
 返回：
 :::::::::
-返回CUDA的版本信息。若paddle wheel包为GPU版本，则返回CUDA具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+若paddle wheel包为GPU版本，则返回paddle wheel包编译时使用的CUDA的版本信息；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -1,0 +1,24 @@
+.. _cn_api_paddle_version_cudnn:
+
+cudnn
+-------------------------------
+
+.. py:function:: paddle.version.cudnn()
+
+获取 paddle 安装包使用的 cudnn 版本号。
+
+
+返回：
+:::::::::
+返回cudnn的版本信息。若paddle包为CPU版本，则返回``False``。
+
+代码示例：
+::::::::::
+
+.. code-block:: python
+
+    import paddle
+
+    paddle.version.cudnn()
+    # '7.6.5'
+

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -5,12 +5,12 @@ cudnn
 
 .. py:function:: paddle.version.cudnn()
 
-获取 paddle 安装包使用的 cudnn 版本号。
+获取 paddle 安装包使用的 cuDNN 版本号。
 
 
 返回：
 :::::::::
-返回cudnn的版本信息。若paddle wheel包为GPU版本，则返回cudnn具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+返回cuDNN的版本信息。若paddle wheel包为GPU版本，则返回cuDNN具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -5,12 +5,12 @@ cudnn
 
 .. py:function:: paddle.version.cudnn()
 
-获取 paddle 安装包使用的 cuDNN 版本号。
+获取 paddle 安装包编译时使用的 cuDNN 版本号。
 
 
 返回：
 :::::::::
-返回cuDNN的版本信息。若paddle wheel包为GPU版本，则返回cuDNN具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+若paddle wheel包为GPU版本，则返回paddle wheel包编译时使用的cuDNN的版本信息；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -10,7 +10,7 @@ cudnn
 
 返回：
 :::::::::
-返回cudnn的版本信息。若paddle包为CPU版本，则返回``False``。
+返回cudnn的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -10,7 +10,7 @@ cudnn
 
 返回：
 :::::::::
-返回cudnn的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
+返回cudnn的版本信息。若paddle wheel包为GPU版本，则返回cudnn具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/show_cn.rst
+++ b/docs/api/paddle/version/show_cn.rst
@@ -5,7 +5,7 @@ show
 
 .. py:function:: paddle.version.show()
 
-如果paddle wheel包已经标记了特定版本，则打印版本号。否则，获取paddle wheel包对应的commit id。
+如果paddle wheel包是正式发行版本，则打印版本号。否则，获取paddle wheel包编译时对应的commit id。
 另外，打印paddle wheel包使用的CUDA和cuDNN的版本信息。
 
 

--- a/docs/api/paddle/version/show_cn.rst
+++ b/docs/api/paddle/version/show_cn.rst
@@ -11,15 +11,15 @@ show
 
 返回：
 :::::::::
-如果paddle wheel包没有被标记为特定版本，输出其对应的commit id。否则，输出如下信息：
+如果paddle wheel包不是正式发行版本，则输出wheel包编译时对应的commit id号。否则，输出如下信息：
 
     - full_version - paddle wheel包的版本号。
     - major - paddle wheel包版本号的major信息。
     - minor - paddle wheel包版本号的minor信息。
     - patch - paddle wheel包版本号的patch信息。
     - rc - 是否是rc版本。
-    - cuda - 若paddle wheel包为GPU版本，则返回CUDA具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
-    - cudnn - 若paddle wheel包为GPU版本，则返回cuDNN具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+    - cuda - 若paddle wheel包为GPU版本，则返回paddle wheel包编译时使用的CUDA的版本信息；若paddle wheel包为CPU版本，则返回 ``False`` 。
+    - cudnn - 若paddle wheel包为GPU版本，则返回paddle wheel包编译时使用的cuDNN的版本信息；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/show_cn.rst
+++ b/docs/api/paddle/version/show_cn.rst
@@ -6,7 +6,7 @@ show
 .. py:function:: paddle.version.show()
 
 如果paddle wheel包已经标记了特定版本，则打印版本号。否则，获取paddle wheel包对应的commit id。
-另外，打印paddle wheel包使用的cuda和cudnn的版本信息。
+另外，打印paddle wheel包使用的CUDA和cuDNN的版本信息。
 
 
 返回：
@@ -18,8 +18,8 @@ show
     - minor - paddle wheel包版本号的minor信息。
     - patch - paddle wheel包版本号的patch信息。
     - rc - 是否是rc版本。
-    - cuda - 若paddle wheel包为GPU版本，则返回cuda具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
-    - cudnn - 若paddle wheel包为GPU版本，则返回cudnn具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+    - cuda - 若paddle wheel包为GPU版本，则返回CUDA具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+    - cudnn - 若paddle wheel包为GPU版本，则返回cuDNN具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/show_cn.rst
+++ b/docs/api/paddle/version/show_cn.rst
@@ -1,0 +1,46 @@
+.. _cn_api_paddle_version_show:
+
+show
+-------------------------------
+
+.. py:function:: paddle.version.show()
+
+如果paddle包已经标记了特定版本，打印版本号。否则，获取paddle包对应的commit id。
+打印paddle包使用的cuda和cudnn的版本信息。
+
+
+返回：
+:::::::::
+如果paddle包没有被标记为特定版本，输出其对应的commit id。否则，输出如下信息：
+
+    - full_version - paddle包的版本号。
+    - major - paddle包版本号的major信息。
+    - minor - paddle包版本号的minor信息。
+    - patch - paddle包版本号的patch信息。
+    - rc - 是否是rc版本。
+    - cuda - paddle包使用的cuda版本。若安装的是CPU版本，则返回``False``。
+    - cudnn - paddle包使用的cudnn版本。若安装的是CPU版本，则返回``False``。
+
+代码示例：
+::::::::::
+
+.. code-block:: python
+
+    import paddle
+
+    # Case 1: paddle is tagged with 2.2.0
+    paddle.version.show()
+    # full_version: 2.2.0
+    # major: 2
+    # minor: 2
+    # patch: 0
+    # rc: 0
+    # cuda: '10.2'
+    # cudnn: '7.6.5'
+
+    # Case 2: paddle is not tagged
+    paddle.version.show()
+    # commit: cfa357e984bfd2ffa16820e354020529df434f7d
+    # cuda: '10.2'
+    # cudnn: '7.6.5'
+

--- a/docs/api/paddle/version/show_cn.rst
+++ b/docs/api/paddle/version/show_cn.rst
@@ -5,21 +5,21 @@ show
 
 .. py:function:: paddle.version.show()
 
-如果paddle包已经标记了特定版本，打印版本号。否则，获取paddle包对应的commit id。
-打印paddle包使用的cuda和cudnn的版本信息。
+如果paddle wheel包已经标记了特定版本，则打印版本号。否则，获取paddle wheel包对应的commit id。
+另外，打印paddle wheel包使用的cuda和cudnn的版本信息。
 
 
 返回：
 :::::::::
-如果paddle包没有被标记为特定版本，输出其对应的commit id。否则，输出如下信息：
+如果paddle wheel包没有被标记为特定版本，输出其对应的commit id。否则，输出如下信息：
 
-    - full_version - paddle包的版本号。
-    - major - paddle包版本号的major信息。
-    - minor - paddle包版本号的minor信息。
-    - patch - paddle包版本号的patch信息。
+    - full_version - paddle wheel包的版本号。
+    - major - paddle wheel包版本号的major信息。
+    - minor - paddle wheel包版本号的minor信息。
+    - patch - paddle wheel包版本号的patch信息。
     - rc - 是否是rc版本。
-    - cuda - paddle包使用的cuda版本。若安装的是CPU版本，则返回 ``False`` 。
-    - cudnn - paddle包使用的cudnn版本。若安装的是CPU版本，则返回 ``False`` 。
+    - cuda - 若paddle wheel包为GPU版本，则返回cuda具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+    - cudnn - 若paddle wheel包为GPU版本，则返回cudnn具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/show_cn.rst
+++ b/docs/api/paddle/version/show_cn.rst
@@ -18,8 +18,8 @@ show
     - minor - paddle包版本号的minor信息。
     - patch - paddle包版本号的patch信息。
     - rc - 是否是rc版本。
-    - cuda - paddle包使用的cuda版本。若安装的是CPU版本，则返回``False``。
-    - cudnn - paddle包使用的cudnn版本。若安装的是CPU版本，则返回``False``。
+    - cuda - paddle包使用的cuda版本。若安装的是CPU版本，则返回 ``False`` 。
+    - cudnn - paddle包使用的cudnn版本。若安装的是CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::


### PR DESCRIPTION
新增了`paddle.version`的文档目录。
并添加了`paddle.version.cuda`、`paddle.version.cudnn`、`paddle.version.show` 3个API文档.

预览链接：
http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1625

![图片](https://user-images.githubusercontent.com/26408901/140942762-c9d8c7d5-d696-49af-b228-2a83cea2e1a4.png)

![图片](https://user-images.githubusercontent.com/26408901/140942778-64e7fd6a-eed5-43a6-bc4b-8d5bf7c094bf.png)

![图片](https://user-images.githubusercontent.com/26408901/140942798-d7d94d60-f56a-434f-9d64-66c599258f6e.png)

![图片](https://user-images.githubusercontent.com/26408901/140942816-2db4ab86-e160-4dbb-951a-dccff399ebfd.png)

![图片](https://user-images.githubusercontent.com/26408901/140942832-43a1e17d-52b6-4ddc-bd6a-1ef7ade728be.png)







