### PR TITLE
[ARBG]<自定义Loss、Metric 及 Callback>章节中外链跳转错误的修复

### DIFF
--- a/docs/guides/advanced/customize_cn.ipynb
+++ b/docs/guides/advanced/customize_cn.ipynb
@@ -18,7 +18,7 @@
     "一般在深度学习任务中，有许多常用的损失函数，例如在图像分类任务中常用的交叉熵损失函数，在目标检测任务中常用的 Focal loss、L1/L2 损失函数等，在图像识别任务中常用的 Triplet Loss 以及 Center Loss 等。如果框架中提供的损失函数不能满足试图解决的问题，可按照框架的 API 结构要求自定义损失函数。\n",
     "\n",
     "### 1.2 自定义 Loss 步骤\n",
-    "飞桨框架中实现自定义 Loss 的方法和使用 [paddle.nn.Layer](../api/paddle/nn/Layer_cn.html) 进行模型组网的方法类似，包括三个步骤：\n",
+    "飞桨框架中实现自定义 Loss 的方法和使用 [paddle.nn.Layer](../../api/paddle/nn/Layer_cn.html) 进行模型组网的方法类似，包括三个步骤：\n",
     "\n",
     "1. 创建一个继承自 `paddle.nn.Layer` 的类；\n",
     "1. 在类的构造函数 `__init__` 中定义需要的参数；\n",
@@ -106,7 +106,7 @@
     "\n",
     "通过框架实现自定义评估指标的方法，包括如下几个步骤：\n",
     "\n",
-    "1. 创建一个继承自 [paddle.metric.Metric](../api/paddle/metric/Metric_cn.html) 的类；\n",
+    "1. 创建一个继承自 [paddle.metric.Metric](../../api/paddle/metric/Metric_cn.html) 的类；\n",
     "1. 在类的构造函数 `__init__` 中定义需要的参数；\n",
     "1. 实现 `name` 方法，返回定义的评估指标名字；\n",
     "1. 实现 `compute` 方法，这个方法主要用于 `update` 的加速，可省略；\n",
@@ -283,7 +283,7 @@
     "\n",
     "Callback 回调函数常用于对模型训练、评估、推理过程状态和参数的观察，如训练进度、loss 值等信息；也可用于实现一些自定义操作，如设置当 loss 值达到一定阈值时停止训练、按照设定规则定期保存模型等。可方便地掌握模型训练状态，及时做出灵活调整。\n",
     "\n",
-    "Callback 用在 `Model.fit` 、`Model.evaluate`、`Model.predict` 等飞桨高层 API 中，先定义一个继承自 [paddle.callbacks.Callback](../api/paddle/callbacks/Callback_cn.html) 的类，然后通过高层 API 接口的 callback 参数传入类的实例，用于模型训练、评估或推理过程中调用。\n",
+    "Callback 用在 `Model.fit` 、`Model.evaluate`、`Model.predict` 等飞桨高层 API 中，先定义一个继承自 [paddle.callbacks.Callback](../../api/paddle/callbacks/Callback_cn.html) 的类，然后通过高层 API 接口的 callback 参数传入类的实例，用于模型训练、评估或推理过程中调用。\n",
     "\n",
     "### 3.2 自定义回调函数\n",
     "\n",
@@ -330,7 +330,7 @@
    "id": "b23a392c",
    "metadata": {},
    "source": [
-    "飞桨框架在 [paddle.callbacks](../api/paddle/callbacks/Overview_cn.html) 下内置了一些常用的回调函数相关 API，接下来看两个框架中的实际例子。其中第一个例子时框架自带的 `ModelCheckpoint` 回调函数，可以在 `Model.fit` 训练模型时自动存储每轮训练得到的模型；第二个例子是框架自带的 `ProgBarLogger` 回调函数,用于在 `Model.fit` 训练时打印损失函数和评估指标。这两个回调函数会在 `Model.fit` 执行时默认被调用。\n"
+    "飞桨框架在 [paddle.callbacks](../../../api/paddle/callbacks/Overview_cn.html) 下内置了一些常用的回调函数相关 API，接下来看两个框架中的实际例子。其中第一个例子时框架自带的 `ModelCheckpoint` 回调函数，可以在 `Model.fit` 训练模型时自动存储每轮训练得到的模型；第二个例子是框架自带的 `ProgBarLogger` 回调函数,用于在 `Model.fit` 训练时打印损失函数和评估指标。这两个回调函数会在 `Model.fit` 执行时默认被调用。\n"
    ]
   },
   {


### PR DESCRIPTION
<自定义Loss、Metric 及 Callback>章节中所有超链接跳转错误，本次提交修复跳转错误问题