### PR TITLE
add cn_doc for mode api

### DIFF
--- a/docs/api/paddle/Tensor_cn.rst
+++ b/docs/api/paddle/Tensor_cn.rst
@@ -1420,6 +1420,15 @@ mod(y, name=None)
 
 请参考 :ref:`cn_api_tensor_mod`
 
+mode(axis=-1, keepdim=False, name=None)
+:::::::::
+
+返回：计算后的Tensor
+
+返回类型：Tensor
+
+请参考 :ref:`cn_api_tensor_mode`
+
 multiplex(index)
 :::::::::
 

--- a/docs/api/paddle/mode_cn.rst
+++ b/docs/api/paddle/mode_cn.rst
@@ -1,0 +1,36 @@
+.. _cn_api_tensor_cn_mode`:
+
+mode
+-------------------------------
+
+.. py:function:: paddle.mode（x, axis=-1, keepdim=False,  name=None):
+
+该OP沿着可选的 ``axis`` 查找对应轴上的众数和结果所在的索引信息。
+
+参数
+:::::::::
+    - **x** （Tensor） - 输入的多维 ``Tensor`` ，支持的数据类型：float32、float64、int32、int64。
+    - **axis** （int，可选） - 指定对输入Tensor进行运算的轴， ``axis`` 的有效范围是[-R, R），R是输入 ``x`` 的Rank， ``axis`` 为负时与 ``axis`` + R 等价。默认值为-1。
+    - **keepdim** (bool, 可选）- 是否保留指定的轴。如果是True, 维度会与输入x一致，对应所指定的轴的size为1。否则，由于对应轴被展开，输出的维度会比输入小1。默认值为1。
+    - **name** （str，可选） – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
+
+返回
+:::::::::
+tuple（Tensor）, 返回检索到的众数结果和对应索引信息。结果的数据类型和输入 ``x`` 一致。索引的数据类型是int64。
+
+代码示例
+:::::::::
+
+
+.. code-block:: python
+
+    import paddle
+
+    tensor = paddle.to_tensor([[[1,2,2],[2,3,3]],[[0,5,5],[9,9,0]]],dtype=paddle.float32)
+    res = paddle.mode(tensor, 2)
+    print(res)
+    # (Tensor(shape=[2, 2], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
+    #   [[2., 3.],
+    #    [5., 9.]]), Tensor(shape=[2, 2], dtype=int64, place=CUDAPlace(0), stop_gradient=True,
+    #   [[1, 1],
+    #    [1, 0]]))


### PR DESCRIPTION
Add CN doc for paddle.mode and paddle.Tensor.mode, the PR is [here](https://github.com/PaddlePaddle/Paddle/pull/38446).

![mode-API文档-PaddlePaddle深度学习平台 - 10 136 157 23](https://user-images.githubusercontent.com/15810355/147472184-3dc1f10b-1545-45d5-b9a9-de384154c4ca.png)
![mode-API Document-PaddlePaddle Deep Learning Platform - 10 136 157 23](https://user-images.githubusercontent.com/15810355/147472175-ae1a5c89-40fd-4585-830d-bb75889678c0.png)
