### PR TITLE
[install doc] fix relative link in install doc

### DIFF
--- a/docs/install/compile/linux-compile.md
+++ b/docs/install/compile/linux-compile.md
@@ -451,7 +451,7 @@ uname -m && cat /etc/*release
 workon paddle-venv
 ```
 
-#### 6. **执行编译前**请您确认在虚环境中安装有[编译依赖表](../Tables.html#third_party)中提到的相关依赖：
+#### 6. **执行编译前**请您确认在虚环境中安装有[编译依赖表](/documentation/docs/zh/install/Tables.html#third_party)中提到的相关依赖：
 
 * 这里特别提供`patchELF`的安装方法，其他的依赖可以使用`yum install`或者`pip install`/`pip3 install` 后跟依赖名称和版本安装:
 

--- a/docs/install/compile/linux-compile_en.md
+++ b/docs/install/compile/linux-compile_en.md
@@ -437,7 +437,7 @@ uname -m && cat /etc/*release
 workon paddle-venv
 ```
 
-#### 6. Before **executing the compilation**, please confirm that the related dependencies mentioned in the [compile dependency table](../Tables.html/#third_party) are installed in the virtual environment:
+#### 6. Before **executing the compilation**, please confirm that the related dependencies mentioned in the [compile dependency table](/documentation/docs/en/install/Tables_en.html/#third_party) are installed in the virtual environment:
 
 * Here is the installation method for `patchELF`. Other dependencies can be installed using `yum install` or `apt install`, `pip install`/`pip3 install` followed by the name and version:
 

--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -290,7 +290,6 @@ pip install -U（whl包的名字）
 pip3 install -U（whl包的名字）
 ```
 
-> 如果您的电脑上安装有多个python环境以及pip请参见[FAQ](/documentation/docs/zh/install/Tables.html#MACPRO)
 
 #### 恭喜，至此您已完成PaddlePaddle的编译安装
 

--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -210,7 +210,7 @@ uname -m
 
 - g. (可选）如果您是在MacOS 10.14上编译PaddlePaddle，请保证您已经安装了[对应版本](http://developer.apple.com/download)的Xcode。
 
-#### 4. **执行编译前**请您确认您的环境中安装有[编译依赖表](../Tables.html#third_party)中提到的相关依赖，否则我们强烈推荐使用`Homebrew`安装相关依赖。
+#### 4. **执行编译前**请您确认您的环境中安装有[编译依赖表](/documentation/docs/zh/install/Tables.html#third_party)中提到的相关依赖，否则我们强烈推荐使用`Homebrew`安装相关依赖。
 
 > MacOS下如果您未自行修改或安装过“编译依赖表”中提到的依赖，则仅需要使用`pip`安装`numpy，protobuf，wheel`，使用`homebrew`安装`wget，swig, unrar`，另外安装`cmake`即可
 
@@ -290,7 +290,7 @@ pip install -U（whl包的名字）
 pip3 install -U（whl包的名字）
 ```
 
-> 如果您的电脑上安装有多个python环境以及pip请参见[FAQ](../Tables.html#MACPRO)
+> 如果您的电脑上安装有多个python环境以及pip请参见[FAQ](/documentation/docs/zh/install/Tables.html#MACPRO)
 
 #### 恭喜，至此您已完成PaddlePaddle的编译安装
 

--- a/docs/install/compile/macos-compile_en.md
+++ b/docs/install/compile/macos-compile_en.md
@@ -213,7 +213,7 @@ Install using Python official website
 - g. (Optional) If you are compiling PaddlePaddle on MacOS 10.14, make sure you have the [appropriate version](http://developer.apple.com/download) of Xcode installed.
 
 
-#### 4. Before **compilation**, please confirm that the relevant dependencies mentioned in the [compilation dependency table](h/documentation/docs/en/install/Tables_en.html/#third_party) are installed in your environment, otherwise we strongly recommend using `Homebrew` to install related dependencies.
+#### 4. Before **compilation**, please confirm that the relevant dependencies mentioned in the [compilation dependency table](/documentation/docs/en/install/Tables_en.html/#third_party) are installed in your environment, otherwise we strongly recommend using `Homebrew` to install related dependencies.
 
 > Under MacOS, if you have not modified or installed the dependencies mentioned in the "Compile Dependency Table", you only need to use `pip` to install `numpy`, `protobuf`, `wheel`, use `homebrew` to install `wget`, `swig`,then install `cmake`.
 
@@ -293,7 +293,6 @@ or
 pip3 install -U (whl package name)
 ```
 
-> If you have multiple python environments and pips installed on your computer, please see the [FAQ](/documentation/docs/en/install/Tables_en.html/#MACPRO).
 
 #### Congratulations, now you have completed the process of compiling PaddlePaddle using this machine.
 

--- a/docs/install/compile/macos-compile_en.md
+++ b/docs/install/compile/macos-compile_en.md
@@ -125,7 +125,7 @@ apt install patchelf
     ```
     cmake .. -DPY_VERSION=3.7 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DWITH_AVX=OFF -DCMAKE_BUILD_TYPE=Release
     ```
-> For details on the compilation options, see the [compilation options table](../Tables_en.html/#Compile).
+> For details on the compilation options, see the [compilation options table](/documentation/docs/en/install/Tables_en.html/#Compile).
 
 > Please attention to modify parameters `-DPY_VERSION` for the version of Python you want to compile with, for example `-DPY_VERSION=3.7` means the version of python is 3.7
 
@@ -213,7 +213,7 @@ Install using Python official website
 - g. (Optional) If you are compiling PaddlePaddle on MacOS 10.14, make sure you have the [appropriate version](http://developer.apple.com/download) of Xcode installed.
 
 
-#### 4. Before **compilation**, please confirm that the relevant dependencies mentioned in the [compilation dependency table](h../Tables.html/#third_party) are installed in your environment, otherwise we strongly recommend using `Homebrew` to install related dependencies.
+#### 4. Before **compilation**, please confirm that the relevant dependencies mentioned in the [compilation dependency table](h/documentation/docs/en/install/Tables_en.html/#third_party) are installed in your environment, otherwise we strongly recommend using `Homebrew` to install related dependencies.
 
 > Under MacOS, if you have not modified or installed the dependencies mentioned in the "Compile Dependency Table", you only need to use `pip` to install `numpy`, `protobuf`, `wheel`, use `homebrew` to install `wget`, `swig`,then install `cmake`.
 
@@ -293,7 +293,7 @@ or
 pip3 install -U (whl package name)
 ```
 
-> If you have multiple python environments and pips installed on your computer, please see the [FAQ](../Tables.html/#MACPRO).
+> If you have multiple python environments and pips installed on your computer, please see the [FAQ](/documentation/docs/en/install/Tables_en.html/#MACPRO).
 
 #### Congratulations, now you have completed the process of compiling PaddlePaddle using this machine.
 


### PR DESCRIPTION
安装文档中使用相对路径的链接会导致首页安装文档中的链接无法访问，进行了修复。

预览链接：http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1722