### PR TITLE
[Deprecated][hooks] add a pre-commit hook to automatically insert space to cn and en char 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: remove-tabs
         files: \.md$|\.rst$
 -   repo: https://github.com/ShigureLab/dochooks
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
     -   id: check-whitespace-between-cn-and-en-char
         files: \.md$|\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
         files: \.md$
     -   id: remove-tabs
         files: \.md$
+-   repo: https://github.com/ShigureLab/dochooks
+    rev: b88c9f47ad85741d1b9b377a2cbefcd7f8ecc314
+    hooks:
+    -   id: check-whitespace-between-cn-and-en-char
+    -   id: insert-whitespace-between-cn-and-en-char
 -   repo: https://github.com/reyoung/pre-commit-hooks-jinja-compile.git
     rev: 4a369cc72a4a2b8d3813ab8cc17abb5f5b21ef6c
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-yapf.git
-    rev: v0.16.0
+    rev: v0.32.0
     hooks:
     -   id: yapf
         files: \.py$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: a11d9314b22d8f8c7556443875b731ef05965464
+    rev: v4.3.0
     hooks:
     -   id: check-merge-conflict
     -   id: check-symlinks
@@ -16,7 +16,7 @@ repos:
     -   id: trailing-whitespace
         files: \.md$|\.rst$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.0.1
+    rev: v1.3.0
     hooks:
     -   id: forbid-crlf
         files: \.md$|\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: remove-tabs
         files: \.md$|\.rst$
 -   repo: https://github.com/ShigureLab/dochooks
-    rev: b88c9f47ad85741d1b9b377a2cbefcd7f8ecc314
+    rev: v0.2.0
     hooks:
     -   id: check-whitespace-between-cn-and-en-char
         files: \.md$|\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,25 +12,27 @@ repos:
     -   id: detect-private-key
         files: (?!.*paddle)^.*$
     -   id: end-of-file-fixer
-        files: \.md$
+        files: \.md$|\.rst$
     -   id: trailing-whitespace
-        files: \.md$
+        files: \.md$|\.rst$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.0.1
     hooks:
     -   id: forbid-crlf
-        files: \.md$
+        files: \.md$|\.rst$
     -   id: remove-crlf
-        files: \.md$
+        files: \.md$|\.rst$
     -   id: forbid-tabs
-        files: \.md$
+        files: \.md$|\.rst$
     -   id: remove-tabs
-        files: \.md$
+        files: \.md$|\.rst$
 -   repo: https://github.com/ShigureLab/dochooks
     rev: b88c9f47ad85741d1b9b377a2cbefcd7f8ecc314
     hooks:
     -   id: check-whitespace-between-cn-and-en-char
+        files: \.md$|\.rst$
     -   id: insert-whitespace-between-cn-and-en-char
+        files: \.md$|\.rst$
 -   repo: https://github.com/reyoung/pre-commit-hooks-jinja-compile.git
     rev: 4a369cc72a4a2b8d3813ab8cc17abb5f5b21ef6c
     hooks:


### PR DESCRIPTION
添加一个自动向中英文之间添加空格的 hook，详情见 https://github.com/ShigureLab/dochooks

类似 #4973，只不过 #4973 只是一个简单的工具，只能一次性修复过去的问题，无法对以后出现的问题进行规范化

另外就是，初步验证了 hook 的写法，之后可以在 dochooks 里再添加对中文 reStructureText API 文档进行 lint 的 hook，以进一步规范中文 API doc 格式

> **Note**
>
> 该 hook 目前仅支持 Python3.7 及以上（Python3.6 已经 EOL 了，现在大多数主流框架/库都 drop 了 3.6 支持），这可能要求开发者本地环境和 CI 环境（CI 应当没问题）都在 Python3.7+