### PR TITLE
update nanmean_cn.rst test=document_fix

### DIFF
--- a/docs/api/paddle/nanmean_cn.rst
+++ b/docs/api/paddle/nanmean_cn.rst
@@ -1,6 +1,6 @@
 .. _cn_api_tensor_cn_nanmean:
 
-paddle.nanmean
+nanmean
 -------------------------------
 
 .. py:function:: paddle.nanmean(x, axis=None, keepdim=False, name=None)


### PR DESCRIPTION
相关issue：https://github.com/PaddlePaddle/docs/issues/5052
针对paddle.nanmean中英文文档标题不一致问题进行修改：
中文文档：(标题为：paddle.nanmean)
https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nanmean_cn.html
英文文档：(标题为：nanmean)
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/nanmean_en.html
修复办法：将中文文档的paddle.nanmean修改为nanmean