### PR TITLE
fix chinese type errors (#5468)

### DIFF
--- a/docs/api/paddle/nn/InstanceNorm1D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm1D_cn.rst
@@ -25,10 +25,10 @@ InstanceNorm1D
     - **num_features** (int) - 指明输入 ``Tensor`` 的通道数量。
     - **epsilon** (float，可选) - 为了数值稳定加在分母上的值。默认值：1e-05。
     - **momentum** (float，可选) - 此值用于计算 ``moving_mean`` 和 ``moving_var``。默认值：0.9。更新公式如上所示。
-    - **weight_attr** (ParamAttr|bool，可选) - 指定权重参数属性的对象。如果为 False，则表示每个通道的伸缩固定为 1，不可改变。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
-    - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。如果为 False，则表示每一个通道的偏移固定为 0，不可改变。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
+    - **weight_attr** (ParamAttr|bool，可选) - 指定权重参数属性的对象。如果为 False，则表示每个通道的伸缩固定为 1，不可改变。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。如果为 False，则表示每一个通道的偏移固定为 0，不可改变。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **data_format** (string，可选) - 指定输入数据格式，数据格式可以为“NC"或者"NCL"。默认值：“NCL”。
-    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
 
 
 形状

--- a/docs/api/paddle/nn/InstanceNorm1D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm1D_cn.rst
@@ -8,6 +8,8 @@ InstanceNorm1D
 
 构建 ``InstanceNorm1D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 2D 或者 3D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。
 
+数据布局: NCL [batch, in_channels, length]
+
 ``input`` 是 mini-batch 的输入。
 
 .. math::

--- a/docs/api/paddle/nn/InstanceNorm1D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm1D_cn.rst
@@ -8,7 +8,7 @@ InstanceNorm1D
 
 构建 ``InstanceNorm1D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 2D 或者 3D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。
 
-数据布局: NCL [batch, in_channels, length]
+数据布局：NCL [batch, in_channels, length]
 
 ``input`` 是 mini-batch 的输入。
 

--- a/docs/api/paddle/nn/InstanceNorm1D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm1D_cn.rst
@@ -3,7 +3,7 @@
 InstanceNorm1D
 -------------------------------
 
-.. py:class:: paddle.nn.InstanceNorm1D(num_features, epsilon=1e-05, momentum=0.9, weight_attr=None, bias_attr=None, data_format="NCL", name=None):
+.. py:class:: paddle.nn.InstanceNorm1D(num_features, epsilon=1e-05, momentum=0.9, weight_attr=None, bias_attr=None, data_format="NCL", name=None)
 
 
 构建 ``InstanceNorm1D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 2D 或者 3D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。

--- a/docs/api/paddle/nn/InstanceNorm2D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm2D_cn.rst
@@ -8,7 +8,7 @@ InstanceNorm2D
 
 构建 ``InstanceNorm2D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 2D 或者 3D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。
 
-数据布局: NCHW [batch, in_channels, in_height, in_width]
+数据布局：NCHW [batch, in_channels, in_height, in_width]
 
 ``input`` 是 mini-batch 的输入。
 

--- a/docs/api/paddle/nn/InstanceNorm2D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm2D_cn.rst
@@ -8,6 +8,8 @@ InstanceNorm2D
 
 构建 ``InstanceNorm2D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 2D 或者 3D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。
 
+数据布局: NCHW [batch, in_channels, in_height, in_width]
+
 ``input`` 是 mini-batch 的输入。
 
 .. math::

--- a/docs/api/paddle/nn/InstanceNorm2D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm2D_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_nn_cn_InstanceNorm2D:
+.. _cn_api_nn_InstanceNorm2D:
 
 InstanceNorm2D
 -------------------------------

--- a/docs/api/paddle/nn/InstanceNorm2D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm2D_cn.rst
@@ -3,7 +3,7 @@
 InstanceNorm2D
 -------------------------------
 
-.. py:class:: paddle.nn.InstanceNorm2D(num_features, epsilon=1e-05, momentum=0.9, weight_attr=None, bias_attr=None, data_format="NCHW", name=None):
+.. py:class:: paddle.nn.InstanceNorm2D(num_features, epsilon=1e-05, momentum=0.9, weight_attr=None, bias_attr=None, data_format="NCHW", name=None)
 
 
 构建 ``InstanceNorm2D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 2D 或者 3D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。

--- a/docs/api/paddle/nn/InstanceNorm2D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm2D_cn.rst
@@ -25,10 +25,10 @@ InstanceNorm2D
     - **num_features** (int) - 指明输入 ``Tensor`` 的通道数量。
     - **epsilon** (float，可选) - 为了数值稳定加在分母上的值。默认值：1e-05。
     - **momentum** (float，可选) - 此值用于计算 ``moving_mean`` 和 ``moving_var``。默认值：0.9。更新公式如上所示。
-    - **weight_attr** (ParamAttr|bool，可选) - 指定权重参数属性的对象。如果为 False，则表示每个通道的伸缩固定为 1，不可改变。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
-    - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。如果为 False，则表示每一个通道的偏移固定为 0，不可改变。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
+    - **weight_attr** (ParamAttr|bool，可选) - 指定权重参数属性的对象。如果为 False，则表示每个通道的伸缩固定为 1，不可改变。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。如果为 False，则表示每一个通道的偏移固定为 0，不可改变。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **data_format** (string，可选) - 指定输入数据格式，数据格式可以为“NCHW"。默认值：“NCHW”。
-    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
 
 
 形状

--- a/docs/api/paddle/nn/InstanceNorm3D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm3D_cn.rst
@@ -3,7 +3,7 @@
 InstanceNorm3D
 -------------------------------
 
-.. py:class:: paddle.nn.InstanceNorm3D(num_features, epsilon=1e-05, momentum=0.9, weight_attr=None, bias_attr=None, data_format="NCDHW", name=None):
+.. py:class:: paddle.nn.InstanceNorm3D(num_features, epsilon=1e-05, momentum=0.9, weight_attr=None, bias_attr=None, data_format="NCDHW", name=None)
 
 构建 ``InstanceNorm3D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 5D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。
 

--- a/docs/api/paddle/nn/InstanceNorm3D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm3D_cn.rst
@@ -24,10 +24,10 @@ InstanceNorm3D
     - **num_features** (int) - 指明输入 ``Tensor`` 的通道数量。
     - **epsilon** (float，可选) - 为了数值稳定加在分母上的值。默认值：1e-05。
     - **momentum** (float，可选) - 此值用于计算 ``moving_mean`` 和 ``moving_var``。默认值：0.9。更新公式如上所示。
-    - **weight_attr** (ParamAttr|bool，可选) - 指定权重参数属性的对象。如果为 False，则表示每个通道的伸缩固定为 1，不可改变。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
-    - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。如果为 False，则表示每一个通道的偏移固定为 0，不可改变。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_ParamAttr` 。
+    - **weight_attr** (ParamAttr|bool，可选) - 指定权重参数属性的对象。如果为 False，则表示每个通道的伸缩固定为 1，不可改变。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
+    - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。如果为 False，则表示每一个通道的偏移固定为 0，不可改变。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_fluid_ParamAttr` 。
     - **data_format** (string，可选) - 指定输入数据格式，数据格式可以为"NCDHW"。默认值：“NCDHW”。
-    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
 
 
 形状

--- a/docs/api/paddle/nn/InstanceNorm3D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm3D_cn.rst
@@ -7,6 +7,8 @@ InstanceNorm3D
 
 构建 ``InstanceNorm3D`` 类的一个可调用对象，具体用法参照 ``代码示例``。可以处理 5D 的 Tensor，实现了实例归一化层（Instance Normalization Layer）的功能。更多详情请参考：Instance Normalization: The Missing Ingredient for Fast Stylization 。
 
+数据布局：NCDHW [batch, in_channels, D, in_height, in_width]
+
 ``input`` 是 mini-batch 的输入。
 
 .. math::

--- a/docs/api/paddle/nn/InstanceNorm3D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm3D_cn.rst
@@ -1,4 +1,4 @@
-.. _cn_api_nn_cn_InstanceNorm3D:
+.. _cn_api_nn_InstanceNorm3D:
 
 InstanceNorm3D
 -------------------------------

--- a/docs/api/paddle/nn/KLDivLoss_cn.rst
+++ b/docs/api/paddle/nn/KLDivLoss_cn.rst
@@ -30,9 +30,9 @@ kL 发散损失计算如下：
 形状
 ::::::::::::
 
-    - **input** (Tensor): - 输入的 Tensor，维度是[N, *]，其中 N 是 batch size， `*` 是任意数量的额外维度。数据类型为：float32、float64。
-    - **label** (Tensor): - 标签，维度是[N, *]，与 ``input`` 相同。数据类型为：float32、float64。
-    - **output** (Tensor): - 输入 ``input`` 和标签 ``label`` 间的 kl 散度。如果 `reduction` 是 ``'none'``，则输出 Loss 的维度为 [N, *]，与输入 ``input`` 相同。如果 `reduction` 是 ``'batchmean'`` 、 ``'mean'`` 或 ``'sum'``，则输出 Loss 的维度为 [1]。
+    - **input** (Tensor)：输入的 Tensor，维度是[N, *]，其中 N 是 batch size， `*` 是任意数量的额外维度。数据类型为：float32、float64。
+    - **label** (Tensor)：标签，维度是[N, *]，与 ``input`` 相同。数据类型为：float32、float64。
+    - **output** (Tensor)：输入 ``input`` 和标签 ``label`` 间的 kl 散度。如果 `reduction` 是 ``'none'``，则输出 Loss 的维度为 [N, *]，与输入 ``input`` 相同。如果 `reduction` 是 ``'batchmean'`` 、 ``'mean'`` 或 ``'sum'``，则输出 Loss 的维度为 [1]。
 
 代码示例
 ::::::::::::

--- a/docs/api/paddle/nn/L1Loss_cn.rst
+++ b/docs/api/paddle/nn/L1Loss_cn.rst
@@ -11,18 +11,18 @@ L1Loss
 
 当 `reduction` 设置为 ``'none'`` 时：
 
-.. math::
+..  math::
     Out = \lvert input - label\rvert
 
 当 `reduction` 设置为 ``'mean'`` 时：
 
-.. math::
+..  math::
     Out = MEAN(\lvert input - label\rvert)
 
 当 `reduction` 设置为 ``'sum'`` 时：
 
-.. math::
-Out = SUM(\lvert input - label\rvert)
+..  math::
+    Out = SUM(\lvert input - label\rvert)
 
 
 参数

--- a/docs/api/paddle/nn/L1Loss_cn.rst
+++ b/docs/api/paddle/nn/L1Loss_cn.rst
@@ -9,20 +9,20 @@ L1Loss
 
 该损失函数的数学计算公式如下：
 
-当 `reduction` 设置为 ``'none'`` 时，
+当 `reduction` 设置为 ``'none'`` 时：
 
-    .. math::
-        Out = \lvert input - label\rvert
+.. math::
+    Out = \lvert input - label\rvert
 
-当 `reduction` 设置为 ``'mean'`` 时，
+当 `reduction` 设置为 ``'mean'`` 时：
 
-    .. math::
-       Out = MEAN(\lvert input - label\rvert)
+.. math::
+    Out = MEAN(\lvert input - label\rvert)
 
-当 `reduction` 设置为 ``'sum'`` 时，
+当 `reduction` 设置为 ``'sum'`` 时：
 
-    .. math::
-       Out = SUM(\lvert input - label\rvert)
+.. math::
+Out = SUM(\lvert input - label\rvert)
 
 
 参数

--- a/docs/api/paddle/nn/L1Loss_cn.rst
+++ b/docs/api/paddle/nn/L1Loss_cn.rst
@@ -27,14 +27,14 @@ L1Loss
 
 参数
 :::::::::
-    - **reduction** (str，可选): - 指定应用于输出结果的计算方式，可选值有：``'none'``, ``'mean'``, ``'sum'``。默认为 ``'mean'``，计算 `L1Loss` 的均值；设置为 ``'sum'`` 时，计算 `L1Loss` 的总和；设置为 ``'none'`` 时，则返回 `L1Loss`。
+    - **reduction** (str，可选) - 指定应用于输出结果的计算方式，可选值有：``'none'``, ``'mean'``, ``'sum'``。默认为 ``'mean'``，计算 `L1Loss` 的均值；设置为 ``'sum'`` 时，计算 `L1Loss` 的总和；设置为 ``'none'`` 时，则返回 `L1Loss`。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 形状
 :::::::::
-    - **input** (Tensor): - 输入的 Tensor，维度是[N, *]，其中 N 是 batch size， `*` 是任意数量的额外维度。数据类型为：float32、float64、int32、int64。
-    - **label** (Tensor): - 标签，维度是[N, *]，与 ``input`` 相同。数据类型为：float32、float64、int32、int64。
-    - **output** (Tensor): - 输入 ``input`` 和标签 ``label`` 间的 `L1 loss` 损失。如果 `reduction` 是 ``'none'``，则输出 Loss 的维度为 [N, *]，与输入 ``input`` 相同。如果 `reduction` 是 ``'mean'`` 或 ``'sum'``，则输出 Loss 的维度为 [1]。
+    - **input** (Tensor)：输入的 Tensor，维度是[N, *]，其中 N 是 batch size， `*` 是任意数量的额外维度。数据类型为：float32、float64、int32、int64。
+    - **label** (Tensor)：标签，维度是[N, *]，与 ``input`` 相同。数据类型为：float32、float64、int32、int64。
+    - **output** (Tensor)：输入 ``input`` 和标签 ``label`` 间的 `L1 loss` 损失。如果 `reduction` 是 ``'none'``，则输出 Loss 的维度为 [N, *]，与输入 ``input`` 相同。如果 `reduction` 是 ``'mean'`` 或 ``'sum'``，则输出 Loss 的维度为 [1]。
 
 代码示例
 :::::::::

--- a/docs/api/paddle/nn/functional/instance_norm_cn.rst
+++ b/docs/api/paddle/nn/functional/instance_norm_cn.rst
@@ -5,9 +5,7 @@ instance_norm
 
 .. py:class:: paddle.nn.functional.instance_norm(x, running_mean=None, running_var=None, weight=None, bias=None, use_input_stats=True, momentum=0.9, eps=1e-05, data_format='NCHW', name=None)
 
-推荐使用 nn.InstanceNorm1D，nn.InstanceNorm2D，nn.InstanceNorm3D，由内部调用此方法。
-
-详情见 :ref:`cn_api_nn_InstanceNorm1D` 。
+推荐使用 :ref:`cn_api_nn_InstanceNorm1D`，:ref:`cn_api_nn_InstanceNorm2D`，:ref:`cn_api_nn_InstanceNorm3D`，由内部调用此方法。
 
 参数
 ::::::::::::

--- a/docs/api/paddle/nn/functional/instance_norm_cn.rst
+++ b/docs/api/paddle/nn/functional/instance_norm_cn.rst
@@ -3,7 +3,7 @@
 instance_norm
 -------------------------------
 
-.. py:class:: paddle.nn.functional.instance_norm(x, running_mean=None, running_var=None, weight=None, bias=None, use_input_stats=True, momentum=0.9, eps=1e-05, data_format='NCHW', name=None):
+.. py:class:: paddle.nn.functional.instance_norm(x, running_mean=None, running_var=None, weight=None, bias=None, use_input_stats=True, momentum=0.9, eps=1e-05, data_format='NCHW', name=None)
 
 推荐使用 nn.InstanceNorm1D，nn.InstanceNorm2D，nn.InstanceNorm3D，由内部调用此方法。
 

--- a/docs/api/paddle/nn/functional/l1_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/l1_loss_cn.rst
@@ -11,17 +11,17 @@ l1_loss
 
 当 `reduction` 设置为 ``'none'`` 时：
 
-.. math::
+..  math::
     Out = \lvert input - label\rvert
 
 当 `reduction` 设置为 ``'mean'`` 时：
 
-.. math::
+..  math::
     Out = MEAN(\lvert input - label\rvert)
 
 当 `reduction` 设置为 ``'sum'`` 时：
 
-.. math::
+..  math::
     Out = SUM(\lvert input - label\rvert)
 
 

--- a/docs/api/paddle/nn/functional/l1_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/l1_loss_cn.rst
@@ -9,20 +9,20 @@ l1_loss
 
 该损失函数的数学计算公式如下：
 
-当 `reduction` 设置为 ``'none'`` 时，
+当 `reduction` 设置为 ``'none'`` 时：
 
-    .. math::
-        Out = \lvert input - label\rvert
+.. math::
+    Out = \lvert input - label\rvert
 
-当 `reduction` 设置为 ``'mean'`` 时，
+当 `reduction` 设置为 ``'mean'`` 时：
 
-    .. math::
-       Out = MEAN(\lvert input - label\rvert)
+.. math::
+    Out = MEAN(\lvert input - label\rvert)
 
-当 `reduction` 设置为 ``'sum'`` 时，
+当 `reduction` 设置为 ``'sum'`` 时：
 
-    .. math::
-       Out = SUM(\lvert input - label\rvert)
+.. math::
+    Out = SUM(\lvert input - label\rvert)
 
 
 参数

--- a/docs/api/paddle/nn/functional/l1_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/l1_loss_cn.rst
@@ -27,9 +27,9 @@ l1_loss
 
 参数
 :::::::::
-    - **input** (Tensor): - 输入的 Tensor，维度是[N, *]，其中 N 是 batch size， `*` 是任意数量的额外维度。数据类型为：float32、float64、int32、int64。
-    - **label** (Tensor): - 标签，维度是[N, *]，与 ``input`` 相同。数据类型为：float32、float64、int32、int64。
-    - **reduction** (str，可选): - 指定应用于输出结果的计算方式，可选值有：``'none'``, ``'mean'``, ``'sum'``。默认为 ``'mean'``，计算 `L1Loss` 的均值；设置为 ``'sum'`` 时，计算 `L1Loss` 的总和；设置为 ``'none'`` 时，则返回 `L1Loss`。
+    - **input** (Tensor) - 输入的 Tensor，维度是[N, *]，其中 N 是 batch size， `*` 是任意数量的额外维度。数据类型为：float32、float64、int32、int64。
+    - **label** (Tensor) - 标签，维度是[N, *]，与 ``input`` 相同。数据类型为：float32、float64、int32、int64。
+    - **reduction** (str，可选) - 指定应用于输出结果的计算方式，可选值有：``'none'``, ``'mean'``, ``'sum'``。默认为 ``'mean'``，计算 `L1Loss` 的均值；设置为 ``'sum'`` 时，计算 `L1Loss` 的总和；设置为 ``'none'`` 时，则返回 `L1Loss`。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/nn/functional/layer_norm_cn.rst
+++ b/docs/api/paddle/nn/functional/layer_norm_cn.rst
@@ -14,8 +14,8 @@ layer_norm
 
     - **x** (int) - 输入，数据类型为 float32, float64。
     - **normalized_shape** (int|list|tuple) - 期望的输入是 :math:`[*, normalized_shape[0], normalized_shape[1], ..., normalized_shape[-1]]`，如果是一个整数，会作用在最后一个维度。
-    - **weight** (Tensor) - 权重的 Tensor，默认为 None。
-    - **bias** (Tensor) - 偏置的 Tensor，默认为 None。
+    - **weight** (Tensor，可选) - 权重的 Tensor，默认为 None。
+    - **bias** (Tensor，可选) - 偏置的 Tensor，默认为 None。
     - **epsilon** (float，可选) - 为了数值稳定加在分母上的值。默认值：1e-05。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/nn/functional/layer_norm_cn.rst
+++ b/docs/api/paddle/nn/functional/layer_norm_cn.rst
@@ -3,7 +3,7 @@
 layer_norm
 -------------------------------
 
-.. py:class:: paddle.nn.functional.layer_norm(x, normalized_shape, weight=None, bias=None, epsilon=1e-05, name=None):
+.. py:function:: paddle.nn.functional.layer_norm(x, normalized_shape, weight=None, bias=None, epsilon=1e-05, name=None)
 
 推荐使用 nn.LayerNorm。
 


### PR DESCRIPTION
* paddle.nn.functional.instance_norm 中去掉冒号

* paddle.nn.L1Loss 更改math公式格式

* paddle.nn.functional.l1_loss 更改math公式格式

* paddle.nn.functional.layer_norm 更改class 为 function

* paddle.nn.InstanceNorm1D、paddle.nn.InstanceNorm2D、paddle.nn.InstanceNorm3D中格式以及超链接。以及中英文文档内容一致性增加了DataLayout: NCHW [batch, in_channels, D, in_height, in_width]等内容，对DataLayout翻译为数据布局。
 
test=document_fix

