### PR TITLE
飞桨文档相互引用和死链修复

### DIFF
--- a/docs/advanced_guide/performance_improving/multinode_training_improving/cpu_train_best_practice.rst
+++ b/docs/advanced_guide/performance_improving/multinode_training_improving/cpu_train_best_practice.rst
@@ -63,7 +63,7 @@ API 详细使用方法参考 :ref:`cn_api_fluid_ParallelExecutor` ，简单实�
 
 要提高 CPU 分布式的数据 IO 速度，可以首先考虑使用 dataset API 进行数据读取。 dataset 是一种多生产者多消费者模式的数据读取方法，默认情况下耦合数据读取线程与训练线程，在多线程的训练中，dataset 表现出极高的性能优势。
 
-API 接口介绍可以参考：https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/dataset_cn/QueueDataset_cn.html
+API 接口介绍可以参考： :ref:`cn_api_distributed_QueueDataset`
 
 结合实际的网络，比如 CTR-DNN 模型，引入的方法可以参考：https://github.com/PaddlePaddle/models/tree/release/1.7/PaddleRec/ctr/dnn
 

--- a/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
@@ -23,7 +23,7 @@ BFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optimi
 :::::::::
 - minimize_bfgs 优化器当前实现为函数形式，与 Paddle 现有 SGD、Adam 优化器等使用略微有些区别。
   SGD/Adam 等通过调用 backward()计算梯度，并使用 step()更新网络参数。 而 minimize_bfgs 传入
-  loss 函数，并返回优化后参数，返回参数需要通过 `paddle.assign <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/assign_cn.html>`_  以 inpalce 方式进行更新。具体参考代码示例 1.
+  loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_tensor_creation_assign` 以 inpalce 方式进行更新。具体参考代码示例 1.
 - 由于当前实现上一些限制，当前 minimize_bfgs 要求函数输入为一维 Tensor。当输入参数维度超过一维，
   可以先将参数展平，使用 minimize_bfgs 计算后，再 reshape 到原有形状，更新参数。具体参考代码示例 2.
 

--- a/docs/api/paddle/incubate/optimizer/functional/minimize_lbfgs_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/functional/minimize_lbfgs_cn.rst
@@ -16,7 +16,7 @@ LBFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optim
 :::::::::
 - minimize_bfgs 优化器当前实现为函数形式，与 Paddle 现有 SGD、Adam 优化器等使用略微有些区别。
   SGD/Adam 等通过调用 backward()计算梯度，并使用 step()更新网络参数，而 minimize_lbfgs 传入
-  loss 函数，并返回优化后参数，返回参数需要通过 `paddle.assign <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/assign_cn.html>`_ 以 inpalce 方式进行更新。具体参考代码示例 1.
+  loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_tensor_creation_assign` 以 inpalce 方式进行更新。具体参考代码示例 1.
 - 由于当前实现上一些限制，当前 minimize_bfgs 要求函数输入为一维 Tensor。当输入参数维度超过一维，
   可以先将参数展平，使用 minimize_bfgs 计算后，再 reshape 到原有形状，更新参数。具体参考代码示例 2.
 

--- a/docs/dev_guides/api_contributing_guides/api_docs_guidelines_cn.md
+++ b/docs/dev_guides/api_contributing_guides/api_docs_guidelines_cn.md
@@ -130,7 +130,7 @@ API 的声明部分，要给出 API 的声明信息；
 
 ### API 功能描述
 
-API 功能描述部分只需要尽可能简单的描述出 API 的功能作用即可，要让用户能快速看懂。如 [paddle.add](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/math/add_cn.html#add)：
+API 功能描述部分只需要尽可能简单的描述出 API 的功能作用即可，要让用户能快速看懂。如 [paddle.add](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/add_cn.html#add)：
 
 可以拆解为 3 个部分，功能作用 + 计算公式 + 注解部分，其中：
 

--- a/docs/faq/data_cn.md
+++ b/docs/faq/data_cn.md
@@ -24,7 +24,7 @@ paddle 中推荐使用 `DataLoader`，这是一种灵活的异步加载方式。
 
 ##### 问题：有拓展 Tensor 维度的 Op 吗？
 
-+ 答复：请参考 API [paddle.unsqueeze](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/unsqueeze_cn.html#unsqueez)。
++ 答复：请参考 API [paddle.unsqueeze](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/unsqueeze_cn.html#unsqueeze)。
 
 ----------
 

--- a/docs/faq/data_cn.md
+++ b/docs/faq/data_cn.md
@@ -24,7 +24,7 @@ paddle 中推荐使用 `DataLoader`，这是一种灵活的异步加载方式。
 
 ##### 问题：有拓展 Tensor 维度的 Op 吗？
 
-+ 答复：请参考 API [paddle.unsqueeze](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/manipulation/unsqueeze_cn.html#unsqueeze)。
++ 答复：请参考 API [paddle.unsqueeze](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/unsqueeze_cn.html#unsqueez)。
 
 ----------
 
@@ -33,7 +33,7 @@ paddle 中推荐使用 `DataLoader`，这是一种灵活的异步加载方式。
 
 + 答复：如果是在进入 paddle 计算流程之前，数据仍然是 numpy.array 的形式，使用 numpy 接口`numpy.expand_dims`为图片数据增加维度后，再通过`numpy.reshape`进行操作即可，具体使用方法可查阅 numpy 的官方文档。
 
-如果是希望在模型训练或预测流程中完成通道的操作，可以使用 paddle 对应的 API [paddle.unsqueeze](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/manipulation/unsqueeze_cn.html#unsqueeze) 和 [paddle.reshape](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/manipulation/reshape_cn.html#reshape)。
+如果是希望在模型训练或预测流程中完成通道的操作，可以使用 paddle 对应的 API [paddle.unsqueeze](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/unsqueeze_cn.html#unsqueeze) 和 [paddle.reshape](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/reshape_cn.html#reshape)。
 
 ----------
 
@@ -58,4 +58,4 @@ z = paddle.ones([2, 2], 'float32')
 ##### 问题：如何初始化一个随机数的 Tensor？
 
 + 答复：使用`paddle.rand` 或 `paddle.randn` 等 API。具体请参考：
-[paddle.rand](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/random/rand_cn.html#rand) 和[paddle.randn](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tensor/random/randn_cn.html#randn)
+[paddle.rand](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/rand_cn.html#rand) 和[paddle.randn](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/randn_cn.html#randn)

--- a/docs/faq/distributed_cn.md
+++ b/docs/faq/distributed_cn.md
@@ -72,7 +72,7 @@
 ##### 问题：飞桨 2.0 分布式配置项统一到 DistributedStrategy 后有哪些具体变化？
 
 + 答复：
-2.0 版本之后，建议根据 [DistributedStrategy 文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/fleet/DistributedStrategy_cn.html) 和 [BuildStrategy 文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/compiler/BuildStrategy_cn.html#buildstrategy) 修改配置选项。
+2.0 版本之后，建议根据 [DistributedStrategy 文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/fleet/DistributedStrategy_cn.html) 和 [BuildStrategy 文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/static/BuildStrategy_cn.html#buildstrategy) 修改配置选项。
 
 2.0 版本将 3 个环境变量配置变为`DistributedStrategy`配置项，3 个环境变量将不生效，包括
 

--- a/docs/faq/params_cn.md
+++ b/docs/faq/params_cn.md
@@ -23,7 +23,7 @@
 
 + 答复：
 
-1. 在动态图中，使用`paddle.save` API， 并将最后一层的`layer.state_dict()` 传入至 save 方法的 obj 参数即可， 然后使用`paddle.load` 方法加载对应层的参数值。详细可参考 API 文档[save](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/framework/io/save_cn.html#save) 和[load](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/framework/io/load_cn.html#load)。
+1. 在动态图中，使用`paddle.save` API， 并将最后一层的`layer.state_dict()` 传入至 save 方法的 obj 参数即可， 然后使用`paddle.load` 方法加载对应层的参数值。详细可参考 API 文档[save](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/save_cn.html#save) 和[load](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/load_cn.html#load)。
 2. 在静态图中，使用`paddle.static.save_vars`保存指定的 vars，然后使用`paddle.static.load_vars`加载对应层的参数值。具体示例请见 API 文档：[load_vars](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/io/load_vars_cn.html) 和 [save_vars](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/io/save_vars_cn.html) 。
 
 ----------
@@ -32,7 +32,7 @@
 
 + 答复：
 
-1. 对于固定 BN：设置 `use_global_stats=True`，使用已加载的全局均值和方差：`global mean/variance`，具体内容可查看官网 API 文档[batch_norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/layers/batch_norm_cn.html#batch-norm)。
+1. 对于固定 BN：设置 `use_global_stats=True`，使用已加载的全局均值和方差：`global mean/variance`，具体内容可查看官网 API 文档[batch_norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/batch_norm_cn.html#batch-norm)。
 
 2. 对于固定网络层：如： stage1→ stage2 → stage3 ，设置 stage2 的输出，假设为*y*，设置 `y.stop_gradient=True`，那么， stage1→ stage2 整体都固定了，不再更新。
 

--- a/docs/faq/save_cn.md
+++ b/docs/faq/save_cn.md
@@ -126,5 +126,5 @@ tensor_bias[0] = 10
 
 更多介绍请参考以下 API 文档：
 
-- [paddle.save](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/framework/io/save_cn.html)
-- [paddle.load](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/framework/io/load_cn.html)
+- [paddle.save](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/save_cn.html#save)
+- [paddle.load](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/load_cn.html#load)

--- a/docs/faq/train_cn.md
+++ b/docs/faq/train_cn.md
@@ -61,7 +61,7 @@ torch.gather(input, dim, index, *, sparse_grad=False, out=None)
 
 ##### 问题：如何不训练某层的权重？
 
-+ 答复：在`ParamAttr`里设置`learning_rate=0`或`trainable`设置为`False`。具体请[参考文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/param_attr/ParamAttr_cn.html)
++ 答复：在`ParamAttr`里设置`learning_rate=0`或`trainable`设置为`False`。具体请[参考文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/ParamAttr_cn.html#paramattr)
 
 ----------
 

--- a/docs/guides/06_distributed_training/cluster_quick_start_collective_cn.rst
+++ b/docs/guides/06_distributed_training/cluster_quick_start_collective_cn.rst
@@ -7,7 +7,7 @@
 但在每个进程上处理不同的数据。因此，数据并行非常适合单卡已经能够放得下完整的模型和参数，但希望通过并行来增大
 全局数据(global batch)大小来提升训练的吞吐量。
 
-本节将采用自定义卷积网络和 Paddle 内置的 CIFAR-10 数据集来介绍如何使用 `Fleet API <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/Overview_cn.html#fleetapi>`_ (paddle.distributed.fleet) 进行数据并行训练。
+本节将采用自定义卷积网络和 Paddle 内置的 CIFAR-10 数据集来介绍如何使用 :ref:`cn_overview_distributed` (paddle.distributed.fleet) 进行数据并行训练。
 
 1.1 版本要求
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@
 分布式初始化需要：
 
     1. 设置 is_collective 为 True，表示分布式训练采用 Collective 模式。
-    2. [可选] 设置分布式策略 `DistributedStrategy <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/fleet/DistributedStrategy_cn.html>`_，跳过将使用缺省配置。
+    2. [可选] 设置分布式策略 :ref:`cn_api_distributed_fleet_DistributedStrategy` ，跳过将使用缺省配置。
 
 .. code-block:: python
 
@@ -79,7 +79,7 @@
 1.2.5 构建分布式训练使用的数据加载器
 """""""""""""""""""""""""""""""""""""""""""""
 
-由于分布式训练过程中每个进程可能读取不同数据，所以需要对数据集进行合理拆分后再进行加载。这里只需要在构建 `DataLoader <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/DataLoader_cn.html#dataloader>`_ 时, 设置分布式数据采样器 `DistributedBatchSampler <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/DistributedBatchSampler_cn.html#distributedbatchsampler>`_ 即可。
+由于分布式训练过程中每个进程可能读取不同数据，所以需要对数据集进行合理拆分后再进行加载。这里只需要在构建 :ref:`cn_api_fluid_io_DataLoader` 时, 设置分布式数据采样器 :ref:`cn_api_io_cn_DistributedBatchSampler` 即可。
 
 .. code-block:: python
 
@@ -249,4 +249,4 @@
             --ips=192.168.1.2,192.168.1.3 \
             train_with_fleet.py
 
-相关启动问题，可参考 `paddle.distributed.launch <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/launch_cn.html#launch>`_。
+相关启动问题，可参考 :ref:`cn_api_distributed_launch` 。

--- a/docs/guides/06_distributed_training/cluster_quick_start_ps_cn.rst
+++ b/docs/guides/06_distributed_training/cluster_quick_start_ps_cn.rst
@@ -270,4 +270,4 @@ InMemoryDataset/QueueDataset 所对应的数据处理脚本参考 examples/wide_
     time: [2022-05-18 11:27:27], batch: [4], loss[1]:[0.703863]
     time: [2022-05-18 11:27:27], batch: [5], loss[1]:[0.670717]
 
-备注：启动相关问题，请参考\ `launch <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/launch_cn.html>`_\。
+备注：启动相关问题，请参考 :ref:`cn_api_distributed_launch` 。

--- a/docs/guides/06_distributed_training/data_parallel/amp_cn.rst
+++ b/docs/guides/06_distributed_training/data_parallel/amp_cn.rst
@@ -46,7 +46,7 @@
 二、动态图操作实践
 ---------------------------
 
-使用飞桨框架提供的 API：\ ``paddle.amp.auto_cast``\ 和\ ``paddle.amp.GradScaler``\ 能够实现动态图的自动混合精度训练，即在相关 OP 的计算中，自动选择 FP16 或 FP32 格式计算。开启 AMP 模式后，使用 FP16 与 FP32 进行计算的 OP 列表可以参见\ `AMP 概览 <https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/amp/Overview_cn.html>`_\ 。
+使用飞桨框架提供的 API：\ ``paddle.amp.auto_cast``\ 和\ ``paddle.amp.GradScaler``\ 能够实现动态图的自动混合精度训练，即在相关 OP 的计算中，自动选择 FP16 或 FP32 格式计算。开启 AMP 模式后，使用 FP16 与 FP32 进行计算的 OP 列表可以参见 :ref:`cn_overview_amp` 。
 
 2.1 具体示例
 ^^^^^^^^^^^^^^^^^^

--- a/docs/guides/advanced/layer_and_model_cn.md
+++ b/docs/guides/advanced/layer_and_model_cn.md
@@ -39,7 +39,7 @@ paddle.nn.Layer 是飞桨定义的一个非常重要的类，是飞桨所有神�
 
 ### 2.1 加载 Mnist 数据集
 
-相信根据前面的内容，你已经知道如何使用 [paddle.Dataset](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/Dataset_cn.html) 和 [paddle.DataLoader](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/DataLoader_cn.html) 处理想要的数据了，如果你还有问题可以参考[数据读取](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/data_load_cn.html)文档，这里采用前面讲到的方法使用 Mnist 数据集。
+相信根据前面的内容，你已经知道如何使用 [paddle.Dataset](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/Dataset_cn.html) 和 [paddle.DataLoader](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/DataLoader_cn.html) 处理想要的数据了，如果你还有问题可以参考[数据集定义与加载](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/data_load_cn.html)文档，这里采用前面讲到的方法使用 Mnist 数据集。
 
 ```python
 import paddle

--- a/docs/guides/jit/case_analysis_cn.md
+++ b/docs/guides/jit/case_analysis_cn.md
@@ -348,7 +348,7 @@ out = convert_ifelse(paddle.mean(x) > 5.0, true_fn_0, false_fn_0, (x,), (x,), (o
 
 当控制流中，出现了 ``list.append`` 类似语法时，情况会有一点点特殊。
 
-Paddle 框架中的 ``cond_op`` 和 [``while_loop``](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/layers/while_loop_cn.html#cn-api-fluid-layers-while-loop) 对输入和返回类型有一个要求：
+Paddle 框架中的 ``cond_op`` 和 [``while_loop``](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/static/nn/while_loop_cn.html#while-loop) 对输入和返回类型有一个要求：
 > 输入或者返回类型必须是：LoDTensor 或者 LoDTensorArray <br><br>
 > 即：不支持其他非 LoDTensor 类型
 


### PR DESCRIPTION
第一批次提交（上个提交没通过pre-commit检查）。https://github.com/PaddlePaddle/Paddle/issues/48047 “路线一：API文档问题修复 ”中的 “对与超链接没有生成的情况，进行全量检索与修复”。