### PR TITLE
update learning_rate decay doc

### DIFF
--- a/docs/api/paddle/optimizer/lr/ExponentialDecay_cn.rst
+++ b/docs/api/paddle/optimizer/lr/ExponentialDecay_cn.rst
@@ -15,7 +15,7 @@ ExponentialDecay
 
 参数：
     - **learning_rate** (float) - 初始学习率，数据类型为Python float。
-    - **gamma** (float) - 衰减率，``new_lr = origin_lr * gamma`` 。
+    - **gamma** (float) - 衰减率，``new_lr = origin_lr * gamma`` 。gamma应该在区间 (0.0, 1.0) 内。
     - **last_epoch** (int，可选) - 上一轮的轮数，重启训练时设置为上一轮的epoch数。默认值为 -1，则为初始学习率 。
     - **verbose** (bool，可选) - 如果是 ``True`` ，则在每一轮更新时在标准输出 `stdout` 输出一条信息。默认值为 ``False`` 。
 

--- a/docs/api/paddle/optimizer/lr/NaturalExpDecay_cn.rst
+++ b/docs/api/paddle/optimizer/lr/NaturalExpDecay_cn.rst
@@ -15,7 +15,7 @@ NaturalExpDecay
 
 参数：
     - **learning_rate** (float) - 初始学习率，数据类型为Python float。
-    - **gamma** (float) - 衰减率。
+    - **gamma** (float) - 衰减率，gamma应该大于0.0，才能使学习率衰减。默认值为0.1。
     - **last_epoch** (int，可选) - 上一轮的轮数，重启训练时设置为上一轮的epoch数。默认值为 -1，则为初始学习率。
     - **verbose** (bool，可选) - 如果是 ``True`` ，则在每一轮更新时在标准输出 `stdout` 输出一条信息。默认值为 ``False`` 。
 

--- a/docs/api/paddle/optimizer/lr/PolynomialDecay_cn.rst
+++ b/docs/api/paddle/optimizer/lr/PolynomialDecay_cn.rst
@@ -29,7 +29,7 @@ PolynomialDecay
     - **learning_rate** (float) - 初始学习率，数据类型为Python float。
     - **decay_steps** (int) - 进行衰减的步长，这个决定了衰减周期。
     - **end_lr** (float，可选）- 最小的最终学习率。默认值为0.0001。
-    - **power** (float，可选) - 多项式的幂。默认值为1.0。
+    - **power** (float，可选) - 多项式的幂，power应该大于0.0，才能使学习率衰减。默认值为1.0。
     - **cycle** (bool，可选) - 学习率下降后是否重新上升。若为True，则学习率衰减到最低学习率值时，会重新上升。若为False，则学习率单调递减。默认值为False。
     - **last_epoch** (int，可选) - 上一轮的轮数，重启训练时设置为上一轮的epoch数。默认值为 -1，则为初始学习率。
     - **verbose** (bool，可选) - 如果是 `True` ，则在每一轮更新时在标准输出 `stdout` 输出一条信息。默认值为 ``False`` 。


### PR DESCRIPTION
update docs of learning rate decay with the lr.py modification [pr#38782](https://github.com/PaddlePaddle/Paddle/pull/38782), see the original icafe [issue[DLTP-38875]](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-38875/show?source=notification).
this is the preview [result](http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1951):
![image](https://user-images.githubusercontent.com/51314274/149106505-b030e00b-992b-44a8-a246-f38c8ea50308.png)
![image](https://user-images.githubusercontent.com/51314274/149106892-cbe3941c-52e8-4468-a1db-f44880e6d9f7.png)
![image](https://user-images.githubusercontent.com/51314274/149107260-80e25547-108b-444f-b261-039d6433ce24.png)
