### PR TITLE
remove deprecated parameter of mobilenetv3

### DIFF
--- a/docs/api/paddle/vision/models/MobileNetV3Large_cn.rst
+++ b/docs/api/paddle/vision/models/MobileNetV3Large_cn.rst
@@ -3,7 +3,7 @@
 MobileNetV3Large
 -------------------------------
 
-.. py:class:: paddle.vision.models.MobileNetV3Large(scale=1.0, last_channel=1280, num_classes=1000, with_pool=True)
+.. py:class:: paddle.vision.models.MobileNetV3Large(scale=1.0, num_classes=1000, with_pool=True)
 
  MobileNetV3Large模型，来自论文 `"Searching for MobileNetV3" <https://arxiv.org/abs/1905.02244>`_ 。
 

--- a/docs/api/paddle/vision/models/MobileNetV3Small_cn.rst
+++ b/docs/api/paddle/vision/models/MobileNetV3Small_cn.rst
@@ -3,7 +3,7 @@
 MobileNetV3Small
 -------------------------------
 
-.. py:class:: paddle.vision.models.MobileNetV3Small(scale=1.0, last_channel=1280, num_classes=1000, with_pool=True)
+.. py:class:: paddle.vision.models.MobileNetV3Small(scale=1.0, num_classes=1000, with_pool=True)
 
  MobileNetV3Small模型，来自论文 `"Searching for MobileNetV3" <https://arxiv.org/abs/1905.02244>`_ 。
 

--- a/docs/api/paddle/vision/models/mobilenet_v3_large_cn.rst
+++ b/docs/api/paddle/vision/models/mobilenet_v3_large_cn.rst
@@ -3,7 +3,7 @@
 mobilenet_v3_large
 -------------------------------
 
-.. py:function:: paddle.vision.models.mobilenet_v3_large(pretrained=False, scale=1.0, last_channel=1280, **kwargs)
+.. py:function:: paddle.vision.models.mobilenet_v3_large(pretrained=False, scale=1.0, **kwargs)
 
  MobileNetV3Large模型，来自论文 `"Searching for MobileNetV3" <https://arxiv.org/abs/1905.02244>`_ 。
 

--- a/docs/api/paddle/vision/models/mobilenet_v3_small_cn.rst
+++ b/docs/api/paddle/vision/models/mobilenet_v3_small_cn.rst
@@ -3,7 +3,7 @@
 mobilenet_v3_small
 -------------------------------
 
-.. py:function:: paddle.vision.models.mobilenet_v3_small(pretrained=False, scale=1.0, last_channel=1280, **kwargs)
+.. py:function:: paddle.vision.models.mobilenet_v3_small(pretrained=False, scale=1.0, **kwargs)
 
  MobileNetV3Small模型，来自论文 `"Searching for MobileNetV3" <https://arxiv.org/abs/1905.02244>`_ 。
 


### PR DESCRIPTION
移除 `MobileNetV3` 忘记删除的参数 `last_channel`

该参数是早期设计的 API 版本使用的，但后来删除后同步中文文档时忘记修改最上面的参数表了\_(:з」∠)\_，十分抱歉！