### PR TITLE
docs: fix incorrect `docker run` options in distributed training employment chapter

### DIFF
--- a/docs/guides/06_distributed_training/deployment_cn.rst
+++ b/docs/guides/06_distributed_training/deployment_cn.rst
@@ -52,10 +52,10 @@ paddle 环境安装
 
 .. code-block::
 
-   $ docker run --name paddle -it --host=net -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.2.2-gpu-cuda11.2-cudnn8 /bin/bash
+   $ docker run --name paddle -it --net=host -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.2.2-gpu-cuda11.2-cudnn8 /bin/bash
 
 * 当使用 gpu 时请配置 nvidia docker runtime 或使用 nvidia-docker 启动容器，进入容器后使用 nvidia-smi 命令确认环境正确
-* 使用分布式时需要添加 --host=net 参数让容器使用主机网络以实现跨机建立连接
+* 使用分布式时需要添加 --net=host 参数让容器使用主机网络以实现跨机建立连接
 
 安装后，运行以下命令
 


### PR DESCRIPTION
This fix is patched to distributed training employment chapter.