### PR TITLE
Fix CrossEntropyLoss description

### DIFF
--- a/doc/fluid/api_cn/nn_cn/loss_cn/CrossEntropyLoss_cn.rst
+++ b/doc/fluid/api_cn/nn_cn/loss_cn/CrossEntropyLoss_cn.rst
@@ -24,7 +24,7 @@ CrossEntropyLoss
 参数
 :::::::::
     - **weight** (Tensor, 可选): - 指定每个类别的权重。其默认为 `None` 。如果提供该参数的话，维度必须为 `C` （类别数）。数据类型为float32或float64。
-    - **ignore_index** (int64, 可选): - 指定一个忽略的标签值，此标签值不参与计算，负值表示无需忽略任何标签值。仅在soft_label=False时有效。默认值为-100。数据类型为int64。
+    - **ignore_index** (int64, 可选): - 指定一个忽略的标签值，此标签值不参与计算。默认值为-100。数据类型为int64。
     - **reduction** (str, 可选): - 指定应用于输出结果的计算方式，数据类型为string，可选值有: `none`, `mean`, `sum` 。默认为 `mean` ，计算 `mini-batch` loss均值。设置为 `sum` 时，计算 `mini-batch` loss的总和。设置为 `none` 时，则返回loss Tensor。
 
 形状

--- a/doc/fluid/api_cn/nn_cn/loss_cn/CrossEntropyLoss_cn.rst
+++ b/doc/fluid/api_cn/nn_cn/loss_cn/CrossEntropyLoss_cn.rst
@@ -24,7 +24,7 @@ CrossEntropyLoss
 参数
 :::::::::
     - **weight** (Tensor, 可选): - 指定每个类别的权重。其默认为 `None` 。如果提供该参数的话，维度必须为 `C` （类别数）。数据类型为float32或float64。
-    - **ignore_index** (int64, 可选): - 指定一个忽略的标签值，此标签值不参与计算。默认值为-100。数据类型为int64。
+    - **ignore_index** (int64, 可选): - 指定一个忽略的标签值，此标签值不参与计算，负值表示无需忽略任何标签值。仅在soft_label=False时有效。默认值为-100。数据类型为int64。
     - **reduction** (str, 可选): - 指定应用于输出结果的计算方式，数据类型为string，可选值有: `none`, `mean`, `sum` 。默认为 `mean` ，计算 `mini-batch` loss均值。设置为 `sum` 时，计算 `mini-batch` loss的总和。设置为 `none` 时，则返回loss Tensor。
 
 形状

--- a/docs/api/paddle/nn/CrossEntropyLoss_cn.rst
+++ b/docs/api/paddle/nn/CrossEntropyLoss_cn.rst
@@ -24,7 +24,7 @@ CrossEntropyLoss
 参数
 :::::::::
     - **weight** (Tensor, 可选): - 指定每个类别的权重。其默认为 `None` 。如果提供该参数的话，维度必须为 `C` （类别数）。数据类型为float32或float64。
-    - **ignore_index** (int64, 可选): - 指定一个忽略的标签值，此标签值不参与计算。默认值为-100。数据类型为int64。
+    - **ignore_index** (int64, 可选): - 指定一个忽略的标签值，此标签值不参与计算，负值表示无需忽略任何标签值。仅在soft_label=False时有效。默认值为-100。数据类型为int64。
     - **reduction** (str, 可选): - 指定应用于输出结果的计算方式，数据类型为string，可选值有: `none`, `mean`, `sum` 。默认为 `mean` ，计算 `mini-batch` loss均值。设置为 `sum` 时，计算 `mini-batch` loss的总和。设置为 `none` 时，则返回loss Tensor。
     - **soft_label** (bool, optional) – 指明label是否为软标签。默认为False，表示label为硬标签；若soft_label=True则表示软标签。
     - **axis** (int, optional) - 进行softmax计算的维度索引。 它应该在 :math:`[-1，dim-1]` 范围内，而 ``dim`` 是输入logits的维度。 默认值：-1。


### PR DESCRIPTION
1. 修复中文文档中`CrossEntropyLoss`的`ignore_index`参数描述不够明确的问题，与[英文文档](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/nn/CrossEntropyLoss_en.html#crossentropyloss)和[cross_entropy文档](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/nn/CrossEntropyLoss_en.html#crossentropyloss)对齐