### PR TITLE
a mod's __file__ is None.

### DIFF
--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -229,6 +229,7 @@ def parse_module_file(mod):
         if (isinstance(src_file, str) and isinstance(src_file, str)):
             logger.error('%s: mod_name=%s, src_file=%s',
                          str(mod), mod_name, src_file)
+            return
         logger.debug("parsing %s:%s", mod_name, src_file)
         if len(mod_name) >= 6 and mod_name[:6] == 'paddle':
             if os.path.splitext(src_file)[1].lower() == '.py':

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -141,17 +141,23 @@ def process_module(m, attr="__all__"):
                 if inspect.isclass(api_info['object']):
                     for name, value in inspect.getmembers(api_info['object']):
                         if (not name.startswith("_")):
-                            method_full_name = full_name + '.' + name  # value.__name__
-                            if name and value and isinstance(value, property):
-                                method_api_info = insert_api_into_dict(
-                                    method_full_name, 'class_property')
-                                if method_api_info is not None:
-                                    api_counter += 1
-                            elif hasattr(value, '__name__'):
-                                method_api_info = insert_api_into_dict(
-                                    method_full_name, 'class_method')
-                                if method_api_info is not None:
-                                    api_counter += 1
+                            try:
+                                method_full_name = full_name + '.' + name  # value.__name__
+                                if name and value and isinstance(value,
+                                                                 property):
+                                    method_api_info = insert_api_into_dict(
+                                        method_full_name, 'class_property')
+                                    if method_api_info is not None:
+                                        api_counter += 1
+                                elif hasattr(value, '__name__'):
+                                    method_api_info = insert_api_into_dict(
+                                        method_full_name, 'class_method')
+                                    if method_api_info is not None:
+                                        api_counter += 1
+                            except ValueError as e:
+                                logger.error(
+                                    'ValueError when processing %s: %s',
+                                    method_full_name, str(e))
     return api_counter
 
 

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -226,6 +226,9 @@ def parse_module_file(mod):
     if hasattr(mod, '__name__') and hasattr(mod, '__file__'):
         src_file = mod.__file__
         mod_name = mod.__name__
+        if (isinstance(src_file, str) and isinstance(src_file, str)):
+            logger.error('%s: mod_name=%s, src_file=%s',
+                         str(mod), mod_name, src_file)
         logger.debug("parsing %s:%s", mod_name, src_file)
         if len(mod_name) >= 6 and mod_name[:6] == 'paddle':
             if os.path.splitext(src_file)[1].lower() == '.py':

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -226,13 +226,14 @@ def parse_module_file(mod):
     if hasattr(mod, '__name__') and hasattr(mod, '__file__'):
         src_file = mod.__file__
         mod_name = mod.__name__
-        if (isinstance(src_file, str) and isinstance(src_file, str)):
+        if not (isinstance(src_file, str) and isinstance(src_file, str)):
             logger.error('%s: mod_name=%s, src_file=%s',
                          str(mod), mod_name, src_file)
             return
         logger.debug("parsing %s:%s", mod_name, src_file)
         if len(mod_name) >= 6 and mod_name[:6] == 'paddle':
-            if os.path.splitext(src_file)[1].lower() == '.py':
+            fn_splited = os.path.splitext(src_file)
+            if len(fn_splited) > 1 and fn_splited[1].lower() == '.py':
                 mod_ast = ast.parse(open(src_file, "r").read())
                 for node in mod_ast.body:
                     short_names = []


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./gen_doc.py", line 1270, in <module>
    set_source_code_attrs()
  File "./gen_doc.py", line 180, in set_source_code_attrs
    parse_module_file(obj)
  File "./gen_doc.py", line 234, in parse_module_file
    if os.path.splitext(src_file)[1].lower() == '.py':
  File "/usr/lib/python3.8/posixpath.py", line 118, in splitext
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
this module's src_file is None.
```
2021-11-05 08:36:13,385 - parse_module_file:233 - ERROR - <module 'paddle.incubate.nn.layer' (namespace)>: mod_name=paddle.incubate.nn.layer, src_file=None
```