### PR TITLE
fix paddle.vision.transforms.Resize cn docs

### DIFF
--- a/docs/api/paddle/vision/transforms/Resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/Resize_cn.rst
@@ -12,7 +12,20 @@ resize
 
     - img (numpy.ndarray|PIL.Image) - 输入数据，可以是(H, W, C)形状的图像或遮罩。
     - size (int|tuple) - 输出图像大小。如果size是一个序列，例如（h，w），输出大小将与此匹配。如果size为int，图像的较小边缘将与此数字匹配，即如果 height > width，则图像将重新缩放为(size * height / width, size)。
-    - interpolation (int|str, optional) - 插值的方法. 默认值: 'bilinear'。 当使用 ``pil`` 作为后端时, 支持的插值方法如下: - "nearest": Image.NEAREST, - "bilinear": Image.BILINEAR, - "bicubic": Image.BICUBIC, - "box": Image.BOX, - "lanczos": Image.LANCZOS, - "hamming": Image.HAMMING。当使用 ``cv2`` 作为后端时, 支持的插值方法如下: - "nearest": cv2.INTER_NEAREST, - "bilinear": cv2.INTER_LINEAR, - "area": cv2.INTER_AREA, - "bicubic": cv2.INTER_CUBIC, - "lanczos": cv2.INTER_LANCZOS4。
+    - interpolation (int|str, optional) - 插值的方法，默认值: 'bilinear'。
+        - 当使用 ``pil`` 作为后端时, 支持的插值方法如下
+            + "nearest": Image.NEAREST, 
+            + "bilinear": Image.BILINEAR, 
+            + "bicubic": Image.BICUBIC, 
+            + "box": Image.BOX, 
+            + "lanczos": Image.LANCZOS, 
+            + "hamming": Image.HAMMING。
+        - 当使用 ``cv2`` 作为后端时, 支持的插值方法如下
+            + "nearest": cv2.INTER_NEAREST, 
+            + "bilinear": cv2.INTER_LINEAR, 
+            + "area": cv2.INTER_AREA, 
+            + "bicubic": cv2.INTER_CUBIC, 
+            + "lanczos": cv2.INTER_LANCZOS4。
 
 返回
 :::::::::
@@ -34,7 +47,9 @@ resize
 
     converted_img = F.resize(fake_img, 224)
     print(converted_img.size)
+    # (262, 224)
 
     converted_img = F.resize(fake_img, (200, 150))
     print(converted_img.size)
+    # (150, 200)
         

--- a/docs/api/paddle/vision/transforms/Resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/Resize_cn.rst
@@ -45,11 +45,11 @@ resize
 
     fake_img = Image.fromarray(fake_img)
 
-    converted_img = F.resize(fake_img, 224)
-    print(converted_img.size)
+    converted_img1 = F.resize(fake_img, 224)
+    print(converted_img1.size)
     # (262, 224)
 
-    converted_img = F.resize(fake_img, (200, 150))
-    print(converted_img.size)
+    converted_img2 = F.resize(fake_img, (200, 150))
+    print(converted_img2.size)
     # (150, 200)
         

--- a/docs/api/paddle/vision/transforms/Resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/Resize_cn.rst
@@ -45,11 +45,11 @@ resize
 
     fake_img = Image.fromarray(fake_img)
 
-    converted_img1 = F.resize(fake_img, 224)
-    print(converted_img1.size)
+    converted_img = F.resize(fake_img, 224)
+    print(converted_img.size)
     # (262, 224)
 
-    converted_img2 = F.resize(fake_img, (200, 150))
-    print(converted_img2.size)
+    converted_img = F.resize(fake_img, (200, 150))
+    print(converted_img.size)
     # (150, 200)
         

--- a/docs/api/paddle/vision/transforms/resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/resize_cn.rst
@@ -12,8 +12,21 @@ resize
 
     - img (numpy.ndarray|PIL.Image) - 输入数据，可以是(H, W, C)形状的图像或遮罩。
     - size (int|tuple) - 输出图像大小。如果size是一个序列，例如（h，w），输出大小将与此匹配。如果size为int，图像的较小边缘将与此数字匹配，即如果 height > width，则图像将重新缩放为(size * height / width, size)。
-    - interpolation (int|str, optional) - 插值的方法. 默认值: 'bilinear'。 当使用 ``pil`` 作为后端时, 支持的插值方法如下: - "nearest": Image.NEAREST, - "bilinear": Image.BILINEAR, - "bicubic": Image.BICUBIC, - "box": Image.BOX, - "lanczos": Image.LANCZOS, - "hamming": Image.HAMMING。当使用 ``cv2`` 作为后端时, 支持的插值方法如下: - "nearest": cv2.INTER_NEAREST, - "bilinear": cv2.INTER_LINEAR, - "area": cv2.INTER_AREA, - "bicubic": cv2.INTER_CUBIC, - "lanczos": cv2.INTER_LANCZOS4。
-
+    - interpolation (int|str, optional) - 插值的方法，默认值: 'bilinear'。
+        - 当使用 ``pil`` 作为后端时, 支持的插值方法如下
+            + "nearest": Image.NEAREST, 
+            + "bilinear": Image.BILINEAR, 
+            + "bicubic": Image.BICUBIC, 
+            + "box": Image.BOX, 
+            + "lanczos": Image.LANCZOS, 
+            + "hamming": Image.HAMMING。
+        - 当使用 ``cv2`` 作为后端时, 支持的插值方法如下
+            + "nearest": cv2.INTER_NEAREST, 
+            + "bilinear": cv2.INTER_LINEAR, 
+            + "area": cv2.INTER_AREA, 
+            + "bicubic": cv2.INTER_CUBIC, 
+            + "lanczos": cv2.INTER_LANCZOS4。
+            
 返回
 :::::::::
 
@@ -32,9 +45,11 @@ resize
 
     fake_img = Image.fromarray(fake_img)
 
-    converted_img = F.resize(fake_img, 224)
+    converted_img1 = F.resize(fake_img, 224)
     print(converted_img.size)
+    # (262, 224)
 
-    converted_img = F.resize(fake_img, (200, 150))
+    converted_img2 = F.resize(fake_img, (200, 150))
     print(converted_img.size)
+    # (150, 200)
         

--- a/docs/api/paddle/vision/transforms/resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/resize_cn.rst
@@ -45,11 +45,11 @@ resize
 
     fake_img = Image.fromarray(fake_img)
 
-    converted_img1 = F.resize(fake_img, 224)
-    print(converted_img1.size)
+    converted_img = F.resize(fake_img, 224)
+    print(converted_img.size)
     # (262, 224)
 
-    converted_img2 = F.resize(fake_img, (200, 150))
-    print(converted_img2.size)
+    converted_img = F.resize(fake_img, (200, 150))
+    print(converted_img.size)
     # (150, 200)
         

--- a/docs/api/paddle/vision/transforms/resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/resize_cn.rst
@@ -46,10 +46,10 @@ resize
     fake_img = Image.fromarray(fake_img)
 
     converted_img1 = F.resize(fake_img, 224)
-    print(converted_img.size)
+    print(converted_img1.size)
     # (262, 224)
 
     converted_img2 = F.resize(fake_img, (200, 150))
-    print(converted_img.size)
+    print(converted_img2.size)
     # (150, 200)
         


### PR DESCRIPTION
任务目标：https://github.com/PaddlePaddle/docs/issues/4239

由于中文develop的Resize docs显示内容和resize完全相同，本节以resize docs为基础进行了以下修改
1. 修改了resize和Resize的interpolation的参数展示
2. 增加resize和Resize的输出说明
3. 没有使中英文Resize代码保持完全同步，仅修改代码示例，使英文的输出内容和中文文档保持同步

由于我的电脑抽取英文文档报错，因此没有对英文interpolation的参数展示进行修改，仅修改示例代码以保持一致