### PR TITLE
Update default value of clip_extra in save_inference_model

### DIFF
--- a/docs/api/paddle/static/save_inference_model_cn.rst
+++ b/docs/api/paddle/static/save_inference_model_cn.rst
@@ -23,7 +23,7 @@ save_inference_model
 
       - **program** - 自定义一个 program，默认使用 default_main_program。
 
-      - **clip_extra** - 保存模型 program 时是否对每个算子附加额外的参数进行裁剪，默认值为 True，即默认会裁剪掉算子非标准定义的参数。
+      - **clip_extra** - 保存模型 program 时是否对每个算子附加额外的参数进行裁剪，默认值为 True（即默认会裁剪掉算子非标准定义的参数）。
 
 
 返回

--- a/docs/api/paddle/static/save_inference_model_cn.rst
+++ b/docs/api/paddle/static/save_inference_model_cn.rst
@@ -23,7 +23,7 @@ save_inference_model
 
       - **program** - 自定义一个 program，默认使用 default_main_program。
 
-      - **clip_extra** - 如果你想为每个算子附加额外的信息，则设置为 True。
+      - **clip_extra** - 保存模型 program 时是否对每个算子附加额外的参数进行裁剪，默认值为 True，即默认会裁剪掉算子非标准定义的参数。
 
 
 返回


### PR DESCRIPTION
`save_inference_model`接口`clip_extra`参数的默认值由False修改为True。

相关PR：[PR46151](https://github.com/PaddlePaddle/Paddle/pull/46151), [PR46456](https://github.com/PaddlePaddle/Paddle/pull/46456)