### PR TITLE
[cherry-pick] handle the aliases problems in API docs, cheat the sphinx #4109

### DIFF
--- a/docs/api/api_aliases.ini
+++ b/docs/api/api_aliases.ini
@@ -1,0 +1,6 @@
+[help]
+help_zh=左侧是target name，右侧是origin name， 如paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent
+
+[en]
+paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent
+paddle.device.cuda.Stream=paddle.fluid.core_avx.CUDAStream


### PR DESCRIPTION
加个转换paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent的配置，与sphinx conf.py文件配合完成alias的问题 (#4108)