### PR TITLE
Update hyperlink in Chinese Overview doc

### DIFF
--- a/docs/dev_guides/Overview_cn.md
+++ b/docs/dev_guides/Overview_cn.md
@@ -6,8 +6,8 @@
 
 - [新建一个 ISSUE 来反馈 bug](https://github.com/PaddlePaddle/Paddle/issues/new/choose)
 - [新建一个 ISSUE 来提出新功能需求](https://github.com/PaddlePaddle/Paddle/issues/new/choose)
-- [提 PR 来修复一个 bug](https://www.paddlepaddle.org.cn/documentation/docs/zh/dev_guides/git_guides/submit_pr_guide_cn.html)
-- [提 PR 来实现一个新功能](https://www.paddlepaddle.org.cn/documentation/docs/zh/dev_guides/git_guides/submit_pr_guide_cn.html)
+- [提 PR 来修复一个 bug](https://paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/code_contributing_path_cn.html)
+- [提 PR 来实现一个新功能](https://paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/code_contributing_path_cn.html)
 - [优化我们的文档](https://github.com/PaddlePaddle/docs/wiki/%E6%96%87%E6%A1%A3%E8%B4%A1%E7%8C%AE%E6%8C%87%E5%8D%97)
 
 感谢你对飞桨开源项目的贡献！

--- a/docs/dev_guides/Overview_cn.md
+++ b/docs/dev_guides/Overview_cn.md
@@ -6,8 +6,8 @@
 
 - [新建一个 ISSUE 来反馈 bug](https://github.com/PaddlePaddle/Paddle/issues/new/choose)
 - [新建一个 ISSUE 来提出新功能需求](https://github.com/PaddlePaddle/Paddle/issues/new/choose)
-- [提 PR 来修复一个 bug](https://paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/code_contributing_path_cn.html)
-- [提 PR 来实现一个新功能](https://paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/code_contributing_path_cn.html)
+- [提 PR 来修复一个 bug](./code_contributing_path_cn.html)
+- [提 PR 来实现一个新功能](./code_contributing_path_cn.html)
 - [优化我们的文档](https://github.com/PaddlePaddle/docs/wiki/%E6%96%87%E6%A1%A3%E8%B4%A1%E7%8C%AE%E6%8C%87%E5%8D%97)
 
 感谢你对飞桨开源项目的贡献！

--- a/docs/dev_guides/Overview_cn.md
+++ b/docs/dev_guides/Overview_cn.md
@@ -6,8 +6,8 @@
 
 - [新建一个 ISSUE 来反馈 bug](https://github.com/PaddlePaddle/Paddle/issues/new/choose)
 - [新建一个 ISSUE 来提出新功能需求](https://github.com/PaddlePaddle/Paddle/issues/new/choose)
-- [提 PR 来修复一个 bug](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/10_contribution/local_dev_guide_cn.html)
-- [提 PR 来实现一个新功能](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/10_contribution/local_dev_guide_cn.html)
+- [提 PR 来修复一个 bug](https://www.paddlepaddle.org.cn/documentation/docs/zh/dev_guides/git_guides/submit_pr_guide_cn.html)
+- [提 PR 来实现一个新功能](https://www.paddlepaddle.org.cn/documentation/docs/zh/dev_guides/git_guides/submit_pr_guide_cn.html)
 - [优化我们的文档](https://github.com/PaddlePaddle/docs/wiki/%E6%96%87%E6%A1%A3%E8%B4%A1%E7%8C%AE%E6%8C%87%E5%8D%97)
 
 感谢你对飞桨开源项目的贡献！


### PR DESCRIPTION
中文概述处 
[提PR来修复一个bug](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/10_contribution/local_dev_guide_cn.html)
以及
[提PR来实现一个新功能](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/10_contribution/local_dev_guide_cn.html)
的超链接会跳转至使用指南，使用逻辑上容易造成疑惑和混乱。将这两处的超链接修改为文档中PR指南的链接
https://www.paddlepaddle.org.cn/documentation/docs/zh/dev_guides/git_guides/submit_pr_guide_cn.html
更符合中文使用逻辑

fixes #5308