### PR TITLE
[install] fix macos make fixed number of cores

### DIFF
--- a/docs/install/compile/macos-compile.md
+++ b/docs/install/compile/macos-compile.md
@@ -267,7 +267,7 @@ mkdir build && cd build
 #### 9. 使用以下命令来编译：
 
 ```
-make -j4
+make -j$(sysctl -n hw.ncpu)
 ```
 
 #### 10. 编译成功后进入`/paddle/build/python/dist`目录下找到生成的`.whl`包：

--- a/docs/install/compile/macos-compile_en.md
+++ b/docs/install/compile/macos-compile_en.md
@@ -271,7 +271,7 @@ mkdir build && cd build
 #### 9. Compile with the following command:
 
 ```
-make -j4
+make -j$(sysctl -n hw.ncpu)
 ```
 
 #### 10. After compiling successfully, go to the `/paddle/build/python/dist `directory and find the generated `.whl` package:


### PR DESCRIPTION
修复文档中 macos 编译核心数为固定值
```bash
gouzi@gouzi-MacBook-pro ~/Documents/git/Paddle: echo $(sysctl -n hw.ncpu)
8
```
