### PR TITLE
get pulbic api list by __all__ of module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea
 build
 .vscode
+venv/

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -1,7 +1,5 @@
 import paddle
 import os
-import shutil
-import time
 import pkgutil
 import types
 import contextlib
@@ -17,6 +15,7 @@ import subprocess
 import multiprocessing
 import platform
 import extract_api_from_docs
+from queue import Queue
 """
 generate api_info_dict.json to describe all info about the apis.
 """
@@ -403,101 +402,96 @@ def set_display_attr_of_apis():
                 logger.info("set {} display to False".format(id_api))
 
 
+def check_module_in_black_list(module_name):
+    black_module_list = [
+        'paddle.fluid',
+    ]
+    for i in black_module_list:
+        if i in module_name:
+            return True
+    return False
+
+
+def get_all_modules():
+    """
+    get all modules from paddle
+    :return: module list
+    """
+    module_str_queue = Queue()
+    module_str_queue.put('paddle')
+
+    MODULE_CLS = type(paddle)
+    module_list = []
+    while not module_str_queue.empty():
+        module_name = module_str_queue.get()
+        try:
+            module = importlib.import_module(module_name)
+            module_list.append(module)
+            for sub_module_str in dir(module):
+                if sub_module_str.startswith('_'):
+                    continue
+                full_sub_module_path = '.'.join([module_name, sub_module_str])
+                sub_module = eval(full_sub_module_path)
+                if isinstance(sub_module, MODULE_CLS):
+                    module_str_queue.put(full_sub_module_path)
+        except Exception as e:
+            continue
+
+    return module_list
+
+
+def get_public_modules():
+    """
+    get public modules from paddle
+    :return: module list
+    """
+    public_module_list = []
+    all_modules = get_all_modules()
+    for module in all_modules:
+        if check_module_in_black_list(module.__name__):
+            logger.info('module %s in black module list', module.__name__)
+            continue
+        if hasattr(module, '__all__'):
+            api_in_module = module.__all__
+            if len(api_in_module) == 0:
+                logger.info('API in module %s is empty', module.__name__)
+                continue
+            public_module_list.append(module)
+    return public_module_list
+
+
+def get_api_from_module(module):
+    """
+    get api list from module
+    :param module: module object
+    :return: api list
+    """
+    if not hasattr(module, '__all__'):
+        return []
+    return module.__all__
+
+
 def set_api_sketch():
     """
     set the in_api_sktech attr. may replace the set_display_attr_of_apis.
     """
     global api_info_dict
-    modulelist = [  #noqa
-        paddle,
-        paddle.amp,
-        paddle.nn,
-        paddle.nn.functional,
-        paddle.nn.initializer,
-        paddle.nn.utils,
-        paddle.nn.quant.quant_layers,
-        paddle.static,
-        paddle.static.nn,
-        paddle.static.sparsity,
-        paddle.signal,
-        paddle.io,
-        paddle.jit,
-        paddle.metric,
-        paddle.distribution,
-        paddle.distribution.transform,
-        paddle.distribution.kl,
-        paddle.optimizer,
-        paddle.optimizer.lr,
-        paddle.regularizer,
-        paddle.text,
-        paddle.utils,
-        paddle.utils.download,
-        paddle.utils.profiler,
-        paddle.utils.cpp_extension,
-        paddle.utils.unique_name,
-        paddle.utils.dlpack,
-        paddle.sysconfig,
-        paddle.vision,
-        paddle.vision.datasets,
-        paddle.vision.models,
-        paddle.vision.transforms,
-        paddle.vision.ops,
-        paddle.distributed,
-        paddle.distributed.fleet,
-        paddle.distributed.fleet.utils,
-        paddle.distributed.fleet.base.topology,
-        paddle.distributed.parallel,
-        paddle.distributed.utils,
-        paddle.distributed.passes,
-        paddle.distributed.ps.utils,
-        paddle.distributed.ps.utils.ps_factory,
-        paddle.distributed.ps.the_one_ps,
-        paddle.distributed.sharding,
-        paddle.callbacks,
-        paddle.hub,
-        paddle.autograd,
-        paddle.incubate,
-        paddle.incubate.autograd,
-        paddle.incubate.nn,
-        paddle.incubate.nn.functional,
-        paddle.incubate.optimizer,
-        paddle.incubate.optimizer.functional,
-        paddle.incubate.operators,
-        paddle.incubate.operators.resnet_unit,
-        paddle.inference,
-        paddle.onnx,
-        paddle.device,
-        paddle.device.cuda,
-        paddle.linalg,
-        paddle.fft,
-        paddle.version,
-        paddle.profiler,
-        paddle.sparse,
-    ]
 
-    alldict = {}
-    for module in modulelist:
-        if hasattr(module, '__all__'):
-            old_all = module.__all__
-        else:
-            old_all = []
-            dirall = dir(module)
-            for item in dirall:
-                if item.startswith('__'):
-                    continue
-                old_all.append(item)
-        alldict.update({module.__name__: old_all})
+    module_list = get_public_modules()
+    all_dict = {}
+    for module in module_list:
+        all_dict.update({module.__name__: get_api_from_module(module)})
 
     old_all = []
-    dirall = dir(paddle.Tensor)
-    for item in dirall:
+    dir_all = dir(paddle.Tensor)
+    for item in dir_all:
         if item.startswith('_'):
             continue
         old_all.append(item)
-    alldict.update({'paddle.Tensor': old_all})
+    all_dict.update({'paddle.Tensor': old_all})
 
     all_api_found = {}
-    for m, apis in alldict.items():
+    for m, apis in all_dict.items():
         for api in apis:
             all_api_found['{}.{}'.format(m, api)] = False
 

--- a/docs/api/paddle/metric/Accuracy_cn.rst
+++ b/docs/api/paddle/metric/Accuracy_cn.rst
@@ -1,108 +1,37 @@
-.. _cn_api_metric_Accuracy:
+.. _cn_api_paddle_metric_accuracy:
 
-Accuracy
+accuracy
 -------------------------------
 
-.. py:class:: paddle.metric.Accuracy()
+.. py:function:: paddle.metric.accuracy(input, label, k=1, correct=None, total=None, name=None)
 
-计算准确率(accuracy)。
+accuracy layer。 参考 https://en.wikipedia.org/wiki/Precision_and_recall
 
-参数：
+使用输入和标签计算准确率。 如果正确的标签在topk个预测值里，则计算结果加1。注意：输出正确率的类型由input类型决定，input和lable的类型可以不一样。
+
+参数
 :::::::::
-    - **topk** (list[int]|tuple(int)) - 计算准确率的top个数，默认是(1,)。
-    - **name** (str, optional) - metric实例的名字，默认是'acc'。
+
+    - **input** (Tensor)-数据类型为float32,float64。输入为网络的预测值。shape为 ``[sample_number, class_dim]`` 。
+    - **label** (Tensor)-数据类型为int64，int32。输入为数据集的标签。shape为 ``[sample_number, 1]`` 。
+    - **k** (int64|int32，可选) - 取每个类别中k个预测值用于计算，默认值为1。
+    - **correct** (int64|int32, 可选)-正确预测值的个数，默认值为None。
+    - **total** (int64|int32，可选)-总共的预测值，默认值为None。
+    - **name** (str，可选) – 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为None。
+
+返回
+:::::::::
+
+    ``Tensor``，计算出来的正确率，数据类型为float32的Tensor。
 
 代码示例
 :::::::::
 
-**独立使用示例:**
-        
-    .. code-block:: python
+.. code-block:: python
 
-        import numpy as np
-        import paddle
+    import paddle
 
-        x = paddle.to_tensor(np.array([
-            [0.1, 0.2, 0.3, 0.4],
-            [0.1, 0.4, 0.3, 0.2],
-            [0.1, 0.2, 0.4, 0.3],
-            [0.1, 0.2, 0.3, 0.4]]))
-        y = paddle.to_tensor(np.array([[0], [1], [2], [3]]))
-
-        m = paddle.metric.Accuracy()
-        correct = m.compute(x, y)
-        m.update(correct)
-        res = m.accumulate()
-        print(res) # 0.75
-
-
-**在Model API中的示例**
-        
-    .. code-block:: python
-
-        import paddle
-        from paddle.static import InputSpec
-        import paddle.vision.transforms as T
-        from paddle.vision.datasets import MNIST
-               
-        input = InputSpec([None, 1, 28, 28], 'float32', 'image')
-        label = InputSpec([None, 1], 'int64', 'label')
-        transform = T.Compose([T.Transpose(), T.Normalize([127.5], [127.5])])
-        train_dataset = MNIST(mode='train', transform=transform)
-  
-        model = paddle.Model(paddle.vision.models.LeNet(), input, label)
-        optim = paddle.optimizer.Adam(
-            learning_rate=0.001, parameters=model.parameters())
-        model.prepare(
-            optim,
-            loss=paddle.nn.CrossEntropyLoss(),
-            metrics=paddle.metric.Accuracy())
-  
-        model.fit(train_dataset, batch_size=64)
-
-
-
-compute(pred, label, *args)
-:::::::::
-
-计算top-k（topk中的最大值）的索引。
-
-**参数**
-    
-    - **pred**  (Tensor) - 预测结果为是float64或float32类型的Tensor。shape为[batch_size, d0, ..., dN].
-    - **label**  (Tensor) - 真实的标签值是一个int64类型的Tensor，shape为[batch_size, d0, ..., 1] 或one hot表示的形状[batch_size, d0, ..., num_classes].
-
-**返回**: Tensor，shape是[batch_size, d0, ..., topk], 值为0或1，1表示预测正确.
-
-
-update(pred, label, *args)
-:::::::::
-
-更新metric的状态（正确预测的个数和总个数），以便计算累积的准确率。返回当前step的准确率。
-
-**参数:**
-
-    - **correct** (numpy.array | Tensor): 一个值为0或1的Tensor，shape是[batch_size, d0, ..., topk]。
-
-**返回:** 当前step的准确率。
-
-
-reset()
-:::::::::
-
-清空状态和计算结果。
-
-accumulate()
-:::::::::
-
-累积的统计指标，计算和返回准确率。
-
-**返回:** 准确率，一般是个标量 或 多个标量，和topk的个数一致。
-
-
-name()
-:::::::::
-
-返回Metric实例的名字, 参考上述name，默认是'acc'。
-
-**返回:** 评估的名字，string类型。
+    predictions = paddle.to_tensor([[0.2, 0.1, 0.4, 0.1, 0.1], [0.2, 0.3, 0.1, 0.15, 0.25]], dtype='float32')
+    label = paddle.to_tensor([[2], [0]], dtype="int64")
+    result = paddle.metric.accuracy(input=predictions, label=label, k=1)
+    # [0.5]

--- a/docs/api/paddle/vision/transforms/Normalize_cn.rst
+++ b/docs/api/paddle/vision/transforms/Normalize_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_vision_transforms_Normalize:
+.. _cn_api_vision_transforms_normalize:
 
 Normalize
 -------------------------------

--- a/docs/api/paddle/vision/transforms/Resize_cn.rst
+++ b/docs/api/paddle/vision/transforms/Resize_cn.rst
@@ -26,7 +26,7 @@ resize
             + "area": cv2.INTER_AREA, 
             + "bicubic": cv2.INTER_CUBIC, 
             + "lanczos": cv2.INTER_LANCZOS4。
-
+            
 返回
 :::::::::
 


### PR DESCRIPTION
背景：已有获取公开API的方法，依赖于人工维护的module list，当有新module下的API merge后，需要人工手动将新module加入到module list中，否则无法获取公开API，使数据存在一定滞后性

解决方案：遍历所有的module，如果module有__all__属性，且__all__的值不为空，则该module为公开module，其下的API为公开API

修改点： api/gen_doc.py