### PR TITLE
【CI】disable parameter check, first build doc then check

### DIFF
--- a/ci_scripts/check_api_cn.sh
+++ b/ci_scripts/check_api_cn.sh
@@ -46,10 +46,10 @@ else
     for file in $need_check_files;do
         python chinese_samplecode_processor.py ../docs/$file
         if [ $? -ne 0 ];then
-            echo "chinese sample code failed, the file is ${file}"
-            exit 5
+            EXIT_CODE=5
         fi
     done
+    exit ${EXIT_CODE}
 
     #if [ "${need_check_cn_doc_files}" != "" ];then
     #    cd ../docs/paddle/api

--- a/ci_scripts/check_code.sh
+++ b/ci_scripts/check_code.sh
@@ -50,7 +50,9 @@ function check_style(){
         fi
     done
     if [ $commit_files == 'off' ];then
-        echo "code format error"
+        echo "======================================================================="
+        echo "Code style check failed! Please check the error info above carefully."
+        echo "======================================================================="
         exit 1
     fi
     trap 0

--- a/ci_scripts/checkapproval.sh
+++ b/ci_scripts/checkapproval.sh
@@ -16,7 +16,11 @@ for API_FILE in ${API_FILES[*]}; do
   fi
   if [ "${APPROVALS}" == "FALSE" ]; then
     if [ "${API_FILE}" == "docs/api/paddle" ];then
+      set +x
+      echo "=========================================================================================="
       echo "You must have one TPM (jzhang533/ZhangJun or dingjiaweiww/DingJiaWei or TCChenlong/ChenLong or Ligoml/LiMengLiu) approval for the api change! ${API_FILE} for the management reason of API interface and API document."
+      echo "=========================================================================================="
+      set -x
     fi
     exit 1
   fi

--- a/ci_scripts/ci_start.sh
+++ b/ci_scripts/ci_start.sh
@@ -33,26 +33,7 @@ fi
 export PADDLE_WHL
 echo "PADDLE_WHL=${PADDLE_WHL}"
 
-# 2 check code style/format.
-/bin/bash  ${DIR_PATH}/check_code.sh
-if [ $? -ne 0 ];then
-    echo "code format error"
-    exit 1
-fi
-
-need_check_cn_doc_files=$(find_all_cn_api_files_modified_by_pr)
-echo $need_check_cn_doc_files
-# 3 Chinese api docs check
-if [ "${need_check_cn_doc_files}" = "" ] ; then
-    echo "chinese api doc fileslist is empty, skip check."
-else
-    /bin/bash -x ${DIR_PATH}/check_api_cn.sh "${need_check_cn_doc_files}"
-    if [ $? -ne 0 ];then
-        exit 1
-    fi
-fi
-
-# 4 build all the Chinese and English docs, and upload them. Controlled with Env BUILD_DOC and UPLOAD_DOC
+# 2 build all the Chinese and English docs, and upload them. Controlled with Env BUILD_DOC and UPLOAD_DOC
 PREVIEW_URL_PROMPT="ipipe_log_param_preview_url: None"
 if [ "${BUILD_DOC}" = "true" ] &&  [ -x /usr/local/bin/sphinx-build ] ; then
     export OUTPUTDIR=/docs
@@ -98,8 +79,10 @@ if [ "${BUILD_DOC}" = "true" ] &&  [ -x /usr/local/bin/sphinx-build ] ; then
     fi
 fi
 
-if [ "${need_check_cn_doc_files}" = "" ] ; then
-    echo "chinese api doc fileslist is empty, skip check."
+check_parameters=OFF
+if [ "${check_parameters}" = "OFF" ] ; then
+    #echo "chinese api doc fileslist is empty, skip check."
+    echo "check_api_parameters is not stable, close it temporarily."
 else
     jsonfn=${OUTPUTDIR}/en/${VERSIONSTR}/gen_doc_output/api_info_all.json
     if [ -f $jsonfn ] ; then
@@ -113,6 +96,35 @@ else
         exit 1
     fi
 fi
+
+EXIT_CODE=0
+# 3 check code style/format.
+/bin/bash  ${DIR_PATH}/check_code.sh
+if [ $? -ne 0 ];then
+    EXIT_CODE=1
+fi
+
+need_check_cn_doc_files=$(find_all_cn_api_files_modified_by_pr)
+echo $need_check_cn_doc_files
+# 4 Chinese api docs check
+if [ "${need_check_cn_doc_files}" = "" ] ; then
+    echo "chinese api doc fileslist is empty, skip check."
+else
+    /bin/bash -x ${DIR_PATH}/check_api_cn.sh "${need_check_cn_doc_files}"
+    if [ $? -ne 0 ];then
+        EXIT_CODE=1
+    fi
+fi
+
+if [ ${EXIT_CODE} -ne 0 ]; then
+    set +x
+    echo "=========================================================================================="
+    echo "Code style check or API Chinese doc check failed! Please check the error info above carefully."
+    echo "=========================================================================================="
+    set -x
+    exit ${EXIT_CODE}
+fi
+
 # 5 Approval check
 /bin/bash  ${DIR_PATH}/checkapproval.sh
 if [ $? -ne 0 ];then

--- a/ci_scripts/utils.sh
+++ b/ci_scripts/utils.sh
@@ -79,7 +79,7 @@ function get_paddle_pr_num_from_docs_pr_info(){
 function install_paddle() {
     # try to download paddle, and install
     # PADDLE_WHL is defined in ci_start.sh
-    pip install --no-cache-dir -i https://mirror.baidu.com/pypi/simple ${PADDLE_WHL}
+    pip install --no-cache-dir -i https://mirror.baidu.com/pypi/simple ${PADDLE_WHL} 1>nul
     # if failed, build paddle
     if [ $? -ne 0 ];then
         build_paddle


### PR DESCRIPTION
- disable parameter check since it's not stable
- first build doc then check format and sample code so that always build the doc
- improve error info