### PR TITLE
fix path in compile guide

### DIFF
--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -53,7 +53,7 @@
 5. 进入Docker后进入paddle目录下：
 
     ```
-    cd paddle
+    cd /paddle
     ```
 
 6. 切换到`develop`版本进行编译：

--- a/docs/install/compile/macos-compile_en.md
+++ b/docs/install/compile/macos-compile_en.md
@@ -57,7 +57,7 @@ Please follow the steps below to install:
 5. After entering Docker, go to the paddle directory:
 
     ```
-    cd paddle
+    cd /paddle
     ```
 
 6. Switch to `develop` version to compile:


### PR DESCRIPTION
页面: <https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/macos-compile.html#anzhuangbuzhou>

docker 是将当前目录挂载到 `/paddle` 的，而 docker 最后一次 WORKDIR 是 `/home`，因此只能使用绝对路径 `/paddle`