### PR TITLE
handle the aliases problems in API docs, cheat the sphinx

### DIFF
--- a/docs/api/api_aliases.ini
+++ b/docs/api/api_aliases.ini
@@ -1,0 +1,6 @@
+[help]
+help_zh=左侧是target name，右侧是origin name， 如paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent
+
+[en]
+paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent
+paddle.device.cuda.Stream=paddle.fluid.core_avx.CUDAStream


### PR DESCRIPTION
加个转换`paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent`的配置，与sphinx conf.py文件配合完成alias的问题

fix https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-35024/show?source=drawer-header