### PR TITLE
将paddle.audio添加到no-inherited名单中

### DIFF
--- a/docs/api/api_aliases.ini
+++ b/docs/api/api_aliases.ini
@@ -4,3 +4,4 @@ help_zh=左侧是target name，右侧是origin name， 如paddle.device.cuda.Eve
 [en]
 paddle.device.cuda.Event=paddle.fluid.core_avx.CUDAEvent
 paddle.device.cuda.Stream=paddle.fluid.core_avx.CUDAStream
+paddle.no_grad=paddle.fluid.dygraph.base.no_grad_

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -779,6 +779,7 @@ class EnDocGenerator(object):
                 'paddle.nn',
                 'paddle.incubate.nn',
                 'paddle.incubate.sparse.nn',
+                'paddle.audio',
         ]:
             if self.api_name.startswith(m):
                 tmpl = 'no-inherited'


### PR DESCRIPTION
在 gen_docs.py 中，设置了某些目录的文档编译采用非继承关系，由于paddle.audio是新的目录，没有加到这里，导致目前的 paddle.audio 文档中引入大量父类文档
现将 paddle.audio 加入到no-inherited 名单中，可以解决该目录下文档编译的问题
引发的问题是，后续新的目录，如何处理，这个逻辑隐藏的挺深的