### PR TITLE
fix missing colon after cn api label

### DIFF
--- a/docs/api/paddle/compat/floor_division_cn.rst
+++ b/docs/api/paddle/compat/floor_division_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_compat_floor_division
+.. _cn_api_paddle_compat_floor_division:
 
 floor_division
 -------------------------------

--- a/docs/api/paddle/compat/get_exception_message_cn.rst
+++ b/docs/api/paddle/compat/get_exception_message_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_compat_get_exception_message
+.. _cn_api_paddle_compat_get_exception_message:
 
 get_exception_message
 -------------------------------

--- a/docs/api/paddle/compat/long_type_cn.rst
+++ b/docs/api/paddle/compat/long_type_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_compat_long_type
+.. _cn_api_paddle_compat_long_type:
 
 long_type
 -------------------------------

--- a/docs/api/paddle/compat/round_cn.rst
+++ b/docs/api/paddle/compat/round_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_compat_round
+.. _cn_api_paddle_compat_round:
 
 round
 -------------------------------

--- a/docs/api/paddle/compat/to_bytes_cn.rst
+++ b/docs/api/paddle/compat/to_bytes_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_compat_to_bytes
+.. _cn_api_paddle_compat_to_bytes:
 
 to_bytes
 -------------------------------

--- a/docs/api/paddle/compat/to_text_cn.rst
+++ b/docs/api/paddle/compat/to_text_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_compat_to_text
+.. _cn_api_paddle_compat_to_text:
 
 to_text
 -------------------------------

--- a/docs/api/paddle/split_cn.rst
+++ b/docs/api/paddle/split_cn.rst
@@ -1,4 +1,5 @@
-.. _cn_api_paddle_tensor_split
+.. _cn_api_paddle_tensor_split:
+
 split
 -------------------------------
 

--- a/docs/api/paddle/sysconfig/get_include_cn.rst
+++ b/docs/api/paddle/sysconfig/get_include_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_sysconfig_get_include
+.. _cn_api_paddle_sysconfig_get_include:
 
 get_include
 -------------------------------

--- a/docs/api/paddle/sysconfig/get_lib_cn.rst
+++ b/docs/api/paddle/sysconfig/get_lib_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_paddle_sysconfig_get_lib
+.. _cn_api_paddle_sysconfig_get_lib:
 
 get_lib
 -------------------------------


### PR DESCRIPTION
emmmm，就是部分中文 API 文档里的 label 忘记了最后的 `:` 啦～

<!-- CheckPRPRPRPRPRPRPRPRPRPRPRPRPRPRPRPRPRPRPRTemplate! -->