### PR TITLE
refine amax/amin docs

### DIFF
--- a/doc/fluid/api_cn/tensor_cn/amax_cn.rst
+++ b/doc/fluid/api_cn/tensor_cn/amax_cn.rst
@@ -16,7 +16,7 @@ amax
 
 参数
 :::::::::
-   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64。
+   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64，维度不超过4维。
    - **axis** （list | int ，可选）- 求最大值运算的维度。如果为None，则计算所有元素的最大值并返回包含单个元素的Tensor变量，否则必须在  :math:`[-x.ndim, x.ndim]` 范围内。如果 :math:`axis[i] <0` ，则维度将变为 :math:`x.ndim+axis[i]` ，默认值为None。
    - **keepdim** （bool）- 是否在输出Tensor中保留减小的维度。如果keepdim 为 False，结果张量的维度将比输入张量的小，默认值为False。
    - **name** （str， 可选）- 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。

--- a/doc/fluid/api_cn/tensor_cn/amin_cn.rst
+++ b/doc/fluid/api_cn/tensor_cn/amin_cn.rst
@@ -16,7 +16,7 @@ amin
 
 参数
 :::::::::
-   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64。
+   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64，维度不超过4维。
    - **axis** （list | int ，可选）- 求最小值运算的维度。如果为None，则计算所有元素的最小值并返回包含单个元素的Tensor变量，否则必须在  :math:`[−x.ndim, x.ndim]` 范围内。如果 :math:`axis[i] < 0` ，则维度将变为 :math:`x.ndim+axis[i]` ，默认值为None。
    - **keepdim** （bool）- 是否在输出Tensor中保留减小的维度。如果keepdim 为False，结果张量的维度将比输入张量的小，默认值为False。
    - **name** （str， 可选）- 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。

--- a/docs/api/paddle/amax_cn.rst
+++ b/docs/api/paddle/amax_cn.rst
@@ -14,7 +14,7 @@ amax
 
 参数
 :::::::::
-   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64。
+   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64，维度不超过4维。
    - **axis** （list | int ，可选）- 求最大值运算的维度。如果为None，则计算所有元素的最大值并返回包含单个元素的Tensor变量，否则必须在  :math:`[-x.ndim, x.ndim]` 范围内。如果 :math:`axis[i] <0` ，则维度将变为 :math:`x.ndim+axis[i]` ，默认值为None。
    - **keepdim** （bool）- 是否在输出Tensor中保留减小的维度。如果keepdim 为 False，结果张量的维度将比输入张量的小，默认值为False。
    - **name** （str， 可选）- 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。

--- a/docs/api/paddle/amin_cn.rst
+++ b/docs/api/paddle/amin_cn.rst
@@ -14,7 +14,7 @@ amin
 
 参数
 :::::::::
-   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64。
+   - **x** （Tensor）- Tensor，支持数据类型为float32，float64，int32，int64，维度不超过4维。
    - **axis** （list | int ，可选）- 求最小值运算的维度。如果为None，则计算所有元素的最小值并返回包含单个元素的Tensor变量，否则必须在  :math:`[−x.ndim, x.ndim]` 范围内。如果 :math:`axis[i] < 0` ，则维度将变为 :math:`x.ndim+axis[i]` ，默认值为None。
    - **keepdim** （bool）- 是否在输出Tensor中保留减小的维度。如果keepdim 为False，结果张量的维度将比输入张量的小，默认值为False。
    - **name** （str， 可选）- 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。


### PR DESCRIPTION
由于amax/amin编译6维比较耗时，先降低到只支持4维。https://github.com/PaddlePaddle/Paddle/pull/38534