### PR TITLE
[docs][ARBG]Tensor 介绍 章节中 部分三级标题使用规范错误的修正

### DIFF
--- a/docs/guides/beginner/tensor_cn.md
+++ b/docs/guides/beginner/tensor_cn.md
@@ -68,7 +68,7 @@ weight:  Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=Fals
 
 与 Numpy 创建数组方式类似，通过给定 Python 序列（如列表 list、元组 tuple），可使用 [paddle.to_tensor](../../../api/paddle/to_tensor_cn.html) 创建任意维度的 Tensor。示例如下：
 
-（1）创建类似向量（vector）的 1 维 Tensor：
+2.1.1 创建类似向量（vector）的 1 维 Tensor：
 ```python
 import paddle # 后面的示例代码默认已导入 paddle 模块
 ndim_1_Tensor = paddle.to_tensor([2.0, 3.0, 4.0])
@@ -90,7 +90,7 @@ paddle.to_tensor([2])
 Tensor(shape=[1], dtype=int64, place=Place(gpu:0), stop_gradient=True,
        [2])
 ```
-（2）创建类似矩阵（matrix）的 2 维 Tensor：
+2.1.2 创建类似矩阵（matrix）的 2 维 Tensor：
 ```python
 ndim_2_Tensor = paddle.to_tensor([[1.0, 2.0, 3.0],
                                   [4.0, 5.0, 6.0]])
@@ -101,7 +101,7 @@ Tensor(shape=[2, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
        [[1., 2., 3.],
         [4., 5., 6.]])
 ```
-（3）创建 3 维 Tensor：
+2.1.3 创建 3 维 Tensor：
 ```python
 ndim_3_Tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
                                    [6, 7, 8, 9, 10]],
@@ -255,7 +255,7 @@ Tensor(shape=[3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
 
 ### 3.1 Tensor 的形状（shape）
 
-**（1）形状的介绍**
+**3.1.1 形状的介绍**
 
 形状是  Tensor 的一个重要的基础属性，可以通过  [Tensor.shape](../../../api/paddle/Tensor_cn.html#shape) 查看一个 Tensor 的形状，以下为相关概念：
 
@@ -287,7 +287,7 @@ Shape of Tensor: [2, 3, 4, 5]
 Elements number along axis 0 of Tensor: 2
 Elements number along the last axis of Tensor: 5
 ```
-**（2）重置 Tensor 形状（Reshape） 的方法**
+**3.1.2 重置 Tensor 形状（Reshape） 的方法**
 
 重新设置 Tensor 的 shape 在深度学习任务中比较常见，如一些计算类 API 会对输入数据有特定的形状要求，这时可通过 [paddle.reshape](../../../api/paddle/reshape_cn.html) 接口来改变 Tensor 的 shape，但并不改变 Tensor 的 size 和其中的元素数据。
 
@@ -333,7 +333,7 @@ Tensor flattened to Vector: [1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 1
 >  * [paddle.flatten](../../../api/paddle/flatten_cn.html)，将 Tensor 的数据在指定的连续维度上展平。
 >  * [paddle.transpose](../../../api/paddle/transpose_cn.html)，对 Tensor 的数据进行重排。
 
-**（3）原位（Inplace）操作和非原位操作的区别**
+**3.1.3 原位（Inplace）操作和非原位操作的区别**
 
 飞桨框架的 API 有原位（Inplace）操作和非原位操作之分，原位操作即在原 Tensor 上保存操作结果，输出 Tensor 将与输入 Tensor 共享数据，并且没有 Tensor 数据拷贝的过程。非原位操作则不会修改原 Tensor，而是返回一个新的 Tensor。通过 API 名称区分两者，如 [paddle.reshape](../../../api/paddle/reshape_cn.html) 是非原位操作，[paddle.reshape_](../../../api/paddle/reshape__cn.html) 是原位操作。
 
@@ -353,7 +353,7 @@ same_tensor name:  generated_tensor_0 # 原位操作后产生的 Tensor 与原�
 ```
 
 ### 3.2 Tensor 的数据类型（dtype）
-**（1）指定数据类型的介绍**
+**3.2.1 指定数据类型的介绍**
 
 Tensor 的数据类型 dtype 可以通过  [Tensor.dtype](../../../api/paddle/Tensor_cn.html#dtype) 查看，支持类型包括：`bool`、`float16`、`float32`、`float64`、`uint8`、`int8`、`int16`、`int32`、`int64`、`complex64`、`complex128`。
 
@@ -390,7 +390,7 @@ Tensor(shape=[2, 2], dtype=complex64, place=Place(gpu:0), stop_gradient=True,
        [[(1+1j), (2+2j)],
         [(3+3j), (4+4j)]])
 ```
-**（2）修改数据类型的方法**
+**3.2.2 修改数据类型的方法**
 
 飞桨框架提供了[paddle.cast](../../../api/paddle/cast_cn.html) 接口来改变 Tensor 的 dtype：
 ```python


### PR DESCRIPTION
《Tensor 介绍》章节中存在三级目录使用（1）（2）。。等情况，本ticket对应修正