### PR TITLE
2.4.0 docs update: del suffix rc0 and many slight modify.

### DIFF
--- a/docs/install/Tables.md
+++ b/docs/install/Tables.md
@@ -320,11 +320,11 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
     </thead>
     <tbody>
     <tr>
-        <td> paddlepaddle==[版本号] 例如 paddlepaddle==2.4.0rc0 </td>
+        <td> paddlepaddle==[版本号] 例如 paddlepaddle==2.4.0 </td>
         <td> 只支持 CPU 对应版本的 PaddlePaddle，具体版本请参见<a href=https://pypi.org/project/paddlepaddle/#history>Pypi</a> </td>
     </tr>
     <tr>
-        <td> paddlepaddle-gpu==[版本号] 例如 paddlepaddle-gpu==2.4.0rc0 </td>
+        <td> paddlepaddle-gpu==[版本号] 例如 paddlepaddle-gpu==2.4.0 </td>
         <td> 默认安装支持 CUDA 10.2 和 cuDNN 7 的对应[版本号]的 PaddlePaddle 安装包 </td>
     </tr>
    </tbody>
@@ -334,7 +334,7 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
 您可以在 [Release History](https://pypi.org/project/paddlepaddle-gpu/#history) 中找到 PaddlePaddle-gpu 的各个发行版本。
 > 其中`postXX` 对应的是 CUDA 和 cuDNN 的版本，`postXX`之前的数字代表 Paddle 的版本
 
-需要注意的是，命令中<code> paddlepaddle-gpu==2.4.0rc0 </code> 在 windows 环境下，会默认安装支持 CUDA 10.2 和 cuDNN 7 的对应[版本号]的 PaddlePaddle 安装包
+需要注意的是，命令中<code> paddlepaddle-gpu==2.4.0 </code> 在 windows 环境下，会默认安装支持 CUDA 10.2 和 cuDNN 7 的对应[版本号]的 PaddlePaddle 安装包
 
 <a name="ciwhls-release"></a>
 </br></br>
@@ -356,17 +356,17 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
     <tbody>
     <tr>
         <td> cpu-mkl-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp39-cp39-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp310-cp310-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.4.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.4.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp39-cp39-linux_x86_64.whl"> paddlepaddle-2.4.0-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp310-cp310-linux_x86_64.whl"> paddlepaddle-2.4.0-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cpu-openblas-avx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-openblas-avx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-openblas-avx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -374,7 +374,7 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
         <td> cpu-mkl-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-noavx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-noavx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -382,156 +382,121 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
         <td> cpu-openblas-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> cuda10.1-cudnn7-mkl-gcc5.4-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
-        <td> cuda10.1-cudnn7-mkl-gcc5.4-noavx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-noavx/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-openblas-noavx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
         <td> cuda10.2-cudnn7-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda10.2-cudnn7-mkl-gcc8.2-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-noavx/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-noavx/paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> cuda11.1-cudnn8.1-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.2-cudnn8.1-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.6-cudnn8.4-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.7-cudnn8.4-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> macos-cpu-openblas </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl">
-        paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl">
+        paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
     </tr>
     <tr>
         <td> macos-cpu-openblas-noavx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl">
-        paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl">
+        paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
     </tr>
     <tr>
         <td> macos-cpu-openblas-m1 </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0rc0-cp38-cp38-macosx_11_0_arm64.whl">
-        paddlepaddle-2.4.0rc0-cp38-cp38-macosx_11_0_arm64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0rc0-cp39-cp39-macosx_11_0_arm64.whl">
-        paddlepaddle-2.4.0rc0-cp39-cp39-macosx_11_0_arm64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0rc0-cp310-cp310-macosx_11_0_arm64.whl">
-        paddlepaddle-2.4.0rc0-cp310-cp310-macosx_11_0_arm64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0-cp38-cp38-macosx_11_0_arm64.whl">
+        paddlepaddle-2.4.0-cp38-cp38-macosx_11_0_arm64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0-cp39-cp39-macosx_11_0_arm64.whl">
+        paddlepaddle-2.4.0-cp39-cp39-macosx_11_0_arm64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0-cp310-cp310-macosx_11_0_arm64.whl">
+        paddlepaddle-2.4.0-cp310-cp310-macosx_11_0_arm64.whl</a></td>
     </tr>
     <tr>
         <td> win-cpu-mkl-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp36-cp36m-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp37-cp37m-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp39-cp39-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp310-cp310-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp36-cp36m-win_amd64.whl"> paddlepaddle-2.4.0-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp37-cp37m-win_amd64.whl"> paddlepaddle-2.4.0-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp39-cp39-win_amd64.whl"> paddlepaddle-2.4.0-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp310-cp310-win_amd64.whl"> paddlepaddle-2.4.0-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cpu-mkl-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-noavx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-noavx-mkl-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -539,7 +504,7 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
         <td> win-cpu-openblas-avx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-openblas-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-openblas-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -547,65 +512,41 @@ PaddePaddle 通过编译时指定路径来实现引用各种 BLAS/CUDA/cuDNN 库
         <td> win-cpu-openblas-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-noavx-openblas-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-noavx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-noavx-openblas-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
         <td> win-cuda10.2-cudnn7-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda10.2-cudnn7-mkl-vs2017-noavx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda11.1-cudnn8.1-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda11.2-cudnn8.2-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda11.6-cudnn8.4-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp310-cp310-win_amd64.whl</a></td>
     </tr>
    </tbody>
 </table>
@@ -674,13 +615,6 @@ platform tag: 类似 'linux_x86_64', 'any'
         <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.1-cudnn7-mkl-gcc5.4 </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp39-cp39-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp310-cp310-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp310-cp310-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
         <td> cuda10.2-cudnn7-mkl </td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post102-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post102-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
@@ -693,13 +627,6 @@ platform tag: 类似 'linux_x86_64', 'any'
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.0-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post110-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.0-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post110-cp39-cp39-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp39-cp39-linux_x86_64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.0-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post110-cp310-cp310-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp310-cp310-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
-        <td> cuda11.1-cudnn8.1-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp39-cp39-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp310-cp310-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.2-cudnn8.1-mkl </td>
@@ -751,20 +678,6 @@ platform tag: 类似 'linux_x86_64', 'any'
         <td> - </td>
     </tr>
     <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-latest-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-latest-cp39-cp39-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-noavx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-noavx/paddlepaddle_gpu-0.0.0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
-        <td> - </td>
-    </tr>
-    <tr>
         <td> win-cuda10.2-cudnn7-mkl-vs2017-avx </td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post102-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-latest-cp36-cp36m-win_amd64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post102-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
@@ -777,13 +690,6 @@ platform tag: 类似 'linux_x86_64', 'any'
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-noavx/paddlepaddle_gpu-0.0.0.post102-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-noavx/paddlepaddle_gpu-0.0.0.post102-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda11.1-cudnn8.1-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-latest-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-latest-cp39-cp39-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda11.2-cudnn8.2-mkl-vs2017-avx </td>

--- a/docs/install/Tables_en.md
+++ b/docs/install/Tables_en.md
@@ -220,11 +220,11 @@ PaddePaddle implements references to various BLAS/CUDA/cuDNN libraries by specif
     </thead>
     <tbody>
     <tr>
-        <td> paddlepaddle==[version code] such as paddlepaddle==2.4.0rc0 </td>
+        <td> paddlepaddle==[version code] such as paddlepaddle==2.4.0 </td>
         <td> Only support the corresponding version of the CPU PaddlePaddle, please refer to <a href=https://pypi.org/project/paddlepaddle/#history>Pypi</a> for the specific version. </td>
     </tr>
     <tr>
-        <td> paddlepaddle-gpu==[version code], such as paddlepaddle-gpu==2.4.0rc0 </td>
+        <td> paddlepaddle-gpu==[version code], such as paddlepaddle-gpu==2.4.0 </td>
         <td> The default installation supports the PaddlePaddle installation package corresponding to [version number] of CUDA 10.2 and cuDNN 7 </td>
     </tr>
    </tbody>
@@ -234,7 +234,7 @@ PaddePaddle implements references to various BLAS/CUDA/cuDNN libraries by specif
 You can find various distributions of PaddlePaddle-gpu in [the Release History](https://pypi.org/project/paddlepaddle-gpu/#history).
 > 'postxx' corresponds to CUDA and cuDNN versions, and the number before 'postxx' represents the version of Paddle
 
-Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0rc0 </code> will install the installation package of PaddlePaddle that supports CUDA 10.2 and cuDNN 7 by default under Windows environment.
+Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0 </code> will install the installation package of PaddlePaddle that supports CUDA 10.2 and cuDNN 7 by default under Windows environment.
 
 
 <a name="ciwhls-release"></a>
@@ -258,17 +258,17 @@ Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0rc0 </code> wil
     <tbody>
     <tr>
         <td> cpu-mkl-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp39-cp39-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0rc0-cp310-cp310-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp36-cp36m-linux_x86_64.whl"> paddlepaddle-2.4.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp37-cp37m-linux_x86_64.whl"> paddlepaddle-2.4.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp39-cp39-linux_x86_64.whl"> paddlepaddle-2.4.0-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-avx/paddlepaddle-2.4.0-cp310-cp310-linux_x86_64.whl"> paddlepaddle-2.4.0-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cpu-openblas-avx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-openblas-avx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-openblas-avx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -276,7 +276,7 @@ Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0rc0 </code> wil
         <td> cpu-mkl-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-mkl-noavx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-mkl-noavx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -284,156 +284,121 @@ Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0rc0 </code> wil
         <td> cpu-openblas-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
-    <tr>
-        <td> cuda10.1-cudnn7-mkl-gcc5.4-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
-        <td> cuda10.1-cudnn7-mkl-gcc5.4-noavx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-noavx/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-cpu-openblas-noavx/paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl"> paddlepaddle-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
         <td> cuda10.2-cudnn7-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda10.2-cudnn7-mkl-gcc8.2-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-noavx/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-noavx/paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0-cp38-cp38-linux_x86_64.whl</a></td>
         <td> - </td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> cuda11.1-cudnn8.1-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.2-cudnn8.1-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post112-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post112-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.6-cudnn8.4-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.6-cudnn8.4.0-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post116-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post116-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.7-cudnn8.4-mkl-gcc8.2-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp36-cp36m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp36-cp36m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp37-cp37m-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp38-cp38-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp39-cp39-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0rc0.post117-cp310-cp310-linux_x86_64.whl">
-        paddlepaddle_gpu-2.4.0rc0.post117-cp310-cp310-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp36-cp36m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp36-cp36m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp37-cp37m-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp37-cp37m-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp38-cp38-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp38-cp38-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp39-cp39-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp39-cp39-linux_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/linux/linux-gpu-cuda11.7-cudnn8.4.1-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.0.post117-cp310-cp310-linux_x86_64.whl">
+        paddlepaddle_gpu-2.4.0.post117-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> macos-cpu-openblas </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas/paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl">
-        paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas/paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl">
+        paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
     </tr>
     <tr>
         <td> macos-cpu-openblas-noavx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl">
-        paddlepaddle-2.4.0rc0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl">
-        paddlepaddle-2.4.0rc0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl">
-        paddlepaddle-2.4.0rc0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp36-cp36m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl">
+        paddlepaddle-2.4.0-cp37-cp37m-macosx_10_6_intel.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp38-cp38-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl">
+        paddlepaddle-2.4.0-cp39-cp39-macosx_10_14_x86_64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-noavx/paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl">
+        paddlepaddle-2.4.0-cp310-cp310-macosx_10_14_universal2.whl</a></td>
     </tr>
     <tr>
         <td> macos-cpu-openblas-m1 </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0rc0-cp38-cp38-macosx_11_0_arm64.whl">
-        paddlepaddle-2.4.0rc0-cp38-cp38-macosx_11_0_arm64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0rc0-cp39-cp39-macosx_11_0_arm64.whl">
-        paddlepaddle-2.4.0rc0-cp39-cp39-macosx_11_0_arm64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0rc0-cp310-cp310-macosx_11_0_arm64.whl">
-        paddlepaddle-2.4.0rc0-cp310-cp310-macosx_11_0_arm64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0-cp38-cp38-macosx_11_0_arm64.whl">
+        paddlepaddle-2.4.0-cp38-cp38-macosx_11_0_arm64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0-cp39-cp39-macosx_11_0_arm64.whl">
+        paddlepaddle-2.4.0-cp39-cp39-macosx_11_0_arm64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/macos/macos-cpu-openblas-m1/paddlepaddle-2.4.0-cp310-cp310-macosx_11_0_arm64.whl">
+        paddlepaddle-2.4.0-cp310-cp310-macosx_11_0_arm64.whl</a></td>
     </tr>
     <tr>
         <td> win-cpu-mkl-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp36-cp36m-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp37-cp37m-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp39-cp39-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp310-cp310-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp36-cp36m-win_amd64.whl"> paddlepaddle-2.4.0-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp37-cp37m-win_amd64.whl"> paddlepaddle-2.4.0-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp39-cp39-win_amd64.whl"> paddlepaddle-2.4.0-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-mkl-vs2017/paddlepaddle-2.4.0-cp310-cp310-win_amd64.whl"> paddlepaddle-2.4.0-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cpu-mkl-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-noavx-mkl-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-noavx-mkl-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -441,7 +406,7 @@ Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0rc0 </code> wil
         <td> win-cpu-openblas-avx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-avx-openblas-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-avx-openblas-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
@@ -449,65 +414,42 @@ Please note that: in the commands, <code> paddlepaddle-gpu==2.4.0rc0 </code> wil
         <td> win-cpu-openblas-noavx </td>
         <td> - </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-cpu-noavx-openblas-vs2017/paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-cpu-noavx-openblas-vs2017/paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
     </tr>
     <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp310-cp310-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-noavx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.1-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post101-cp38-cp38-win_amd64.whl</a></td>
-        <td> - </td>
-        <td> - </td>
-    </tr>
     <tr>
         <td> win-cuda10.2-cudnn7-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda10.2-cudnn7-mkl-vs2017-noavx </td>
         <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda10.2-cudnn7.6.5-mkl-noavx-vs2017/paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda11.1-cudnn8.1-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.1-cudnn8.1.1-mkl-avx-vs2017/paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post111-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda11.2-cudnn8.2-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post112-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.2-cudnn8.2.1-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post112-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post112-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda11.6-cudnn8.4-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp39-cp39-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0-rc0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0rc0.post116-cp310-cp310-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp36-cp36m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp37-cp37m-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp38-cp38-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp39-cp39-win_amd64.whl</a></td>
+        <td> <a href="https://paddle-wheel.bj.bcebos.com/2.4.0/windows/windows-gpu-cuda11.6-cudnn8.4.0-mkl-avx-vs2019/paddlepaddle_gpu-2.4.0.post116-cp310-cp310-win_amd64.whl"> paddlepaddle_gpu-2.4.0.post116-cp310-cp310-win_amd64.whl</a></td>
     </tr>
     </tbody>
 </table>
@@ -580,13 +522,6 @@ platform tag: similar to 'linux_x86_64', 'any'
         <td> - </td>
     </tr>
     <tr>
-        <td> cuda10.1-cudnn7-mkl-gcc5.4 </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp39-cp39-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/paddlepaddle_gpu-0.0.0.post101-cp310-cp310-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp310-cp310-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
         <td> cuda10.2-cudnn7-mkl </td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post102-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-linux_x86_64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.2-cudnn7-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post102-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
@@ -599,13 +534,6 @@ platform tag: similar to 'linux_x86_64', 'any'
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.0-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post110-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.0-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post110-cp39-cp39-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp39-cp39-linux_x86_64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.0-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post110-cp310-cp310-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp310-cp310-linux_x86_64.whl</a></td>
-    </tr>
-    <tr>
-        <td> cuda11.1-cudnn8.1-mkl </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp37-cp37m-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp38-cp38-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp38-cp38-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp39-cp39-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp39-cp39-linux_x86_64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda11.1-cudnn8.1-mkl-gcc8.2-avx/paddlepaddle_gpu-0.0.0.post111-cp310-cp310-linux_x86_64.whl"> paddlepaddle_gpu-latest-cp310-cp310-linux_x86_64.whl</a></td>
     </tr>
     <tr>
         <td> cuda11.2-cudnn8.1-mkl </td>
@@ -657,20 +585,6 @@ platform tag: similar to 'linux_x86_64', 'any'
         <td> - </td>
     </tr>
     <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-latest-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post101-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-latest-cp39-cp39-win_amd64.whl</a></td>
-    </tr>
-    <tr>
-        <td> win-cuda10.1-cudnn7-mkl-vs2017-noavx </td>
-        <td> - </td>
-        <td> - </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.1-cudnn7-mkl-vs2017-noavx/paddlepaddle_gpu-0.0.0.post101-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
-        <td> - </td>
-    </tr>
-    <tr>
         <td> win-cuda10.2-cudnn7-mkl-vs2017-avx </td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post102-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-latest-cp36-cp36m-win_amd64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post102-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
@@ -683,13 +597,6 @@ platform tag: similar to 'linux_x86_64', 'any'
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-noavx/paddlepaddle_gpu-0.0.0.post102-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
         <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda10.2-cudnn7-mkl-vs2017-noavx/paddlepaddle_gpu-0.0.0.post102-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
         <td> - </td>
-    </tr>
-    <tr>
-        <td> win-cuda11.1-cudnn8.1-mkl-vs2017-avx </td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp36-cp36m-win_amd64.whl"> paddlepaddle_gpu-latest-cp36-cp36m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp37-cp37m-win_amd64.whl"> paddlepaddle_gpu-latest-cp37-cp37m-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp38-cp38-win_amd64.whl"> paddlepaddle_gpu-latest-cp38-cp38-win_amd64.whl</a></td>
-        <td> <a href="https://paddle-wheel.bj.bcebos.com/develop/windows/gpu-cuda11.1-cudnn8-mkl-vs2017-avx/paddlepaddle_gpu-0.0.0.post111-cp39-cp39-win_amd64.whl"> paddlepaddle_gpu-latest-cp39-cp39-win_amd64.whl</a></td>
     </tr>
     <tr>
         <td> win-cuda11.2-cudnn8.2-mkl-vs2017-avx </td>

--- a/docs/install/conda/linux-conda.md
+++ b/docs/install/conda/linux-conda.md
@@ -5,12 +5,6 @@
 
 ## 一、环境准备
 
-在进行 PaddlePaddle 安装之前请确保您的 Anaconda 软件环境已经正确安装。软件下载和安装参见 Anaconda 官网(https://www.anaconda.com/)。在您已经正确安装 Anaconda 的情况下请按照下列步骤安装 PaddlePaddle。
-
-* CentOS 7 / Ubuntu16.04 / Ubuntu18.04 / Ubuntu20.04 / Ubuntu22.04 (64bit)
-* GPU 版本支持 CUDA 10.1/10.2/11.2/11.6
-* conda 版本 4.8.3+ (64 bit)
-
 ### 1.1 创建虚拟环境
 
 #### 1.1.1 安装环境
@@ -122,7 +116,7 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 如果您的计算机没有 NVIDIA® GPU，请安装 CPU 版的 PaddlePaddle
 
 ```
-conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
@@ -130,29 +124,23 @@ conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu
 #### GPU 版的 PaddlePaddle
 
 
-*  对于 `CUDA 10.1`，需要搭配 cuDNN 7 (cuDNN>=7.6.5, 多卡环境下 NCCL>=2.7)，安装命令为:
+*  对于 `CUDA 10.2`，需要搭配 cuDNN 7.6.5(多卡环境下 NCCL>=2.7)，安装命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-  ```
-
-*  对于 `CUDA 10.2`，需要搭配 cuDNN 7 (cuDNN>=7.6.5, 多卡环境下 NCCL>=2.7)，安装命令为:
-
-  ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 
-*  对于 `CUDA 11.2`，需要搭配 cuDNN 8.1.1(多卡环境下 NCCL>=2.7)，安装命令为:
+*  对于 `CUDA 11.2`，需要搭配 cuDNN 8.2.1(多卡环境下 NCCL>=2.7)，安装命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 *  对于 `CUDA 11.6`，需要搭配 cuDNN 8.4.0(多卡环境下 NCCL>=2.7)，安装命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 您可参考 NVIDIA 官方文档了解 CUDA 和 CUDNN 的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)

--- a/docs/install/conda/linux-conda.md
+++ b/docs/install/conda/linux-conda.md
@@ -143,6 +143,12 @@ conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn
   conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
+*  对于 `CUDA 11.7`，需要搭配 cuDNN 8.4.1(多卡环境下 NCCL>=2.7)，安装命令为:
+
+  ```
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.7 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  ```
+
 您可参考 NVIDIA 官方文档了解 CUDA 和 CUDNN 的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 

--- a/docs/install/conda/linux-conda_en.md
+++ b/docs/install/conda/linux-conda_en.md
@@ -5,13 +5,6 @@
 
 ## Environmental preparation
 
-Before performing PaddlePaddle installation, please make sure that your Anaconda software environment is properly installed. For software download and installation, see Anaconda's official website (https://www.anaconda.com/). If you have installed Anaconda correctly, follow these steps to install PaddlePaddle.
-
-* CentOS 7 / Ubuntu16.04 / Ubuntu18.04 / Ubuntu20.04 / Ubuntu22.04 (64bit)
-* GPU Version support CUDA 10.1/10.2/11.2/11.6
-* conda version 4.8.3+ (64 bit)
-
-
 ### 1.1 Create Virtual Environment
 
 #### 1.1.1 Create the Anaconda Virtual Environment
@@ -126,7 +119,7 @@ You can choose the following version of PaddlePaddle to start installation:
 If your computer doesn't have NVIDIA® GPU, please install `the CPU Version of PaddlePaddle`
 
 ```
-conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
@@ -134,28 +127,22 @@ conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu
 #### GPU Version of PaddlePaddle
 
 
-*  If you are using CUDA 10.1，cuDNN 7 (cuDNN>=7.6.5, for multi card support, NCCL>=2.7):
+*  If you are usingCUDA 10.2，cuDNN 7.6.5(for multi card support, NCCL>=2.7):
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  If you are usingCUDA 10.2，cuDNN 7 (cuDNN>=7.6.5, for multi card support, NCCL>=2.7):
+*  If you are using CUDA 11.2，cuDNN 8.2.1(for multi card support, NCCL>=2.7):
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-  ```
-
-*  If you are using CUDA 11.2，cuDNN 8.1.1(for multi card support, NCCL>=2.7):
-
-  ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 *  If you are using CUDA 11.6，cuDNN 8.4.0(for multi card support, NCCL>=2.7):
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)

--- a/docs/install/conda/linux-conda_en.md
+++ b/docs/install/conda/linux-conda_en.md
@@ -145,6 +145,12 @@ conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn
   conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
+*  If you are using CUDA 11.7，cuDNN 8.4.1(for multi card support, NCCL>=2.7):
+
+  ```
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.7 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  ```
+
 You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 

--- a/docs/install/conda/macos-conda.md
+++ b/docs/install/conda/macos-conda.md
@@ -4,11 +4,6 @@
 
 ## 一、环境准备
 
-在进行 PaddlePaddle 安装之前请确保您的 Anaconda 软件环境已经正确安装。软件下载和安装参见 Anaconda 官网(https://www.anaconda.com/)。在您已经正确安装 Anaconda 的情况下请按照下列步骤安装 PaddlePaddle。
-
-* MacOS 版本 10.x/11.x (64 bit) (不支持 GPU 版本)
-* conda 版本 4.8.3+ (64 bit)
-
 ### 1.1 创建虚拟环境
 
 #### 1.1.1 安装环境
@@ -115,7 +110,7 @@ python3 -c "import platform;print(platform.architecture()[0]);print(platform.mac
 * 目前在 MacOS 环境仅支持 CPU 版 PaddlePaddle，请参考如下命令安装 Paddle:
 
   ```
-  conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 ## **三、验证安装**

--- a/docs/install/conda/macos-conda_en.md
+++ b/docs/install/conda/macos-conda_en.md
@@ -6,13 +6,6 @@
 
 ## Environmental preparation
 
-Before performing PaddlePaddle installation, please make sure that your Anaconda software environment is properly installed. For software download and installation, see Anaconda's official website (https://www.anaconda.com/). If you have installed Anaconda correctly, follow these steps to install PaddlePaddle.
-
-* MacOS version 10.x/11.x (64 bit)(not support GPU version)
-* conda version 4.8.3+ (64 bit)
-
-
-
 ### 1.1 Create Virtual Environment
 
 #### 1.1.1 Create the Anaconda Virtual Environment
@@ -121,7 +114,7 @@ conda config --set show_channel_urls yes
 * Currently, only the CPU version of PaddlePaddle is supported in the MacOS environment. Please use the following command to install PaddlePaddle：
 
   ```
-  conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
 

--- a/docs/install/conda/windows-conda.md
+++ b/docs/install/conda/windows-conda.md
@@ -1,14 +1,8 @@
 # Windows 下的 Conda 安装
 
-[Anaconda](https://www.anaconda.com/)是一个免费开源的 Python 和 R 语言的发行版本，用于计算科学，Anaconda 致力于简化包管理和部署。Anaconda 的包使用软件包管理系统 Conda 进行管理。Conda 是一个开源包管理系统和环境管理系统，可在 Windows、macOS 和 Linux 上运行。本文档为你介绍 Anaconda 安装方式，飞桨提供的 Anaconda 安装包支持分布式训练（多机多卡）、TensorRT 推理功能。
+[Anaconda](https://www.anaconda.com/)是一个免费开源的 Python 和 R 语言的发行版本，用于计算科学，Anaconda 致力于简化包管理和部署。Anaconda 的包使用软件包管理系统 Conda 进行管理。Conda 是一个开源包管理系统和环境管理系统，可在 Windows、macOS 和 Linux 上运行。本文档为你介绍 Anaconda 安装方式，飞桨提供的 Anaconda 安装包支持 TensorRT 推理功能。
 
 ## 一、环境准备
-
-在进行 PaddlePaddle 安装之前请确保您的 Anaconda 软件环境已经正确安装。软件下载和安装参见 Anaconda 官网(https://www.anaconda.com/)。在您已经正确安装 Anaconda 的情况下请按照下列步骤安装 PaddlePaddle。
-
-* Windows 7/8/10 专业版/企业版 (64bit)
-* GPU 版本支持 CUDA 10.1/10.2/11.2/11.6，且仅支持单卡
-* conda 版本 4.8.3+ (64 bit)
 
 
 ### 1.1 创建虚拟环境
@@ -124,7 +118,7 @@ python -c "import platform;print(platform.architecture()[0]);print(platform.mach
 如果您的计算机没有 NVIDIA® GPU，请安装 CPU 版的 PaddlePaddle
 
 ```
-conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
@@ -132,28 +126,22 @@ conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu
 #### GPU 版的 PaddlePaddle
 
 
-*  对于 `CUDA 10.1`，需要搭配 cuDNN 7 (cuDNN>=7.6.5)，安装命令为:
+*  对于 `CUDA 10.2`，需要搭配 cuDNN 7.6.5，安装命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  对于 `CUDA 10.2`，需要搭配 cuDNN 7 (cuDNN>=7.6.5)，安装命令为:
+*  对于 `CUDA 11.2`，需要搭配 cuDNN 8.2.1，安装命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-  ```
-
-*  对于 `CUDA 11.2`，需要搭配 cuDNN 8.1.1，安装命令为:
-
-  ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 *  对于 `CUDA 11.6`，需要搭配 cuDNN 8.4.0，安装命令为:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 您可参考 NVIDIA 官方文档了解 CUDA 和 CUDNN 的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)

--- a/docs/install/conda/windows-conda.md
+++ b/docs/install/conda/windows-conda.md
@@ -144,6 +144,12 @@ conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn
   conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
+*  对于 `CUDA 11.7`，需要搭配 cuDNN 8.4.1，安装命令为:
+
+  ```
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.7 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  ```
+
 您可参考 NVIDIA 官方文档了解 CUDA 和 CUDNN 的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 

--- a/docs/install/conda/windows-conda_en.md
+++ b/docs/install/conda/windows-conda_en.md
@@ -6,14 +6,6 @@
 
 ## Environmental preparation
 
-Before performing PaddlePaddle installation, please make sure that your Anaconda software environment is properly installed. For software download and installation, see Anaconda's official website (https://www.anaconda.com/). If you have installed Anaconda correctly, follow these steps to install PaddlePaddle.
-
-* Windows 7/8/10 Pro/Enterprise (64bit)
-* GPU Version support CUDA 10.1/10.2/11.2/11.6，and only supports single card
-* conda version 4.8.3+ (64 bit)
-
-
-
 ### 1.1 Create Virtual Environment
 
 #### 1.1.1 Create the Anaconda Virtual Environment
@@ -131,7 +123,7 @@ You can choose the following version of PaddlePaddle to start installation:
 If your computer doesn't have NVIDIA® GPU, please install `the CPU Version of PaddlePaddle`
 
 ```
-conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
 ```
 
 
@@ -140,28 +132,22 @@ conda install paddlepaddle==2.4.0rc0 --channel https://mirrors.tuna.tsinghua.edu
 #### GPU Version of PaddlePaddle
 
 
-*  If you are using CUDA 10.1，cuDNN 7 (cuDNN>=7.6.5):
+*  If you are usingCUDA 10.2，cuDNN 7.6.5:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.1 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
   ```
 
-*  If you are usingCUDA 10.2，cuDNN 7 (cuDNN>=7.6.5):
+*  If you are using CUDA 11.2，cuDNN 8.2.1:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=10.2 --channel https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/
-  ```
-
-*  If you are using CUDA 11.2，cuDNN 8.1.1:
-
-  ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.2 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 *  If you are using CUDA 11.6，cuDNN 8.4.0:
 
   ```
-  conda install paddlepaddle-gpu==2.4.0rc0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
 You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)

--- a/docs/install/conda/windows-conda_en.md
+++ b/docs/install/conda/windows-conda_en.md
@@ -150,6 +150,12 @@ conda install paddlepaddle==2.4.0 --channel https://mirrors.tuna.tsinghua.edu.cn
   conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.6 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
   ```
 
+*  If you are using CUDA 11.7，cuDNN 8.4.1:
+
+  ```
+  conda install paddlepaddle-gpu==2.4.0 cudatoolkit=11.7 -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/Paddle/ -c conda-forge
+  ```
+
 You can refer to NVIDIA official documents for installation process and configuration method of CUDA and cudnn. Please refer to [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)
 
 

--- a/docs/install/docker/linux-docker.md
+++ b/docs/install/docker/linux-docker.md
@@ -21,46 +21,46 @@
 
 * CPU 版的 PaddlePaddle：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0
     ```
 
 * CPU 版的 PaddlePaddle，且镜像中预装好了 jupyter：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 * GPU 版的 PaddlePaddle：
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0
+    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0
     ```
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0
+    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4
+    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4
     ```
 
 如果您的机器不在中国大陆地区，可以直接从 DockerHub 拉取镜像：
 
 * CPU 版的 PaddlePaddle：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0
+    docker pull paddlepaddle/paddle:2.4.0
     ```
 
 * CPU 版的 PaddlePaddle，且镜像中预装好了 jupyter：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 * GPU 版的 PaddlePaddle：
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0
+    nvidia-docker pull paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0
     ```
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0
+    nvidia-docker pull paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4
+    nvidia-docker pull paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4
     ```
 
 您还可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取更多镜像。
@@ -72,7 +72,7 @@
 
 
     ```
-    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 /bin/bash
+    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0 /bin/bash
     ```
 
     - `--name paddle_docker`：设定 Docker 的名称，`paddle_docker` 是自己设置的名称；
@@ -83,7 +83,7 @@
 
     - `-v $PWD:/paddle`：指定将当前路径（PWD 变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0`：指定需要使用的 image 名称，您可以通过`docker images`命令查看；/bin/bash 是在 Docker 中要执行的命令
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0`：指定需要使用的 image 名称，您可以通过`docker images`命令查看；/bin/bash 是在 Docker 中要执行的命令
 
 
 * 使用 CPU 版本的 PaddlePaddle，且镜像中预装好了 jupyter：
@@ -98,7 +98,7 @@
     cd ./jupyter_docker
     ```
     ```
-    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
     - `--rm`：关闭容器后删除容器；
@@ -109,13 +109,13 @@
 
     - `-v $PWD:/home/paddle`：指定将当前路径（PWD 变量会展开为当前路径的绝对路径）挂载到容器内部的 /home/paddle 目录；
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter`：指定需要使用的 image 名称，您可以通过`docker images`命令查看
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter`：指定需要使用的 image 名称，您可以通过`docker images`命令查看
 
 
 * 使用 GPU 版本的 PaddlePaddle：
 
     ```
-    nvidia-docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0 /bin/bash
+    nvidia-docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0 /bin/bash
     ```
 
     - `--name paddle_docker`：设定 Docker 的名称，`paddle_docker` 是自己设置的名称；
@@ -126,7 +126,7 @@
 
     - `-v $PWD:/paddle`：指定将当前路径（PWD 变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0`：指定需要使用的 image 名称，如果您希望使用 CUDA 11.2 或 CUDA 11.7 的镜像，也可以将其替换成`registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0` 或 `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4`。您可以通过`docker images`命令查看镜像。/bin/bash 是在 Docker 中要执行的命令
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0`：指定需要使用的 image 名称，如果您希望使用 CUDA 11.2 或 CUDA 11.7 的镜像，也可以将其替换成`registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0` 或 `registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4`。您可以通过`docker images`命令查看镜像。/bin/bash 是在 Docker 中要执行的命令
 
 
 
@@ -145,24 +145,24 @@
     </thead>
     <tbody>
         <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 CPU 镜像 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0 </td>
+        <td> 安装了 2.4.0 版本 paddle 的 CPU 镜像 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 CPU 镜像，且镜像中预装好了 jupyter，启动 docker 即运行 jupyter 服务 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter </td>
+        <td> 安装了 2.4.0 版本 paddle 的 CPU 镜像，且镜像中预装好了 jupyter，启动 docker 即运行 jupyter 服务 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4 </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 GPU 镜像，cuda 版本为 11.7，cudnn 版本为 8.4，trt 版本为 8.4 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4 </td>
+        <td> 安装了 2.4.0 版本 paddle 的 GPU 镜像，cuda 版本为 11.7，cudnn 版本为 8.4，trt 版本为 8.4 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0 </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 GPU 镜像，cuda 版本为 11.2，cudnn 版本为 8.1，trt 版本为 8.0 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0 </td>
+        <td> 安装了 2.4.0 版本 paddle 的 GPU 镜像，cuda 版本为 11.2，cudnn 版本为 8.2，trt 版本为 8.0 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0 </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 GPU 镜像，cuda 版本为 10.2，cudnn 版本为 7.6，trt 版本为 7.0 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0 </td>
+        <td> 安装了 2.4.0 版本 paddle 的 GPU 镜像，cuda 版本为 10.2，cudnn 版本为 7.6，trt 版本为 7.0 </td>
     </tr>
    </tbody>
 </table>

--- a/docs/install/docker/linux-docker_en.md
+++ b/docs/install/docker/linux-docker_en.md
@@ -21,46 +21,46 @@ For domestic users, when downloading docker is slow due to network problems, you
 
 * CPU version of PaddlePaddle：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0
     ```
 
 * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 * GPU version of PaddlePaddle：
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0
+    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0
     ```
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0
+    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4
+    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4
     ```
 
 If your machine is not in mainland China, you can pull the image directly from DockerHub:
 
 * CPU version of PaddlePaddle：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0
+    docker pull paddlepaddle/paddle:2.4.0
     ```
 
 * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 * GPU version of PaddlePaddle：
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0
+    nvidia-docker pull paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0
     ```
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0
+    nvidia-docker pull paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4
+    nvidia-docker pull paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4
     ```
 
 You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get more images.
@@ -72,7 +72,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
 
     ```
-    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 /bin/bash
+    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0 /bin/bash
     ```
 
     - `--name paddle_docker`: set name of Docker, `paddle_docker` is name of docker you set;
@@ -83,7 +83,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-v $PWD:/paddle`: Specifies to mount the current path of the host (PWD variable in Linux will expand to the absolute path of the current path) to the /paddle directory inside the container;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
 
 
 * Use GPU version of PaddlePaddle：
@@ -91,7 +91,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
 
     ```
-    nvidia-docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0 /bin/bash
+    nvidia-docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0 /bin/bash
     ```
 
     - `--name paddle_docker`: set name of Docker, `paddle_docker` is name of docker you set;
@@ -102,7 +102,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-v $PWD:/paddle`: Specifies to mount the current path of the host (PWD variable in Linux will expand to the absolute path of the current path) to the /paddle directory inside the container;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
 
 
 * Use CPU version of PaddlePaddle with jupyter：
@@ -118,7 +118,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
     cd ./jupyter_docker
     ```
     ```
-    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
     - `--rm`: Delete the container after closing it;
@@ -129,7 +129,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-v $PWD:/home/paddle`: Specifies to mount the current path (the PWD variable will be expanded to the absolute path of the current path) to the /home/paddle directory inside the container;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter`: Specify the name of the image to be used, you can view it through the `docker images` command
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter`: Specify the name of the image to be used, you can view it through the `docker images` command
 
 
 Now you have successfully used Docker to install PaddlePaddle. For more information about using Docker, see[Docker official documents](https://docs.docker.com)
@@ -147,24 +147,24 @@ Now you have successfully used Docker to install PaddlePaddle. For more informat
     </thead>
     <tbody>
         <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 </td>
-        <td> CPU image with 2.4.0rc0 version of paddle installed </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0 </td>
+        <td> CPU image with 2.4.0 version of paddle installed </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter </td>
-        <td> CPU image of paddle version 2.4.0rc0 is installed, and jupyter is pre-installed in the image. Start the docker to run the jupyter service </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter </td>
+        <td> CPU image of paddle version 2.4.0 is installed, and jupyter is pre-installed in the image. Start the docker to run the jupyter service </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.7-cudnn8.4-trt8.4 </td>
-        <td> GPU image of paddle version 2.4.0rc0 is installed, cuda version is 11.7, cudnn version is 8.4, trt version is 8.4 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.7-cudnn8.4-trt8.4 </td>
+        <td> GPU image of paddle version 2.4.0 is installed, cuda version is 11.7, cudnn version is 8.4, trt version is 8.4 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0 </td>
-        <td> GPU image of paddle version 2.4.0rc0 is installed, cuda version is 11.2, cudnn version is 8.1, trt version is 8.0 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda11.2-cudnn8.2-trt8.0 </td>
+        <td> GPU image of paddle version 2.4.0 is installed, cuda version is 11.2, cudnn version is 8.2, trt version is 8.0 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-gpu-cuda10.2-cudnn7.6-trt7.0 </td>
-        <td> GPU image of paddle version 2.4.0rc0 is installed, cuda version is 10.2, cudnn version is 7.6, trt version is 7.0 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-gpu-cuda10.2-cudnn7.6-trt7.0 </td>
+        <td> GPU image of paddle version 2.4.0 is installed, cuda version is 10.2, cudnn version is 7.6, trt version is 7.0 </td>
     </tr>
    </tbody>
 </table>

--- a/docs/install/docker/macos-docker.md
+++ b/docs/install/docker/macos-docker.md
@@ -19,24 +19,24 @@
 
 * CPU 版的 PaddlePaddle：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0
     ```
 
 * CPU 版的 PaddlePaddle，且镜像中预装好了 jupyter：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 如果您的机器不在中国大陆地区，可以直接从 DockerHub 拉取镜像：
 
 * CPU 版的 PaddlePaddle：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0
+    docker pull paddlepaddle/paddle:2.4.0
     ```
 
 * CPU 版的 PaddlePaddle，且镜像中预装好了 jupyter：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 您还可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取更多镜像。
@@ -48,7 +48,7 @@
 
 
     ```
-    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 /bin/bash
+    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0 /bin/bash
     ```
 
     - `--name paddle_docker`：设定 Docker 的名称，`paddle_docker` 是自己设置的名称；
@@ -59,7 +59,7 @@
 
     - `-v $PWD:/paddle`：指定将当前路径（PWD 变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0`：指定需要使用的 image 名称，您可以通过`docker images`命令查看；/bin/bash 是在 Docker 中要执行的命令
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0`：指定需要使用的 image 名称，您可以通过`docker images`命令查看；/bin/bash 是在 Docker 中要执行的命令
 
 * 使用 CPU 版本的 PaddlePaddle，且镜像中预装好了 jupyter：
 
@@ -73,7 +73,7 @@
     cd ./jupyter_docker
     ```
     ```
-    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
     - `--rm`：关闭容器后删除容器；
@@ -84,7 +84,7 @@
 
     - `-v $PWD:/home/paddle`：指定将当前路径（PWD 变量会展开为当前路径的绝对路径）挂载到容器内部的 /home/paddle 目录；
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter`：指定需要使用的 image 名称，您可以通过`docker images`命令查看
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter`：指定需要使用的 image 名称，您可以通过`docker images`命令查看
 
 
 
@@ -104,12 +104,12 @@
     </thead>
     <tbody>
         <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 CPU 镜像 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0 </td>
+        <td> 安装了 2.4.0 版本 paddle 的 CPU 镜像 </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter </td>
-        <td> 安装了 2.4.0rc0 版本 paddle 的 CPU 镜像，且镜像中预装好了 jupyter，启动 docker 即运行 jupyter 服务 </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter </td>
+        <td> 安装了 2.4.0 版本 paddle 的 CPU 镜像，且镜像中预装好了 jupyter，启动 docker 即运行 jupyter 服务 </td>
     </tr>
    </tbody>
 </table>

--- a/docs/install/docker/macos-docker_en.md
+++ b/docs/install/docker/macos-docker_en.md
@@ -19,24 +19,24 @@ For domestic users, when downloading docker is slow due to network problems, you
 
 * CPU version of PaddlePaddle：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0
     ```
 
 * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 If your machine is not in mainland China, you can pull the image directly from DockerHub:
 
 * CPU version of PaddlePaddle：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0
+    docker pull paddlepaddle/paddle:2.4.0
     ```
 
 * CPU version of PaddlePaddle, and the image is pre-installed with jupyter：
     ```
-    docker pull paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker pull paddlepaddle/paddle:2.4.0-jupyter
     ```
 
 You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get more images.
@@ -48,7 +48,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
 
     ```
-    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 /bin/bash
+    docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0 /bin/bash
     ```
 
     - `--name paddle_docker`: set name of Docker, `paddle_docker` is name of docker you set;
@@ -59,7 +59,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-v $PWD:/paddle`: Specifies to mount the current path of the host (PWD variable in Linux will expand to the absolute path of the current path) to the /paddle directory inside the container;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
 
 
 * Use CPU version of PaddlePaddle with jupyter：
@@ -75,7 +75,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
     cd ./jupyter_docker
     ```
     ```
-    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter
+    docker run -p 80:80 --rm --env USER_PASSWD="password you set" -v $PWD:/home/paddle registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter
     ```
 
     - `--rm`: Delete the container after closing it;
@@ -86,7 +86,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-v $PWD:/home/paddle`: Specifies to mount the current path (the PWD variable will be expanded to the absolute path of the current path) to the /home/paddle directory inside the container;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter`: Specify the name of the image to be used, you can view it through the `docker images` command
+    - `registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter`: Specify the name of the image to be used, you can view it through the `docker images` command
 
 
 
@@ -105,12 +105,12 @@ Now you have successfully used Docker to install PaddlePaddle. For more informat
     </thead>
     <tbody>
         <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0 </td>
-        <td> CPU image with 2.4.0rc0 version of paddle installed </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0 </td>
+        <td> CPU image with 2.4.0 version of paddle installed </td>
     </tr>
     <tr>
-        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-jupyter </td>
-        <td> CPU image of paddle version 2.4.0rc0 is installed, and jupyter is pre-installed in the image. Start the docker to run the jupyter service </td>
+        <td> registry.baidubce.com/paddlepaddle/paddle:2.4.0-jupyter </td>
+        <td> CPU image of paddle version 2.4.0 is installed, and jupyter is pre-installed in the image. Start the docker to run the jupyter service </td>
     </tr>
    </tbody>
 </table>

--- a/docs/install/index_cn.rst
+++ b/docs/install/index_cn.rst
@@ -33,7 +33,7 @@
 **4. PaddlePaddle 对 GPU 支持情况：**
 
 * 目前 **PaddlePaddle** 支持 **NVIDIA** 显卡的 **CUDA** 驱动和 **AMD** 显卡的 **ROCm** 架构
-* 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.6(For CUDA10.1/10.2)
+* 需要安装 `cuDNN <https://docs.nvidia.com/deeplearning/sdk/cudnn-install/>`_ ，版本要求 7.6(For CUDA10.2)
 * 如果您需要 GPU 多卡模式，需要安装 `NCCL 2 <https://developer.nvidia.com/nccl/>`_
 
     * 仅 Ubuntu/CentOS 支持 NCCL 2 技术
@@ -41,20 +41,20 @@
 
     * Windows 安装 GPU 版本
 
-        * Windows 7/8/10 支持 CUDA 10.1/10.2/11.1/11.2/11.6/11.7 单卡模式
+        * Windows 7/8/10 支持 CUDA 10.2/11.2/11.6/11.7 单卡模式
         * 不支持 **nvidia-docker** 方式安装
     * Ubuntu 安装 GPU 版本
 
-        * Ubuntu 16.04/18.04/20.04/22.04 支持 CUDA 10.1/10.2/11.1/11.2/11.6/11.7
+        * Ubuntu 16.04/18.04/20.04/22.04 支持 CUDA 10.2/11.2/11.6/11.7
         * 如果您是使用 **nvidia-docker** 安装，支持 CUDA 10.2/11.2/11.7
     * CentOS 安装 GPU 版本
 
         * 如果您是使用本机 **pip** 安装：
 
-            * CentOS 7 支持 CUDA 10.1/10.2/11.1/11.2/11.6/11.7
+            * CentOS 7 支持 CUDA 10.2/11.2/11.6/11.7
         * 如果您是使用本机源码编译安装：
 
-            * CentOS 7 支持 CUDA 10.1/10.2/11.1/11.2/11.6/11.7
+            * CentOS 7 支持 CUDA 10.2/11.2/11.6/11.7
             * CentOS 6 不推荐，不提供编译出现问题时的官方支持
         * 如果您是使用 **nvidia-docker** 安装，在 CentOS 7 下支持 CUDA 10.2/11.2/11.7
     * MacOS 不支持：MacOS 平台不支持 GPU 安装
@@ -70,13 +70,13 @@
 
     * Ubuntu 16.04/18.04/20.04/22.04:
 
-        * CUDA10.1 下支持 NCCL v2.4.2-v2.4.8
+        * 支持 NCCL v2.7.8 及更高版本
 * CentOS 支持情况
 
     * CentOS 6：不支持 NCCL
     * CentOS 7：
 
-        * CUDA10.1 下支持 NCCL v2.4.2-v2.4.8
+        * 支持 NCCL v2.7.8 及更高版本
 * MacOS 支持情况
 
     * 不支持 NCCL
@@ -137,11 +137,11 @@
         安装 CPU 版本的命令为：
         ::
 
-            python -m pip install paddlepaddle==2.4.0rc0 -i https://mirror.baidu.com/pypi/simple
+            python -m pip install paddlepaddle==2.4.0 -i https://mirror.baidu.com/pypi/simple
 
             或
 
-            python -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 
     (2). **GPU 版本** ：如果您想使用 GPU 版本请参考如下命令安装
@@ -153,11 +153,11 @@
         请注意用以下指令安装的 PaddlePaddle 在 Windows、Ubuntu、CentOS 下只支持 CUDA10.2：
         ::
 
-            python -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://mirror.baidu.com/pypi/simple
+            python -m pip install paddlepaddle-gpu==2.4.0 -i https://mirror.baidu.com/pypi/simple
 
             或
 
-            python -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle-gpu==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 
     请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径。

--- a/docs/install/index_en.rst
+++ b/docs/install/index_en.rst
@@ -47,20 +47,20 @@ The manuals will guide you to build and install PaddlePaddle on your 64-bit desk
 
     * Windows install GPU version
 
-        * Windows 7 / 8 / 10 support CUDA 10.1/10.2/11.1/11.2/11.6/11.7 single-card mode, but don't support CUDA 9.1/9.2/10.1
+        * Windows 7 / 8 / 10 support CUDA 10.2/11.2/11.6/11.7 single-card mode
         * don't support install using **nvidia-docker**
     * Ubuntu install GPU version
 
-        * Ubuntu 16.04 / 18.04 / 20.04 / 22.04 supports CUDA 10.1/10.2/11.1/11.2/11.6/11.7
+        * Ubuntu 16.04 / 18.04 / 20.04 / 22.04 supports CUDA 10.2/11.2/11.6/11.7
         * If you install using **nvidia-docker** , it supports CUDA 10.2/11.2/11.7
     * CentOS install GPU version
 
         * If you install using native **pip** :
 
-            * CentOS 7 supports CUDA 10.1/10.2/11.1/11.2/11.6/11.7
+            * CentOS 7 supports CUDA 10.2/11.2/11.6/11.7
         * If you compile and install using native source code:
 
-            * CentOS 7 supports CUDA 10.1/10.2/11.1/11.2/11.6/11.7
+            * CentOS 7 supports CUDA 10.2/11.2/11.6/11.7
         * If you install using  **nvidia-docker** , CentOS 7 supports CUDA 10.2/11.2/11.7
     * MacOS isn't supported: PaddlePaddle has no GPU support in Mac OS platform
 
@@ -145,11 +145,11 @@ This section describes how to use pip to install.
         Command to install CPU version is:
         ::
 
-            python -m pip install paddlepaddle==2.4.0rc0 -i https://mirror.baidu.com/pypi/simple
+            python -m pip install paddlepaddle==2.4.0 -i https://mirror.baidu.com/pypi/simple
 
             or
 
-            python -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 
     (2). **GPU version** : If you only want to install GPU version, please refer to command below
@@ -162,11 +162,11 @@ This section describes how to use pip to install.
         Please attention that PaddlePaddle installed through command below only supports CUDA10.2 under Windows、Ubuntu、CentOS:
         ::
 
-            python -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://mirror.baidu.com/pypi/simple
+            python -m pip install paddlepaddle-gpu==2.4.0 -i https://mirror.baidu.com/pypi/simple
 
             or
 
-            python -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+            python -m pip install paddlepaddle-gpu==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 
     Please confirm that the Python where you need to install PaddlePaddle is your expected location, because your computer may have multiple Python. Depending on the environment, you may need to replace Python in all command lines in the instructions with Python 3 or specific Python path.

--- a/docs/install/pip/linux-pip.md
+++ b/docs/install/pip/linux-pip.md
@@ -4,18 +4,7 @@
 
 ## 一、环境准备
 
-### 1.1 目前飞桨支持的环境
-
-* **Linux 版本 (64 bit)**
-
-  * **CentOS 7**
-  * **Ubuntu 16.04/18.04/20.04/22.04**
-
-* **Python 版本 3.6/3.7/3.8/3.9/3.10 (64 bit)**
-
-* **pip3 版本 20.2.2 或更高版本 (64 bit)**
-
-### 1.2 如何查看您的环境
+### 1.1 如何查看您的环境
 
 * 可以使用以下命令查看本机的操作系统和位数信息：
 
@@ -75,13 +64,9 @@
 
 * 如果您的计算机有 NVIDIA® GPU，请确保满足以下条件并且安装[GPU 版 PaddlePaddle](#gpu)，依赖库环境版本要求如下：
 
-  * **CUDA 工具包 10.1 配合 cuDNN 7 (cuDNN 版本>=7.6.5）, 不支持使用 TensorRT**
+  * **CUDA 工具包 10.2 配合 cuDNN v7.6.5, 如需使用 PaddleTensorRT 推理，需配合 TensorRT7.0.0.11**
 
-  * **CUDA 工具包 10.2 配合 cuDNN 7 (cuDNN 版本>=7.6.5）, 如需使用 PaddleTensorRT 推理，需配合 TensorRT7.0.0.11**
-
-  * **CUDA 工具包 11.1 配合 cuDNN v8.1.1, 如需使用 PaddleTensorRT 推理，需配合 TensorRT7.2.3.4**
-
-  * **CUDA 工具包 11.2 配合 cuDNN v8.1.1, 如需使用 PaddleTensorRT 推理，需配合 TensorRT8.0.3.4**
+  * **CUDA 工具包 11.2 配合 cuDNN v8.2.1, 如需使用 PaddleTensorRT 推理，需配合 TensorRT8.0.3.4**
 
   * **CUDA 工具包 11.6 配合 cuDNN v8.4.0, 如需使用 PaddleTensorRT 推理，需配合 TensorRT8.4.0.6**
 
@@ -130,7 +115,7 @@
 
 
   ```
-  python3 -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python3 -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
@@ -139,55 +124,34 @@
 
 
 
-2.2.1 CUDA10.1 的 PaddlePaddle
-
-  ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-  ```
-
-
-
-2.2.2 CUDA10.2 的 PaddlePaddle
+2.2.1 CUDA10.2 的 PaddlePaddle
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python3 -m pip install paddlepaddle-gpu==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
-2.2.3 CUDA11.1 的 PaddlePaddle
+2.2.2 CUDA11.2 的 PaddlePaddle
 
-
+  如果您只进行训练，可使用cuDNN8.2.1 版本的飞桨:
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post111 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-  ```
-
-
-2.2.4 CUDA11.2 的 PaddlePaddle
-
-  如果您只进行训练，可使用cuDNN8.1.1 版本的飞桨:
-  ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-  ```
-
-  如果你想使用 PaddleTensorRT 进行推理，cudnn8.2.1 与 TensorRT8.0.3.4 联编的安装包能够获得更优的推理性能，安装命令如下：
-  ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/cuda11.2-cudnn8.2-tensorrt8.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
 
 
-2.2.5 CUDA11.6 的 PaddlePaddle
+2.2.3 CUDA11.6 的 PaddlePaddle
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post116 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0.post116 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
 
-2.2.6 CUDA11.7 的 PaddlePaddle
+2.2.4 CUDA11.7 的 PaddlePaddle
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post117 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0.post117 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
 
 
@@ -213,26 +177,20 @@
   * cpu、mkl 版本 noavx 机器安装：
 
   ```
-  python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
+  python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
   ```
 
   * cpu、openblas 版本 noavx 机器安装：
 
   ```
-  python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/noavx/stable.html --no-index --no-deps
+  python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/noavx/stable.html --no-index --no-deps
   ```
 
-
-  * gpu 版本 cuda10.1 noavx 机器安装：
-
-  ```
-  python3 -m pip download paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
-  ```
 
   * gpu 版本 cuda10.2 noavx 机器安装：
 
   ```
-  python3 -m pip download paddlepaddle-gpu==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
+  python3 -m pip download paddlepaddle-gpu==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
   ```
   
   再使用`python3 -m pip install [name].whl`本地安装（[name]为 wheel 包名称）。
@@ -241,7 +199,7 @@
 * 如果你想安装`avx`、`openblas`的 Paddle 包，可以通过以下命令将 wheel 包下载到本地，再使用`python3 -m pip install [name].whl`本地安装（[name]为 wheel 包名称）：
 
   ```
-  python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/avx/stable.html --no-index --no-deps
+  python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/avx/stable.html --no-index --no-deps
   ```
 
 

--- a/docs/install/pip/linux-pip.md
+++ b/docs/install/pip/linux-pip.md
@@ -134,7 +134,7 @@
 
 2.2.2 CUDA11.2 的 PaddlePaddle
 
-  如果您只进行训练，可使用cuDNN8.2.1 版本的飞桨:
+  如果您只进行训练，可使用 cuDNN8.2.1 版本的飞桨:
   ```
   python3 -m pip install paddlepaddle-gpu==2.4.0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
@@ -159,7 +159,7 @@
 
 * 如果你使用的是安培架构的 GPU，推荐使用 CUDA11 以上。如果你使用的是非安培架构的 GPU，推荐使用 CUDA10.2，性能更优。
 
-* 飞桨对于主流各python 版本均提供了对应的安装包，而您环境中可能有多个 Python，请确认你想使用的python 版本并下载对应的paddlepaddle 安装包。例如您想使用python3.7 的环境，则安装命令为python3.7 -m pip install paddlepaddle。
+* 飞桨对于主流各 python 版本均提供了对应的安装包，而您环境中可能有多个 Python，请确认你想使用的 python 版本并下载对应的 paddlepaddle 安装包。例如您想使用 python3.7 的环境，则安装命令为 python3.7 -m pip install paddlepaddle。
 
 * 如果您需要使用清华源，可以通过以下命令
 
@@ -192,7 +192,7 @@
   ```
   python3 -m pip download paddlepaddle-gpu==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
   ```
-  
+
   再使用`python3 -m pip install [name].whl`本地安装（[name]为 wheel 包名称）。
 
 

--- a/docs/install/pip/linux-pip.md
+++ b/docs/install/pip/linux-pip.md
@@ -134,7 +134,7 @@
 
 2.2.2 CUDA11.2 的 PaddlePaddle
 
-  如果您只进行训练，可使用 cuDNN8.2.1 版本的飞桨:
+
   ```
   python3 -m pip install paddlepaddle-gpu==2.4.0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```

--- a/docs/install/pip/linux-pip_en.md
+++ b/docs/install/pip/linux-pip_en.md
@@ -2,17 +2,7 @@
 
 ## Environmental preparation
 
-### 1.1 PREQUISITES
-
-* **Linux Version (64 bit)**
-  * **CentOS 7**
-  * **Ubuntu 16.04/18.04/20.04/22.04**
-
-* **Python Version: 3.6/3.7/3.8/3.9/3.10 (64 bit)**
-
-* **pip3 Version 20.2.2 or above (64 bit)**
-
-### 1.2 How to check your environment
+### 1.1 How to check your environment
 
 * You can use the following commands to view the local operating system and bit information
 
@@ -73,13 +63,9 @@
 
 * If your computer has NVIDIA® GPU, please make sure that the following conditions are met and install [the GPU Version of PaddlePaddle](#gpu)
 
-  * **CUDA toolkit 10.1 with cuDNN 7 (cuDNN version>=7.6.5, for multi card support, NCCL2.7 or higher; TensorRT is not supported)**
+  * **CUDA toolkit 10.2 with cuDNN v7.6.5(for multi card support, NCCL2.7 or higher；for PaddleTensorRT deployment, TensorRT7.0.0.11)**
 
-  * **CUDA toolkit 10.2 with cuDNN 7 (cuDNN version>=7.6.5, for multi card support, NCCL2.7 or higher；for PaddleTensorRT deployment, TensorRT7.0.0.11)**
-
-  * **CUDA toolkit 11.1 with cuDNN v8.1.1(for multi card support, NCCL2.7 or higher；for PaddleTensorRT deployment, TensorRT7.2.3.4)**
-
-  * **CUDA toolkit 11.2 with cuDNN v8.1.1(for multi card support, NCCL2.7 or higher；for PaddleTensorRT deployment, TensorRT8.0.3.4)**
+  * **CUDA toolkit 11.2 with cuDNN v8.2.1(for multi card support, NCCL2.7 or higher；for PaddleTensorRT deployment, TensorRT8.0.3.4)**
 
   * **CUDA toolkit 11.6 with cuDNN v8.4.0(for multi card support, NCCL2.7 or higher；for PaddleTensorRT deployment, TensorRT8.4.0.6)**
 
@@ -133,7 +119,7 @@ You can choose the following version of PaddlePaddle to start installation:
 
 
   ```
-  python3 -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python3 -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
@@ -142,50 +128,34 @@ You can choose the following version of PaddlePaddle to start installation:
 
 
 
-2.2.1 If you are using CUDA 10.1
+2.2.1 If you are using CUDA 10.2
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
-
-2.2.2 If you are using CUDA 10.2
-
-
-  ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
-  ```
-
-2.2.3 If you are using CUDA 11.1
+2.2.2 If you are using CUDA 11.2
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post111 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
 
 
-2.2.4 If you are using CUDA 11.2
+2.2.3 If you are using CUDA 11.6
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0.post116 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
 
-
-2.2.5 If you are using CUDA 11.6
-
-
-  ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post116 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-  ```
-
-2.2.6 If you are using CUDA 11.7
+2.2.4 If you are using CUDA 11.7
 
 
   ```
-  python3 -m pip install paddlepaddle-gpu==2.4.0rc0.post117 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  python3 -m pip install paddlepaddle-gpu==2.4.0.post117 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
   ```
 
 Note：
@@ -207,26 +177,20 @@ Note：
    * cpu and mkl version installed on noavx machine：
 
    ```
-   python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
+   python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
    ```
 
    * cpu and openblas version installed on noavx machine：
 
    ```
-   python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/noavx/stable.html --no-index --no-deps
+   python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/noavx/stable.html --no-index --no-deps
    ```
 
-
-   * GPU cuda10.1 version install on noavx machine：
-
-   ```
-   python3 -m pip download paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
-   ```
 
    * GPU cuda10.2 version install on noavx machine：
 
    ```
-   python3 -m pip download paddlepaddle-gpu==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
+   python3 -m pip download paddlepaddle-gpu==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/noavx/stable.html --no-index --no-deps
    ```
 
    To determine whether your machine supports `avx`, you can use the following command. If the output contains `avx`, it means that the machine supports `avx`:
@@ -237,7 +201,7 @@ Note：
 * If you want to install the Paddle package with `avx` and `openblas`, you can use the following command to download the wheel package to the local, and then use `python3 -m pip install [name].whl` to install locally ([name] is the name of the wheel package):
 
   ```
-  python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/avx/stable.html --no-index --no-deps
+  python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/linux/openblas/avx/stable.html --no-index --no-deps
   ```
 
 

--- a/docs/install/pip/macos-pip.md
+++ b/docs/install/pip/macos-pip.md
@@ -1,6 +1,6 @@
 # MacOS 下的 PIP 安装
 
-[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持TensorRT 推理功能。
+[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持 TensorRT 推理功能。
 
 ## 一、环境准备
 

--- a/docs/install/pip/macos-pip.md
+++ b/docs/install/pip/macos-pip.md
@@ -1,21 +1,10 @@
 # MacOS 下的 PIP 安装
 
-[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持分布式训练（多机多卡）、TensorRT 推理功能。
+[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持TensorRT 推理功能。
 
 ## 一、环境准备
 
-### 1.1 目前飞桨支持的环境
-
-* **macOS 版本 10.x/11.x (64 bit) (不支持 GPU 版本)**
-
-* **mac 机器上支持 mac M1 芯片、Intel 芯片**
-
-* **Python 版本 3.6/3.7/3.8/3.9/3.10 (64 bit)**
-
-* **pip 或 pip3 版本 20.2.2 或更高版本 (64 bit)**
-
-
-### 1.2 如何查看您的环境
+### 1.1 如何查看您的环境
 
 * 可以使用以下命令查看本机的操作系统和位数信息：
 
@@ -81,7 +70,7 @@
 
 
   ```
-  python3 -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python3 -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
@@ -95,7 +84,7 @@
   首先使用如下命令将 wheel 包下载到本地，再使用`python3 -m pip install [name].whl`本地安装（[name]为 wheel 包名称）：
 
   ```
-  python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/mac/openblas/avx/stable.html --no-index --no-deps
+  python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/mac/openblas/avx/stable.html --no-index --no-deps
   ```
 
   判断你的机器是否支持`avx`，可以输入以下命令，如果输出中包含`avx`，则表示机器支持`avx`

--- a/docs/install/pip/macos-pip_en.md
+++ b/docs/install/pip/macos-pip_en.md
@@ -2,18 +2,7 @@
 
 ## Environmental preparation
 
-### 1.1 PREQUISITES
-
-* **MacOS version 10.x/11.x (64 bit) (not support GPU version)**
-
-* **Mac machine supports Mac M1 chip, Intel chip**
-
-* **Python version 3.6/3.7/3.8/3.9/3.10 (64 bit)**
-
-* **pip or pip3 Version 20.2.2 or above (64 bit)**
-
-
-### 1.2 How to check your environment
+### 1.1 How to check your environment
 
 * You can use the following commands to view the local operating system and bit information
 
@@ -77,7 +66,7 @@ You can choose the following version of PaddlePaddle to start installation:
 
 
 ```
-python3 -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+python3 -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 Note：
@@ -89,7 +78,7 @@ Note：
   First use the following command to download the wheel package to the local, and then use `python3 -m pip install [name].whl` to install locally ([name] is the name of the wheel package):
 
    ```
-   python3 -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/mac/openblas/avx/stable.html --no-index --no-deps
+   python3 -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/mac/openblas/avx/stable.html --no-index --no-deps
    ```
 
    To determine whether your machine supports `avx`, you can use the following command. If the output contains `avx`, it means that the machine supports `avx`:

--- a/docs/install/pip/windows-pip.md
+++ b/docs/install/pip/windows-pip.md
@@ -1,6 +1,6 @@
 # Windows 下的 PIP 安装
 
-[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持TensorRT 推理功能。
+[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持 TensorRT 推理功能。
 
 ## 一、环境准备
 
@@ -110,10 +110,10 @@
 
 * 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python 替换为具体的 Python 路径。
 
-* 上述命令默认安装`avx`的包。如果你的机器不支持`avx`，需要安装`noavx`的 Paddle 包。判断你的机器是否支持`avx`，可以安装[CPU-Z](https://www.cpuid.com/softwares/cpu-z.html)工具查看“处理器-指令集”。 
+* 上述命令默认安装`avx`的包。如果你的机器不支持`avx`，需要安装`noavx`的 Paddle 包。判断你的机器是否支持`avx`，可以安装[CPU-Z](https://www.cpuid.com/softwares/cpu-z.html)工具查看“处理器-指令集”。
 
-  首先使用如下命令将 wheel 包下载到本地，仅支持python3.8
-  
+  首先使用如下命令将 wheel 包下载到本地，仅支持 python3.8
+
   * cpu、mkl 版本 noavx 机器安装：
 
   ```
@@ -131,7 +131,7 @@
   ```
   python -m pip download paddlepaddle-gpu==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
   ```
-  
+
   再使用`python -m pip install [name].whl`本地安装（[name]为 wheel 包名称）
 
 * 如果你想安装`avx`、`openblas`的 Paddle 包，可以通过以下命令将 wheel 包下载到本地，再使用`python -m pip install [name].whl`本地安装（[name]为 wheel 包名称）：

--- a/docs/install/pip/windows-pip.md
+++ b/docs/install/pip/windows-pip.md
@@ -1,17 +1,10 @@
 # Windows 下的 PIP 安装
 
-[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持分布式训练（多机多卡）、TensorRT 推理功能。
+[The Python Package Index(PyPI)](https://pypi.org/)是 Python 的包管理器。本文档为你介绍 PyPI 安装方式，飞桨提供的 PyPI 安装包支持TensorRT 推理功能。
 
 ## 一、环境准备
 
-### 1.1 目前飞桨支持的环境
-
-* **Windows 7/8/10 专业版/企业版 (64bit)**
-* **GPU 版本支持 CUDA 10.1/10.2/11.1/11.2/11.6/11.7，且仅支持单卡**
-* **Python 版本 3.6+/3.7+/3.8+/3.9+/3.10+ (64 bit)**
-* **pip 版本 20.2.2 或更高版本 (64 bit)**
-
-### 1.2 如何查看您的环境
+### 1.1 如何查看您的环境
 
 * 需要确认 python 的版本是否满足要求
 
@@ -53,11 +46,7 @@
 
 * 如果您的计算机有 NVIDIA® GPU，请确保满足以下条件并且安装 GPU 版 PaddlePaddle
 
-  * **CUDA 工具包 10.1 配合 cuDNN v7.6.5(不支持使用 TensorRT)**
-
   * **CUDA 工具包 10.2 配合 cuDNN v7.6.5，如需使用 PaddleTensorRT 推理，需配合 TensorRT7.0.0.11**
-
-  * **CUDA 工具包 11.1 配合 cuDNN v8.1.1，如需使用 PaddleTensorRT 推理，需配合 TensorRT8.0.3.4**
 
   * **CUDA 工具包 11.2 配合 cuDNN v8.2.1，如需使用 PaddleTensorRT 推理，需配合 TensorRT8.2.4.2**
 
@@ -67,7 +56,7 @@
 
   * **GPU 运算能力超过 3.5 的硬件设备**
 
-  * 注：目前官方发布的 windows 安装包仅包含 CUDA 10.1/10.2/11.1/11.2/11.6/11.7，如需使用其他 cuda 版本，请通过源码自行编译。您可参考 NVIDIA 官方文档了解 CUDA、CUDNN 和 TensorRT 的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)，[TensorRT](https://developer.nvidia.com/tensorrt)
+  * 注：目前官方发布的 windows 安装包仅包含 CUDA 10.2/11.2/11.6/11.7，如需使用其他 cuda 版本，请通过源码自行编译。您可参考 NVIDIA 官方文档了解 CUDA、CUDNN 和 TensorRT 的安装流程和配置方法，请见[CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)，[TensorRT](https://developer.nvidia.com/tensorrt)
 
 
 
@@ -80,53 +69,38 @@
 
 
   ```
-  python -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 #### 2.2 <span id="gpu">GPU 版的 PaddlePaddle</span>
 
 
 
-2.2.1 CUDA10.1 的 PaddlePaddle
+2.2.1 CUDA10.2 的 PaddlePaddle
 
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
-2.2.2 CUDA10.2 的 PaddlePaddle
-
-
-  ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
-  ```
-
-
-2.2.3 CUDA11.1 的 PaddlePaddle
+2.2.2 CUDA11.2 的 PaddlePaddle
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post111 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0.post112 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
   ```
 
 
-2.2.4 CUDA11.2 的 PaddlePaddle
+2.2.3 CUDA11.6 的 PaddlePaddle
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post112 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0.post116 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
   ```
 
-
-2.2.5 CUDA11.6 的 PaddlePaddle
-
-  ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post116 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
-  ```
-
-2.2.6 CUDA11.7 的 PaddlePaddle
+2.2.4 CUDA11.7 的 PaddlePaddle
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post117 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0.post117 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
   ```
 
 
@@ -143,25 +117,19 @@
   * cpu、mkl 版本 noavx 机器安装：
 
   ```
-  python -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
+  python -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
   ```
 
   * cpu、openblas 版本 noavx 机器安装：
 
   ```
-  python -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/noavx/stable.html --no-index --no-deps
-  ```
-
-  * gpu 版本 cuda10.1 noavx 机器安装：
-
-  ```
-  python -m pip download paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
+  python -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/noavx/stable.html --no-index --no-deps
   ```
 
   * gpu 版本 cuda10.2 noavx 机器安装：
 
   ```
-  python -m pip download paddlepaddle-gpu==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
+  python -m pip download paddlepaddle-gpu==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
   ```
   
   再使用`python -m pip install [name].whl`本地安装（[name]为 wheel 包名称）
@@ -169,7 +137,7 @@
 * 如果你想安装`avx`、`openblas`的 Paddle 包，可以通过以下命令将 wheel 包下载到本地，再使用`python -m pip install [name].whl`本地安装（[name]为 wheel 包名称）：
 
   ```
-  python -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/avx/stable.html --no-index --no-deps
+  python -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/avx/stable.html --no-index --no-deps
   ```
 
 

--- a/docs/install/pip/windows-pip_en.md
+++ b/docs/install/pip/windows-pip_en.md
@@ -2,14 +2,7 @@
 
 ## Environmental preparation
 
-### 1.1 PREQUISITES
-
-* **Windows 7/8/10 Pro/Enterprise (64bit)**
-* **GPU Version support CUDA 10.1/10.2/11.1/11.2/11.6/11.7, and only support single GPU**
-* **Python version 3.6+/3.7+/3.8+/3.9+/3.10+(64bit)**
-* **pip version 20.2.2 or above (64bit)**
-
-### 1.2 How to check your environment
+### 1.1 How to check your environment
 
 * Confirm whether the Python version meets the requirements
 
@@ -50,11 +43,7 @@ If you installed Python via Homebrew or the Python website, `pip` was installed 
 
 * If your computer has NVIDIA® GPU, please make sure that the following conditions are met and install [the GPU Version of PaddlePaddle](#gpu)
 
-  * **CUDA toolkit 10.1 with cuDNN v7.6.5(TensorRT is not supported)**
-
   * **CUDA toolkit 10.2 with cuDNN v7.6.5(for PaddleTensorRT deployment, TensorRT7.0.0.11)**
-
-  * **CUDA toolkit 11.1 with cuDNN v8.1.1(for PaddleTensorRT deployment, TensorRT8.0.3.4)**
 
   * **CUDA toolkit 11.2 with cuDNN v8.2.1(for PaddleTensorRT deployment, TensorRT8.2.4.2)**
 
@@ -77,7 +66,7 @@ You can choose the following version of PaddlePaddle to start installation:
 
 
   ```
-  python -m pip install paddlepaddle==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python -m pip install paddlepaddle==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
@@ -85,44 +74,29 @@ You can choose the following version of PaddlePaddle to start installation:
 #### 2.2 <span id="gpu">GPU Version of PaddlePaddle</span>
 
 
-2.2.1 If you are using CUDA 10.1
-
-
-  ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
-  ```
-
-
-2.2.2 If you are using CUDA 10.2
+2.2.1 If you are using CUDA 10.2
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+  python -m pip install paddlepaddle-gpu==2.4.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
   ```
 
 
-2.2.3 If you are using CUDA 11.1
+2.2.2 If you are using CUDA 11.2
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post111 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0.post112 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
   ```
 
-
-2.2.4 If you are using CUDA 11.2
-
-  ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post112 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
-  ```
-
-2.2.5 If you are using CUDA 11.6
+2.2.3 If you are using CUDA 11.6
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post116 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0.post116 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
   ```
 
-2.2.6 If you are using CUDA 11.7
+2.2.4 If you are using CUDA 11.7
 
   ```
-  python -m pip install paddlepaddle-gpu==2.4.0rc0.post117 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
+  python -m pip install paddlepaddle-gpu==2.4.0.post117 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/avx/stable.html
   ```
 
 Note：
@@ -138,25 +112,19 @@ Note：
    * cpu and mkl version installed on noavx machine：
 
    ```
-   python -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
+   python -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
    ```
 
    * cpu and openblas version installed on noavx machine：
 
    ```
-   python -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/noavx/stable.html --no-index --no-deps
-   ```
-
-   * GPU cuda10.1 version install on noavx machine：
-
-   ```
-   python -m pip download paddlepaddle-gpu==2.4.0rc0.post101 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
+   python -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/noavx/stable.html --no-index --no-deps
    ```
 
    * GPU cuda10.2 version install on noavx machine：
 
    ```
-   python -m pip download paddlepaddle-gpu==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
+   python -m pip download paddlepaddle-gpu==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/mkl/noavx/stable.html --no-index --no-deps
    ```
 
    To determine whether your machine supports `avx`, you can install the [CPU-Z](https://www.cpuid.com/softwares/cpu-z.html) tool to view the "processor-instruction set".
@@ -165,7 +133,7 @@ Note：
 * If you want to install the Paddle package with `avx` and `openblas`, you can use the following command to download the wheel package to the local, and then use `python -m pip install [name].whl` to install locally ([name] is the name of the wheel package):
 
   ```
-  python -m pip download paddlepaddle==2.4.0rc0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/avx/stable.html --no-index --no-deps
+  python -m pip download paddlepaddle==2.4.0 -f https://www.paddlepaddle.org.cn/whl/windows/openblas/avx/stable.html --no-index --no-deps
   ```
 
 ## Verify installation


### PR DESCRIPTION
删除“目前飞桨支持的环境”、 cuDNN 7 (cuDNN 版本>=7.6.5）变成cuDNN7.6.5、删除cuda10.1/cuda11.1、cuda11.2删除trt安装命令，只保留第一个安装命令。
cuda11.2对应的cudnn版本变成cudnn8.2.1。
windows文档第一句删除支持分布式训练。
conda安装支持了cuda11.7/cudnn8.4.1。