### PR TITLE
add doc for paddle.version.cuda and paddle.version.cudnn API

### DIFF
--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -436,7 +436,8 @@ def set_api_sketch():
         paddle.device,
         paddle.device.cuda,
         paddle.linalg,
-        paddle.fft
+        paddle.fft,
+        paddle.version
     ]
 
     alldict = {}

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -13,6 +13,6 @@ paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本
     :header: "API名称", "API功能"
     :widths: 10, 30
 
-    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的cuda版本"
-    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cudnn版本"
+    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的CUDA版本"
+    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cuDNN版本"
 

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -13,6 +13,6 @@ paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本
     :header: "API名称", "API功能"
     :widths: 10, 30
 
-    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的CUDA版本"
-    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cuDNN版本"
+    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle wheel包编译时使用的CUDA版本"
+    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle wheel包编译时使用的cuDNN版本"
 

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -5,11 +5,6 @@ paddle.version
 
 paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本信息。具体如下：
 
--  :ref:`配置版本相关API <about_version>`
-
-
-
-.. _about_version:
 
 配置版本相关API
 ::::::::::::::::::::
@@ -18,5 +13,6 @@ paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本
     :header: "API名称", "API功能"
     :widths: 10, 30
 
-    " :ref:`cuda <cn_api_version_cuda>` ", "获取paddle包使用的cuda版本"
-    " :ref:`cudnn <cn_api_version_cudnn>` ", "获取paddle包使用的cudnn版本"
+    " :ref:`cuda <cn_api_paddle_version_cuda>` ", "获取paddle包使用的cuda版本"
+    " :ref:`cudnn <cn_api_paddle_version_cudnn>` ", "获取paddle包使用的cudnn版本"
+

--- a/docs/api/paddle/version/Overview_cn.rst
+++ b/docs/api/paddle/version/Overview_cn.rst
@@ -1,0 +1,22 @@
+.. _cn_overview_version:
+
+paddle.version
+---------------------
+
+paddle.version 目录下包含的API返回 paddle 安装包相关配置的版本信息。具体如下：
+
+-  :ref:`配置版本相关API <about_version>`
+
+
+
+.. _about_version:
+
+配置版本相关API
+::::::::::::::::::::
+
+.. csv-table::
+    :header: "API名称", "API功能"
+    :widths: 10, 30
+
+    " :ref:`cuda <cn_api_version_cuda>` ", "获取paddle包使用的cuda版本"
+    " :ref:`cudnn <cn_api_version_cudnn>` ", "获取paddle包使用的cudnn版本"

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -5,12 +5,12 @@ cuda
 
 .. py:function:: paddle.version.cuda()
 
-获取 paddle 安装包使用的 cuda 版本号。
+获取 paddle 安装包使用的 CUDA 版本号。
 
 
 返回：
 :::::::::
-返回cuda的版本信息。若paddle wheel包为GPU版本，则返回cuda具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+返回CUDA的版本信息。若paddle wheel包为GPU版本，则返回CUDA具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -10,7 +10,7 @@ cuda
 
 返回：
 :::::::::
-返回cuda的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
+返回cuda的版本信息。若paddle wheel包为GPU版本，则返回cuda具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -1,0 +1,24 @@
+.. _cn_api_paddle_version_cuda:
+
+cuda
+-------------------------------
+
+.. py:function:: paddle.version.cuda()
+
+获取 paddle 安装包使用的 cuda 版本号。
+
+
+返回：
+:::::::::
+返回cuda的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
+
+代码示例：
+::::::::::
+
+.. code-block:: python
+
+    import paddle
+
+    paddle.version.cuda()
+    # '10.2'
+

--- a/docs/api/paddle/version/cuda_cn.rst
+++ b/docs/api/paddle/version/cuda_cn.rst
@@ -5,12 +5,12 @@ cuda
 
 .. py:function:: paddle.version.cuda()
 
-获取 paddle 安装包使用的 CUDA 版本号。
+获取 paddle 安装包编译时使用的 CUDA 版本号。
 
 
 返回：
 :::::::::
-返回CUDA的版本信息。若paddle wheel包为GPU版本，则返回CUDA具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+若paddle wheel包为GPU版本，则返回paddle wheel包编译时使用的CUDA的版本信息；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -1,0 +1,24 @@
+.. _cn_api_paddle_version_cudnn:
+
+cudnn
+-------------------------------
+
+.. py:function:: paddle.version.cudnn()
+
+获取 paddle 安装包使用的 cudnn 版本号。
+
+
+返回：
+:::::::::
+返回cudnn的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
+
+代码示例：
+::::::::::
+
+.. code-block:: python
+
+    import paddle
+
+    paddle.version.cudnn()
+    # '7.6.5'
+

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -5,12 +5,12 @@ cudnn
 
 .. py:function:: paddle.version.cudnn()
 
-获取 paddle 安装包使用的 cudnn 版本号。
+获取 paddle 安装包使用的 cuDNN 版本号。
 
 
 返回：
 :::::::::
-返回cudnn的版本信息。若paddle wheel包为GPU版本，则返回cudnn具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+返回cuDNN的版本信息。若paddle wheel包为GPU版本，则返回cuDNN具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -5,12 +5,12 @@ cudnn
 
 .. py:function:: paddle.version.cudnn()
 
-获取 paddle 安装包使用的 cuDNN 版本号。
+获取 paddle 安装包编译时使用的 cuDNN 版本号。
 
 
 返回：
 :::::::::
-返回cuDNN的版本信息。若paddle wheel包为GPU版本，则返回cuDNN具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
+若paddle wheel包为GPU版本，则返回paddle wheel包编译时使用的cuDNN的版本信息；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::

--- a/docs/api/paddle/version/cudnn_cn.rst
+++ b/docs/api/paddle/version/cudnn_cn.rst
@@ -10,7 +10,7 @@ cudnn
 
 返回：
 :::::::::
-返回cudnn的版本信息。若paddle包为CPU版本，则返回 ``False`` 。
+返回cudnn的版本信息。若paddle wheel包为GPU版本，则返回cudnn具体的版本号；若paddle wheel包为CPU版本，则返回 ``False`` 。
 
 代码示例：
 ::::::::::


### PR DESCRIPTION
新增了`paddle.version`的文档目录。
并添加了`paddle.version.cuda`、`paddle.version.cudnn` 2个API文档。

预览链接：
http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1624

![图片](https://user-images.githubusercontent.com/26408901/140941215-5464d2af-6a5a-49ba-9203-da71e85e2172.png)

![图片](https://user-images.githubusercontent.com/26408901/140941249-af304fff-4c81-4035-ba62-a427c8a73ab3.png)

![图片](https://user-images.githubusercontent.com/26408901/140941261-0fb0825f-c13a-4b01-a5a5-b94fec75aa1e.png)
