### PR TITLE
[install] expose docker install doc in paddle 2.2.0

### DIFF
--- a/docs/install/docker/fromdocker.rst
+++ b/docs/install/docker/fromdocker.rst
@@ -5,4 +5,5 @@
 ..	toctree::
 	:maxdepth: 1
 
+	linux-docker.md
 	macos-docker.md

--- a/docs/install/docker/fromdocker_en.rst
+++ b/docs/install/docker/fromdocker_en.rst
@@ -5,4 +5,5 @@
 ..	toctree::
 	
 
+	linux-docker_en.md
 	macos-docker_en.md


### PR DESCRIPTION
之前隐藏了docker安装，这个PR恢复了。

预览链接：

http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1673

