### PR TITLE
Fix rnn, wmt16 docs

### DIFF
--- a/docs/api/paddle/nn/GRU_cn.rst
+++ b/docs/api/paddle/nn/GRU_cn.rst
@@ -29,12 +29,12 @@ GRU
     - :math:`\sigma` ：sigmoid激活函数。
 
 参数：
-    - **input_size** (int) - 输入的大小。
-    - **hidden_size** (int) - 隐藏状态大小。
-    - **num_layers** (int，可选) - 网络层数。默认为1。
-    - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。默认为forward。
-    - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。默认为False。
-    - **dropout** (float，可选) - dropout概率，指的是出第一层外每层输入时的dropout概率。默认为0。
+    - **input_size** (int) - 输入`x`的大小。
+    - **hidden_size** (int) - 隐藏状态`h`大小。
+    - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
+    - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
+    - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。
+    - **dropout** (float，可选) - dropout概率，指的是出第一层外每层输入时的dropout概率。范围为[0, 1]。默认为0。
     - **weight_ih_attr** (ParamAttr，可选) - weight_ih的参数。默认为None。
     - **weight_hh_attr** (ParamAttr，可选) - weight_hh的参数。默认为None。
     - **bias_ih_attr** (ParamAttr，可选) - bias_ih的参数。默认为None。

--- a/docs/api/paddle/nn/GRU_cn.rst
+++ b/docs/api/paddle/nn/GRU_cn.rst
@@ -41,12 +41,12 @@ GRU
     - **bias_hh_attr** (ParamAttr，可选) - bias_hh的参数。默认为None。
     
 输入:
-    - **inputs** (Tensor) - 网络输入。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,input_size]。
-    - **initial_states** (Tensor，可选) - 网络的初始状态，形状为[num_lauers * num_directions, batch_size, hidden_size]。如果没有给出则会以全零初始化。
-    - **sequence_length** (Tensor，可选) - 指定输入序列的长度，形状为[batch_size]，数据类型为int64或int32。在输入序列中所有time step不小于sequence_length的元素都会被当作填充元素处理（状态不再更新）。
+    - **inputs** (Tensor) - 网络输入。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。
+    - **initial_states** (Tensor，可选) - 网络的初始状态，形状为[num_layers * num_directions, batch_size, hidden_size]。如果没有给出则会以全零初始化。
+    - **sequence_length** (Tensor，可选) - 指定输入序列的实际长度，形状为[batch_size]，数据类型为int64或int32。在输入序列中所有time step不小于sequence_length的元素都会被当作填充元素处理（状态不再更新）。
 
 输出:
-    - **outputs** (Tensor) - 输出，由前向和后向cell的输出拼接得到。如果time_major为True，则Tensor的形状为[time_steps,batch_size,num_directions * hidden_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,num_directions * hidden_size]，当direction设置为bidirectional时，num_directions等于2，否则等于1。
+    - **outputs** (Tensor) - 输出，由前向和后向cell的输出拼接得到。如果time_major为True，则Tensor的形状为[time_steps,batch_size,num_directions * hidden_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,num_directions * hidden_size]，当direction设置为bidirectional时，num_directions等于2，否则等于1。`time_steps` 指输出序列的长度。
     - **final_states** (Tensor) - 最终状态。形状为[num_layers * num_directions, batch_size, hidden_size]，当direction设置为bidirectional时，num_directions等于2，返回值的前向和后向的状态的索引是0，2，4，6...和1，3，5，7...，否则等于1。
 
 **代码示例**：

--- a/docs/api/paddle/nn/GRU_cn.rst
+++ b/docs/api/paddle/nn/GRU_cn.rst
@@ -29,8 +29,8 @@ GRU
     - :math:`\sigma` ：sigmoid激活函数。
 
 参数：
-    - **input_size** (int) - 输入`x`的大小。
-    - **hidden_size** (int) - 隐藏状态`h`大小。
+    - **input_size** (int) - 输入`x` 的大小。
+    - **hidden_size** (int) - 隐藏状态`h` 大小。
     - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
     - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
     - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。

--- a/docs/api/paddle/nn/GRU_cn.rst
+++ b/docs/api/paddle/nn/GRU_cn.rst
@@ -29,8 +29,8 @@ GRU
     - :math:`\sigma` ：sigmoid激活函数。
 
 参数：
-    - **input_size** (int) - 输入`x` 的大小。
-    - **hidden_size** (int) - 隐藏状态`h` 大小。
+    - **input_size** (int) - 输入 :math:`x` 的大小。
+    - **hidden_size** (int) - 隐藏状态 :math:`h` 大小。
     - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
     - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
     - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。

--- a/docs/api/paddle/nn/LSTM_cn.rst
+++ b/docs/api/paddle/nn/LSTM_cn.rst
@@ -46,12 +46,12 @@ LSTM
     - **bias_hh_attr** (ParamAttr，可选) - bias_hh的参数。默认为None。
     
 输入:
-    - **inputs** (Tensor) - 网络输入。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,input_size]。
-    - **initial_states** (tuple，可选) - 网络的初始状态，一个包含h和c的元组，形状为[num_lauers * num_directions, batch_size, hidden_size]。如果没有给出则会以全零初始化。
-    - **sequence_length** (Tensor，可选) - 指定输入序列的长度，形状为[batch_size]，数据类型为int64或int32。在输入序列中所有time step不小于sequence_length的元素都会被当作填充元素处理（状态不再更新）。
+    - **inputs** (Tensor) - 网络输入。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。
+    - **initial_states** (tuple，可选) - 网络的初始状态，一个包含h和c的元组，形状为[num_layers * num_directions, batch_size, hidden_size]。如果没有给出则会以全零初始化。
+    - **sequence_length** (Tensor，可选) - 指定输入序列的实际长度，形状为[batch_size]，数据类型为int64或int32。在输入序列中所有time step不小于sequence_length的元素都会被当作填充元素处理（状态不再更新）。
 
 输出:
-    - **outputs** (Tensor) - 输出，由前向和后向cell的输出拼接得到。如果time_major为True，则Tensor的形状为[time_steps,batch_size,num_directions * hidden_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,num_directions * hidden_size]，当direction设置为bidirectional时，num_directions等于2，否则等于1。
+    - **outputs** (Tensor) - 输出，由前向和后向cell的输出拼接得到。如果time_major为True，则Tensor的形状为[time_steps,batch_size,num_directions * hidden_size]，如果time_major为False，则Tensor的形状为[batch_size,time_steps,num_directions * hidden_size]，当direction设置为bidirectional时，num_directions等于2，否则等于1。`time_steps` 指输出序列的长度。
     - **final_states** (tuple) - 最终状态，一个包含h和c的元组。形状为[num_layers * num_directions, batch_size, hidden_size]，当direction设置为bidirectional时，num_directions等于2，返回值的前向和后向的状态的索引是0，2，4，6...和1，3，5，7...，否则等于1。
 
 **代码示例**：

--- a/docs/api/paddle/nn/LSTM_cn.rst
+++ b/docs/api/paddle/nn/LSTM_cn.rst
@@ -34,8 +34,8 @@ LSTM
     - :math:`\sigma` ：sigmoid激活函数。
 
 参数：
-    - **input_size** (int) - 输入`x` 的大小。
-    - **hidden_size** (int) - 隐藏状态`h` 大小。
+    - **input_size** (int) - 输入 :math:`x` 的大小。
+    - **hidden_size** (int) - 隐藏状态 :math:`h` 大小。
     - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
     - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
     - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。

--- a/docs/api/paddle/nn/LSTM_cn.rst
+++ b/docs/api/paddle/nn/LSTM_cn.rst
@@ -34,12 +34,12 @@ LSTM
     - :math:`\sigma` ：sigmoid激活函数。
 
 参数：
-    - **input_size** (int) - 输入的大小。
-    - **hidden_size** (int) - 隐藏状态大小。
-    - **num_layers** (int，可选) - 网络层数。默认为1。
-    - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。默认为forward。
-    - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。默认为False。
-    - **dropout** (float，可选) - dropout概率，指的是出第一层外每层输入时的dropout概率。默认为0。
+    - **input_size** (int) - 输入`x`的大小。
+    - **hidden_size** (int) - 隐藏状态`h`大小。
+    - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
+    - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
+    - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。
+    - **dropout** (float，可选) - dropout概率，指的是出第一层外每层输入时的dropout概率。范围为[0, 1]。默认为0。
     - **weight_ih_attr** (ParamAttr，可选) - weight_ih的参数。默认为None。
     - **weight_hh_attr** (ParamAttr，可选) - weight_hh的参数。默认为None。
     - **bias_ih_attr** (ParamAttr，可选) - bias_ih的参数。默认为None。

--- a/docs/api/paddle/nn/LSTM_cn.rst
+++ b/docs/api/paddle/nn/LSTM_cn.rst
@@ -34,8 +34,8 @@ LSTM
     - :math:`\sigma` ：sigmoid激活函数。
 
 参数：
-    - **input_size** (int) - 输入`x`的大小。
-    - **hidden_size** (int) - 隐藏状态`h`大小。
+    - **input_size** (int) - 输入`x` 的大小。
+    - **hidden_size** (int) - 隐藏状态`h` 大小。
     - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
     - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
     - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。

--- a/docs/api/paddle/nn/SimpleRNN_cn.rst
+++ b/docs/api/paddle/nn/SimpleRNN_cn.rst
@@ -20,8 +20,8 @@ SimpleRNN
         y_{t} & = h_{t}
 
 参数：
-    - **input_size** (int) - 输入`x` 的大小。
-    - **hidden_size** (int) - 隐藏状态`h` 大小。
+    - **input_size** (int) - 输入 :math:`x` 的大小。
+    - **hidden_size** (int) - 隐藏状态 :math:`h` 大小。
     - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
     - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
     - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。

--- a/docs/api/paddle/nn/SimpleRNN_cn.rst
+++ b/docs/api/paddle/nn/SimpleRNN_cn.rst
@@ -20,12 +20,12 @@ SimpleRNN
         y_{t} & = h_{t}
 
 参数：
-    - **input_size** (int) - 输入的大小。
-    - **hidden_size** (int) - 隐藏状态大小。
-    - **num_layers** (int，可选) - 网络层数。默认为1。
-    - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。默认为forward。
-    - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。默认为False。
-    - **dropout** (float，可选) - dropout概率，指的是出第一层外每层输入时的dropout概率。默认为0。
+    - **input_size** (int) - 输入`x`的大小。
+    - **hidden_size** (int) - 隐藏状态`h`大小。
+    - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
+    - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
+    - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。
+    - **dropout** (float，可选) - dropout概率，指的是出第一层外每层输入时的dropout概率。范围为[0, 1]。默认为0。
     - **activation** (str, 可选) - 网络中每个单元的激活函数。可以是tanh或relu。默认为tanh。
     - **weight_ih_attr** (ParamAttr，可选) - weight_ih的参数。默认为None。
     - **weight_hh_attr** (ParamAttr，可选) - weight_hh的参数。默认为None。

--- a/docs/api/paddle/nn/SimpleRNN_cn.rst
+++ b/docs/api/paddle/nn/SimpleRNN_cn.rst
@@ -33,12 +33,12 @@ SimpleRNN
     - **bias_hh_attr** (ParamAttr，可选) - bias_hh的参数。默认为None。
     
 输入:
-    - **inputs** (Tensor) - 网络输入。如果time_major为False，则Tensor的形状为[batch_size,time_steps,input_size]，如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]。
-    - **initial_states** (Tensor，可选) - 网络的初始状态，形状为[num_lauers * num_directions, batch_size, hidden_size]。如果没有给出则会以全零初始化。
-    - **sequence_length** (Tensor，可选) - 指定输入序列的长度，形状为[batch_size]，数据类型为int64或int32。在输入序列中所有time step不小于sequence_length的元素都会被当作填充元素处理（状态不再更新）。
+    - **inputs** (Tensor) - 网络输入。如果time_major为False，则Tensor的形状为[batch_size,time_steps,input_size]，如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]。  `time_steps` 指输入序列的长度。
+    - **initial_states** (Tensor，可选) - 网络的初始状态，形状为[num_layers * num_directions, batch_size, hidden_size]。如果没有给出则会以全零初始化。
+    - **sequence_length** (Tensor，可选) - 指定输入序列的实际长度，形状为[batch_size]，数据类型为int64或int32。在输入序列中所有time step不小于sequence_length的元素都会被当作填充元素处理（状态不再更新）。
 
 输出:
-    - **outputs** (Tensor) - 输出，由前向和后向cell的输出拼接得到。如果time_major为False，则Tensor的形状为[batch_size,time_steps,num_directions * hidden_size]，如果time_major为True，则Tensor的形状为[time_steps,batch_size,num_directions * hidden_size]，当direction设置为bidirectional时，num_directions等于2，否则等于1。
+    - **outputs** (Tensor) - 输出，由前向和后向cell的输出拼接得到。如果time_major为False，则Tensor的形状为[batch_size,time_steps,num_directions * hidden_size]，如果time_major为True，则Tensor的形状为[time_steps,batch_size,num_directions * hidden_size]，当direction设置为bidirectional时，num_directions等于2，否则等于1。 `time_steps` 指输出序列的长度。
     - **final_states** (Tensor) - 最终状态。形状为[num_layers * num_directions, batch_size, hidden_size]，当direction设置为bidirectional时，num_directions等于2，返回值的前向和后向的状态的索引是0，2，4，6...和1，3，5，7...，否则等于1。
 
 **代码示例**：

--- a/docs/api/paddle/nn/SimpleRNN_cn.rst
+++ b/docs/api/paddle/nn/SimpleRNN_cn.rst
@@ -20,8 +20,8 @@ SimpleRNN
         y_{t} & = h_{t}
 
 参数：
-    - **input_size** (int) - 输入`x`的大小。
-    - **hidden_size** (int) - 隐藏状态`h`大小。
+    - **input_size** (int) - 输入`x` 的大小。
+    - **hidden_size** (int) - 隐藏状态`h` 大小。
     - **num_layers** (int，可选) - 循环网络的层数。例如，将层数设为2，会将两层GRU网络堆叠在一起，第二层的输入来自第一层的输出。默认为1。
     - **direction** (str，可选) - 网络迭代方向，可设置为forward或bidirect（或bidirectional）。foward指从序列开始到序列结束的单向GRU网络方向，bidirectional指从序列开始到序列结束，又从序列结束到开始的双向GRU网络方向。默认为forward。
     - **time_major** (bool，可选) - 指定input的第一个维度是否是time steps。如果time_major为True，则Tensor的形状为[time_steps,batch_size,input_size]，否则为[batch_size,time_steps,input_size]。`time_steps` 指输入序列的长度。默认为False。

--- a/docs/api/paddle/text/WMT14_cn.rst
+++ b/docs/api/paddle/text/WMT14_cn.rst
@@ -24,6 +24,9 @@ http://paddlemodels.bj.bcebos.com/wmt/wmt14.tgz
 返回值
 :::::::::
 ``Dataset``，WMT14数据集实例。
+  - src_ids (np.array) - 源语言当前的token id序列。
+  - trg_ids (np.array) - 目标语言当前的token id序列。
+  - trg_ids_next (np.array) - 目标语言下一段的token id序列。
 
 代码示例
 :::::::::

--- a/docs/api/paddle/text/WMT16_cn.rst
+++ b/docs/api/paddle/text/WMT16_cn.rst
@@ -26,8 +26,7 @@ Multi30K: Multilingual English-German Image Descriptions.
 
 参数
 :::::::::
-    - data_file（str）- 保存数据集压缩文件的路径，如果参数:attr:`download`设置为True，可设置为None。
-    默认值为None。
+    - data_file（str）- 保存数据集压缩文件的路径，如果参数:attr:`download`设置为True，可设置为None。默认值为None。
     - mode（str）- 'train', 'test' 或 'val'。默认为'train'。
     - src_dict_size（int）- 源语言词典大小。默认为-1。
     - trg_dict_size（int) - 目标语言测点大小。默认为-1。
@@ -36,7 +35,10 @@ Multi30K: Multilingual English-German Image Descriptions.
 
 返回值
 :::::::::
-``Dataset``，WMT16数据集实例。
+``Dataset``，WMT16数据集实例。实例一共有三个字段：
+  - src_ids (np.array) - 源语言当前的token id序列。
+  - trg_ids (np.array) - 目标语言当前的token id序列。
+  - trg_ids_next (np.array) - 目标语言下一段的token id序列。
 
 代码示例
 :::::::::


### PR DESCRIPTION
1. 添加wmt16，wmt14的返回值字段描述
2. 修复RNN API typo，并添加字段描述。

**WMT16**
![image](https://user-images.githubusercontent.com/10826371/159390027-f06cba60-8a1d-4f9d-8d5c-ba9760200f97.png)

**WMT14**
![image](https://user-images.githubusercontent.com/10826371/159390186-1ed46dbb-4cc8-462a-8f66-cee5478a1417.png)

**GRU**
![image](https://user-images.githubusercontent.com/10826371/159390416-c78fc5a9-1229-4f04-b4ba-80e2d2d5087f.png)