### PR TITLE
修复paddle.nn.UpsamplingBilinear2D等文档

### DIFF
--- a/docs/api/paddle/cumprod_cn.rst
+++ b/docs/api/paddle/cumprod_cn.rst
@@ -9,12 +9,13 @@ cumprod
 
 沿给定维度 ``dim`` 计算输入 tensor ``x`` 的累乘。
 
-**注意**：结果的第一个元素和输入的第一个元素相同。
+.. note::
+    结果的第一个元素和输入的第一个元素相同。
 
 参数
 :::::::::
     - **x** (Tensor) - 累乘的输入，需要进行累乘操作的 tensor。
-    - **dim** (int) - 指明需要累乘的维度，取值范围需在[-x.rank,x.rank)之间，其中 x.rank 表示输入 tensor x 的维度，-1 代表最后一维。
+    - **dim** (int，可选) - 指明需要累乘的维度，取值范围需在[-x.rank,x.rank)之间，其中 x.rank 表示输入 tensor x 的维度，-1 代表最后一维。
     - **dtype** (str，可选) - 输出 tensor 的数据类型，支持 int32、int64、float32、float64、complex64、complex128。如果指定了，那么在执行操作之前，输入的 tensor 将被转换为 dtype 类型。这对于防止数据类型溢出非常有用。默认为：None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/device/cuda/stream_guard_cn.rst
+++ b/docs/api/paddle/device/cuda/stream_guard_cn.rst
@@ -7,6 +7,8 @@ stream_guard
 
 可以切换当前的 CUDA stream 为输入指定的 stream。
 
+.. note::
+    该 API 目前仅支持动态图模式。
 
 参数
 ::::::::::::

--- a/docs/api/paddle/linalg/svd_cn.rst
+++ b/docs/api/paddle/linalg/svd_cn.rst
@@ -19,8 +19,8 @@ svd
 参数
 ::::::::::::
 
-    - **x** (Tensor)：输入的欲进行奇异值分解的一个或一批方阵，类型为 Tensor。 ``x`` 的形状应为 ``[*, M, N]``，其中 ``*`` 为零或更大的批次维度，数据类型支持 float32， float64。
-    - **full_matrics** (bool)：是否计算完整的 U 和 V 矩阵，类型为 bool 默认为 False。这个参数会影响 U 和 V 生成的 Shape。
+    - **x** (Tensor) - 输入的欲进行奇异值分解的一个或一批方阵，类型为 Tensor。 ``x`` 的形状应为 ``[*, M, N]``，其中 ``*`` 为零或更大的批次维度，数据类型支持 float32， float64。
+    - **full_matrics** (bool) - 是否计算完整的 U 和 V 矩阵，类型为 bool 默认为 False。这个参数会影响 U 和 V 生成的 Shape。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/nn/UpsamplingBilinear2D_cn.rst
+++ b/docs/api/paddle/nn/UpsamplingBilinear2D_cn.rst
@@ -3,7 +3,7 @@
 UpsamplingBilinear2D
 -------------------------------
 
-.. py:function:: paddle.nn.UpsamplingBilinear2D(size=None,scale_factor=None, data_format='NCHW',name=None):
+.. py:function:: paddle.nn.UpsamplingBilinear2D(size=None,scale_factor=None, data_format='NCHW',name=None)
 
 
 

--- a/docs/api/paddle/nn/UpsamplingNearest2D_cn.rst
+++ b/docs/api/paddle/nn/UpsamplingNearest2D_cn.rst
@@ -3,7 +3,7 @@
 UpsamplingNearest2D
 -------------------------------
 
-.. py:function:: paddle.nn.UpsamplingNearest2D(size=None,scale_factor=None, data_format='NCHW',name=None):
+.. py:function:: paddle.nn.UpsamplingNearest2D(size=None,scale_factor=None, data_format='NCHW',name=None)
 
 
 

--- a/docs/api/paddle/nn/dynamic_decode_cn.rst
+++ b/docs/api/paddle/nn/dynamic_decode_cn.rst
@@ -5,7 +5,7 @@ dynamic_decode
 
 
 
-.. py:function:: paddle.nn.dynamic_decode(decoder, inits=None, max_step_num=None, output_time_major=False, impute_finished=False, is_test=False, return_length=False, **kwargs):
+.. py:function:: paddle.nn.dynamic_decode(decoder, inits=None, max_step_num=None, output_time_major=False, impute_finished=False, is_test=False, return_length=False, **kwargs)
 
 
 

--- a/docs/api/paddle/nn/functional/diag_embed_cn.rst
+++ b/docs/api/paddle/nn/functional/diag_embed_cn.rst
@@ -3,7 +3,7 @@
 diag_embed
 -------------------------------
 
-.. py:function:: paddle.nn.functional.diag_embed(input, offset=0, dim1=-2, dim2=-1):
+.. py:function:: paddle.nn.functional.diag_embed(input, offset=0, dim1=-2, dim2=-1)
 
 
 

--- a/docs/api/paddle/nn/functional/dice_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/dice_loss_cn.rst
@@ -20,9 +20,10 @@ dice_loss 定义为：
 参数
 ::::::::::::
 
-    - **input** (Tensor) - 分类的预测概率，秩大于等于 2 的多维 Tensor，维度为 :math:`[N_1, N_2, ..., N_k, D]`。第一个维度的大小是 batch_size，最后一维的大小 D 是类别数目。数据类型是 float32 或者 float64
-    - **label** (Tensor)- 正确的标注数据(groud truth)，与输入 ``input`` 的秩相同的 Tensor，维度为 :math:`[N_1, N_2, ..., N_k, 1]`。第一个维度的大小是 batch_size，最后一个维度的大小是 1。数据类型为 int32 或者 int64
-    - **epsilon** (float，可选) - 将会加到分子和分母上的数，浮点型的数值。如果输入和标签都为空，则确保 dice 为 1。默认值：0.00001
+    - **input** (Tensor) - 分类的预测概率，秩大于等于 2 的多维 Tensor，维度为 :math:`[N_1, N_2, ..., N_k, D]`。第一个维度的大小是 batch_size，最后一维的大小 D 是类别数目。数据类型是 float32 或者 float64。
+    - **label** (Tensor)- 正确的标注数据(groud truth)，与输入 ``input`` 的秩相同的 Tensor，维度为 :math:`[N_1, N_2, ..., N_k, 1]`。第一个维度的大小是 batch_size，最后一个维度的大小是 1。数据类型为 int32 或者 int64。
+    - **epsilon** (float，可选) - 将会加到分子和分母上的数，浮点型的数值。如果输入和标签都为空，则确保 dice 为 1。默认值：0.00001。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回
 ::::::::::::


### PR DESCRIPTION
PADDLEPADDLE_PR=48219
修改的API有：

- paddle.nn.UpsamplingBilinear2D
- paddle.nn.UpsamplingNearest2D
- paddle.nn.dynamic_decode
- paddle.nn.functional.diag_embed
- paddle.nn.functional.dice_loss

对应的英文文档修复为：[PaddlePaddle/Paddle/#48219](https://github.com/PaddlePaddle/Paddle/pull/48219)