### PR TITLE
suport tensor input for ColorJitter

### DIFF
--- a/docs/api/paddle/vision/transforms/adjust_brightness_cn.rst
+++ b/docs/api/paddle/vision/transforms/adjust_brightness_cn.rst
@@ -10,13 +10,13 @@ adjust_brightness
 参数
 :::::::::
 
-    - img (PIL.Image|np.array) - 输入的图像。
+    - img (PIL.Image|np.array|paddle.Tensor) - 输入的图像。
     - brightness_factor (float) - 调节图像亮度值的多少，可以是任何非负数。参数等于0时输出黑色图像，参数等于1时输出原始图像，参数大于1时输出图像亮度增强，如参数等于2时图像亮度增强两倍。
 
 返回
 :::::::::
 
-    ``PIL.Image 或 numpy.ndarray``，调整后的图像。
+    ``PIL.Image 或 numpy.ndarray 或 paddle.Tensor``，调整后的图像。
 
 代码示例
 :::::::::

--- a/docs/api/paddle/vision/transforms/adjust_contrast_cn.rst
+++ b/docs/api/paddle/vision/transforms/adjust_contrast_cn.rst
@@ -10,13 +10,13 @@ adjust_contrast
 参数
 :::::::::
 
-    - img (PIL.Image|np.array) - 输入的图像。
+    - img (PIL.Image|np.array|paddle.Tensor) - 输入的图像。
     - contrast_factor (float) - 调节图像对比度的多少，可以是任何非负数。参数等于0时输出纯灰色图像，参数等于1时输出原始图像，参数大于1时图像对比度增强，如参数等于2时图像对比度增强两倍。
 
 返回
 :::::::::
 
-    ``PIL.Image 或 numpy.ndarray``，调整后的图像。
+    ``PIL.Image 或 numpy.ndarray 或 paddle.Tensor``，调整后的图像。
 
 代码示例
 :::::::::

--- a/docs/api/paddle/vision/transforms/adjust_hue_cn.rst
+++ b/docs/api/paddle/vision/transforms/adjust_hue_cn.rst
@@ -10,13 +10,13 @@ adjust_hue
 参数
 :::::::::
 
-    - img (PIL.Image|np.array) - 输入的图像。
+    - img (PIL.Image|np.array|paddle.Tensor) - 输入的图像。
     - hue_factor (float) - 图像的色调通道的偏移量. 数值应在 ``[-0.5, 0.5]`` 。0.5和-0.5分别表示HSV空间中色相通道正向和负向完全反转，0表示没有调整色调。因此，-0.5和0.5都会给出一个带有互补色的图像，而0则会给出原始图像。
 
 返回
 :::::::::
 
-    ``PIL.Image 或 numpy.ndarray``，调整后的图像。
+    ``PIL.Image 或 numpy.ndarray 或 paddle.Tensor``，调整后的图像。
 
 代码示例
 :::::::::


### PR DESCRIPTION
AS the pr [#42382](https://github.com/PaddlePaddle/Paddle/pull/42382) .` adjust_brightness` / `adjust_contrast` / `adjust_hue` will accept input with type `paddle.Tensor`. This pr changes their cn-doc description.