### PR TITLE
Update all_reduce docs & fix typo

### DIFF
--- a/docs/api/paddle/distributed/all_reduce_cn.rst
+++ b/docs/api/paddle/distributed/all_reduce_cn.rst
@@ -17,8 +17,8 @@ all_reduce
 
 参数
 :::::::::
-    - tensor (Tensor) - 操作的输入 Tensor，同时也会将归约结果返回至此 Tensor 中。Tensor 的数据类型为：float16、float32、float64、int32、int64。
-    - op (ReduceOp.SUM|ReduceOp.MAX|ReduceOp.Min|ReduceOp.PROD，可选) - 归约的具体操作，比如求和，取最大值，取最小值和求乘积，默认为求和归约。
+    - tensor (Tensor) - 操作的输入 Tensor，同时也会将归约结果返回至此 Tensor 中。Tensor 的数据类型为：float16、float32、float64、int32、int64、int8、uint8、bool。
+    - op (ReduceOp.SUM|ReduceOp.MAX|ReduceOp.MIN|ReduceOp.PROD，可选) - 归约的具体操作，比如求和，取最大值，取最小值和求乘积，默认为求和归约。
     - group (int，可选) - 工作的进程组编号，默认为 0。
 
 返回

--- a/docs/api/paddle/distributed/reduce_cn.rst
+++ b/docs/api/paddle/distributed/reduce_cn.rst
@@ -19,7 +19,7 @@ reduce
 :::::::::
     - tensor (Tensor) - 操作的输入 Tensor，结果返回至目标进程号的 Tensor 中。Tensor 的数据类型为：float16、float32、float64、int32、int64。
     - dst (int) - 返回操作结果的目标进程编号。
-    - op (ReduceOp.SUM|ReduceOp.MAX|ReduceOp.Min|ReduceOp.PROD，可选) - 归约的具体操作，比如求和，取最大值，取最小值和求乘积，默认为求和归约。
+    - op (ReduceOp.SUM|ReduceOp.MAX|ReduceOp.MIN|ReduceOp.PROD，可选) - 归约的具体操作，比如求和，取最大值，取最小值和求乘积，默认为求和归约。
     - group (int，可选) - 工作的进程组编号，默认为 0。
 
 返回

--- a/docs/api/paddle/distributed/reduce_scatter_cn.rst
+++ b/docs/api/paddle/distributed/reduce_scatter_cn.rst
@@ -11,7 +11,7 @@ reduce_scatter
 :::::::::
     - tensor (Tensor) – 输出的张量。
     - tensor_list (list(Tensor)) – 归约和切分的张量列表。
-    - op (ReduceOp.SUM|ReduceOp.MAX|ReduceOp.Min|ReduceOp.PROD) – 操作类型，默认 ReduceOp.SUM。
+    - op (ReduceOp.SUM|ReduceOp.MAX|ReduceOp.MIN|ReduceOp.PROD) – 操作类型，默认 ReduceOp.SUM。
     - group: (Group, optional) – 通信组；如果是 None，则使用默认通信组。
     - use_calc_stream: (bool, optional) – 决定是在计算流还是通信流上做该通信操作；默认为 True，表示在计算流。
 


### PR DESCRIPTION
1. 修改paddle.distributed.all_reduce的中文文档。
2. 修正paddle.distributed.all_reduce、paddle.distributed.reduce、paddle.distributed.reduce_scatter的笔误。

该算子的实现PR为https://github.com/PaddlePaddle/Paddle/pull/45440
PADDLEPADDLE_PR=45440