### PR TITLE
修复《使用指南》的“数据集定义与加载”1.2章节示例代码缺失的导入

### DIFF
--- a/docs/guides/beginner/data_load_cn.ipynb
+++ b/docs/guides/beginner/data_load_cn.ipynb
@@ -215,6 +215,7 @@
     "import cv2\n",
     "import numpy as np\n",
     "from paddle.io import Dataset\n",
+    "from paddle.vision.transforms import Normalize\n",
     "\n",
     "class MyDataset(Dataset):\n",
     "    \"\"\"\n",


### PR DESCRIPTION
添加缺失的import