### PR TITLE
映射文档 No. 27

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take_along_dim.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take_along_dim.md
@@ -1,43 +1,49 @@
-## [ torch 参数更多 ]torch.take_along_dim
-### [torch.take_along_dim](https://pytorch.org/docs/1.13/generated/torch.take_along_dim.html#torch.take_along_dim)
+## [ torch 参数更多 ]torch.Tensor.take_along_dim
+### [torch.Tensor.take_along_dim](https://pytorch.org/docs/1.13/generated/torch.Tensor.take_along_dim.html?highlight=torch+tensor+take_along_dim#torch.Tensor.take_along_dim)
 
 ```python
-torch.take_along_dim(input,
+torch.Tensor.take_along_dim(input,
                     indices,
                     dim,
                     *,
                     out=None)
 ```
 
-### [paddle.take_along_axis](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/take_along_axis_cn.html#take-along-axis)
+### [paddle.Tensor.take_along_axis]( )
 
 ```python
-paddle.take_along_axis(arr,
-                    indices,
+paddle.Tensor.take_along_axis(indices,
                     axis)
 ```
 
-两者功能一致但参数不一致，具体如下：
+其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
-| input          | arr            | 输入的 Tensor 作为源矩阵，数据类型为：float32、float64，仅参数名不一致。  |
+| input          | -            | 输入 Tensor 作为源矩阵， Paddle 无此参数，需要进行转写。  |
 | indices         | indices         | 索引矩阵，包含沿轴提取 1d 切片的下标，必须和 arr 矩阵有相同的维度，需要能够 broadcast 与 arr 矩阵对齐，数据类型为：int、int64。 |
 |dim         | axis         |   指定沿着哪个维度获取对应的值，数据类型为：int，仅参数名不一致。 |
 | out   |   -   |     表示输出的 Tensor ， Paddle 无此参数，需要进行转写。                              |
 
 ### 转写示例
+#### input：输入
+```python
+# Pytorch 写法
+x = paddle.to_tensor([[10, 30, 20], [60, 40, 50]])
+index = paddle.to_tensor([[0]])
+torch.Tensor.take_along_dim(x, index, 0, out = y)
+
+# Paddle 写法
+x = paddle.to_tensor([[10, 30, 20], [60, 40, 50]])
+index = paddle.to_tensor([[0]])
+y = x.take_along_axis(index, 0)
+```
+
 #### out：指定输出
 ```python
 # Pytorch 写法
-x = torch.tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
-index = torch.tensor([[0]])
-axis = 0
-torch.take_along_dim(x, index, axis, out = y)
+torch.Tensor.take_along_dim(x, index, 0, out = y)
 
 # Paddle 写法
-x = paddle.to_tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
-index = paddle.to_tensor([[0]])
-axis = 0
-paddle.assign(paddle.take_along_axis(x, index, axis), y)
+y = x.take_along_axis(index, 0)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take_along_dim.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take_along_dim.md
@@ -1,0 +1,43 @@
+## [ torch 参数更多 ]torch.take_along_dim
+### [torch.take_along_dim](https://pytorch.org/docs/1.13/generated/torch.take_along_dim.html#torch.take_along_dim)
+
+```python
+torch.take_along_dim(input,
+                    indices,
+                    dim,
+                    *,
+                    out=None)
+```
+
+### [paddle.take_along_axis](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/take_along_axis_cn.html#take-along-axis)
+
+```python
+paddle.take_along_axis(arr,
+                    indices,
+                    axis)
+```
+
+两者功能一致但参数不一致，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| input          | arr            | 输入的 Tensor 作为源矩阵，数据类型为：float32、float64，仅参数名不一致。  |
+| indices         | indices         | 索引矩阵，包含沿轴提取 1d 切片的下标，必须和 arr 矩阵有相同的维度，需要能够 broadcast 与 arr 矩阵对齐，数据类型为：int、int64。 |
+|dim         | axis         |   指定沿着哪个维度获取对应的值，数据类型为：int，仅参数名不一致。 |
+| out   |   -   |     表示输出的 Tensor ， Paddle 无此参数，需要进行转写。                              |
+
+### 转写示例
+#### out：指定输出
+```python
+# Pytorch 写法
+x = torch.tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
+index = torch.tensor([[0]])
+axis = 0
+torch.take_along_dim(x, index, axis, out = y)
+
+# Paddle 写法
+x = paddle.to_tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
+index = paddle.to_tensor([[0]])
+axis = 0
+paddle.assign(paddle.take_along_axis(x, index, axis), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take_along_dim.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take_along_dim.md
@@ -1,12 +1,9 @@
-## [ torch 参数更多 ]torch.Tensor.take_along_dim
+## [ 仅参数名不一致 ]torch.Tensor.take_along_dim
 ### [torch.Tensor.take_along_dim](https://pytorch.org/docs/1.13/generated/torch.Tensor.take_along_dim.html?highlight=torch+tensor+take_along_dim#torch.Tensor.take_along_dim)
 
 ```python
-torch.Tensor.take_along_dim(input,
-                    indices,
-                    dim,
-                    *,
-                    out=None)
+torch.Tensor.take_along_dim(indices,
+                    dim)
 ```
 
 ### [paddle.Tensor.take_along_axis]( )
@@ -16,34 +13,9 @@ paddle.Tensor.take_along_axis(indices,
                     axis)
 ```
 
-其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+两者功能一致，参数名不一致，具体如下：
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
-| input          | -            | 输入 Tensor 作为源矩阵， Paddle 无此参数，需要进行转写。  |
 | indices         | indices         | 索引矩阵，包含沿轴提取 1d 切片的下标，必须和 arr 矩阵有相同的维度，需要能够 broadcast 与 arr 矩阵对齐，数据类型为：int、int64。 |
-|dim         | axis         |   指定沿着哪个维度获取对应的值，数据类型为：int，仅参数名不一致。 |
-| out   |   -   |     表示输出的 Tensor ， Paddle 无此参数，需要进行转写。                              |
-
-### 转写示例
-#### input：输入
-```python
-# Pytorch 写法
-x = paddle.to_tensor([[10, 30, 20], [60, 40, 50]])
-index = paddle.to_tensor([[0]])
-torch.Tensor.take_along_dim(x, index, 0, out = y)
-
-# Paddle 写法
-x = paddle.to_tensor([[10, 30, 20], [60, 40, 50]])
-index = paddle.to_tensor([[0]])
-y = x.take_along_axis(index, 0)
-```
-
-#### out：指定输出
-```python
-# Pytorch 写法
-torch.Tensor.take_along_dim(x, index, 0, out = y)
-
-# Paddle 写法
-y = x.take_along_axis(index, 0)
-```
+| dim         | axis         |   指定沿着哪个维度获取对应的值，数据类型为：int，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_power.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_power.md
@@ -31,5 +31,5 @@ paddle.linalg.matrix_power(x,
 torch.linalg.matrix_power(x, 3， out = y)
 
 # Paddle 写法
-y = paddle.linalg.matrix_power(x, 3)
+paddle.assign(paddle.linalg.matrix_power(x, 3), y)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_power.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_power.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.linalg.matrix_power
+## [ torch 参数更多 ]torch.linalg.matrix_power
 ### [torch.linalg.matrix_power](https://pytorch.org/docs/1.13/generated/torch.linalg.matrix_power.html?highlight=torch+linalg+matrix_power#torch.linalg.matrix_power)
 
 ```python
@@ -16,23 +16,20 @@ paddle.linalg.matrix_power(x,
                         name=None)
 ```
 
-两者功能一致但参数不一致，具体如下：
+其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | A          |  x           | 输入的欲进行 n 次幂运算的一个或一批方阵，类型为 Tensor,仅参数名不一致。  |
 | n         | n         | 输入的幂次，类型为 int。 |
 |out         | -         |  表示输出的 Tensor ， Paddle 无此参数，需要进行转写。 |
-| -   |   name  |        可选，一般无需设置，默认值为 None，PyTorch 无此参数， Paddle 保持默认即可。                            |
 
 ### 转写示例
 #### out：指定输出
 ```python
 # Pytorch 写法
-x = torch.tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
 torch.linalg.matrix_power(x, 3， out = y)
 
 # Paddle 写法
-x = paddle.to_tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
-paddle.assign(paddle.linalg.matrix_power(x, 3), y)
+y = paddle.linalg.matrix_power(x, 3)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_power.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_power.md
@@ -1,0 +1,38 @@
+## [ 参数不一致 ]torch.linalg.matrix_power
+### [torch.linalg.matrix_power](https://pytorch.org/docs/1.13/generated/torch.linalg.matrix_power.html?highlight=torch+linalg+matrix_power#torch.linalg.matrix_power)
+
+```python
+torch.linalg.matrix_power(A,
+                        n,
+                        *,
+                        out=None)
+```
+
+### [paddle.linalg.matrix_power](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/matrix_power_cn.html)
+
+```python
+paddle.linalg.matrix_power(x,
+                        n,
+                        name=None)
+```
+
+两者功能一致但参数不一致，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| A          |  x           | 输入的欲进行 n 次幂运算的一个或一批方阵，类型为 Tensor,仅参数名不一致。  |
+| n         | n         | 输入的幂次，类型为 int。 |
+|out         | -         |  表示输出的 Tensor ， Paddle 无此参数，需要进行转写。 |
+| -   |   name  |        可选，一般无需设置，默认值为 None，PyTorch 无此参数， Paddle 保持默认即可。                            |
+
+### 转写示例
+#### out：指定输出
+```python
+# Pytorch 写法
+x = torch.tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
+torch.linalg.matrix_power(x, 3， out = y)
+
+# Paddle 写法
+x = paddle.to_tensor([[1, 2, 3], [4, 5, 6], [7,8,9]])
+paddle.assign(paddle.linalg.matrix_power(x, 3), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.dsplit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.dsplit.md
@@ -1,0 +1,25 @@
+## [ 仅 paddle 参数更多 ]torch.dsplit
+### [torch.dsplit](https://pytorch.org/docs/1.13/generated/torch.dsplit.html#torch.dsplit)
+
+```python
+torch.dsplit(input,
+        indices_or_sections)
+```
+
+### [paddle.split](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/split_cn.html)
+
+```python
+paddle.split(x,
+        num_or_sections,
+        axis=0,
+        name=None)
+```
+
+Paddle 相比 PyTorch 支持更多其他参数，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| input          |  x           | 输入多维 Tensor ，仅参数名不一致。  |
+| indices_or_sections         | num_or_sections         | int 或者仅含有 int 的 list 或者 tuple ，用于分割的参数，仅参数名不一致。 |
+| -         | axis         |     可选，默认为 0 ，表示需要分割的维度，PyTorch 无此参数，Paddle 保持默认即可。 |
+| -   |   name  |        可选，一般无需设置，默认值为 None。                                |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.dsplit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.dsplit.md
@@ -22,4 +22,3 @@ Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 | input          |  x           | 输入多维 Tensor ，仅参数名不一致。  |
 | indices_or_sections         | num_or_sections         | int 或者仅含有 int 的 list 或者 tuple ，用于分割的参数，仅参数名不一致。 |
 | -         | axis         |     可选，默认为 0 ，表示需要分割的维度，PyTorch 无此参数，Paddle 保持默认即可。 |
-| -   |   name  |        可选，一般无需设置，默认值为 None。                                |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.dsplit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.dsplit.md
@@ -20,5 +20,5 @@ Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | input          |  x           | 输入多维 Tensor ，仅参数名不一致。  |
-| indices_or_sections         | num_or_sections         | int 或者仅含有 int 的 list 或者 tuple ，用于分割的参数，仅参数名不一致。 |
-| -         | axis         |     可选，默认为 0 ，表示需要分割的维度，PyTorch 无此参数，Paddle 保持默认即可。 |
+| indices_or_sections         | num_or_sections         | 用于分割的 int 或 list 或 tuple ，仅参数名不一致。 |
+| -         | axis         |     表示需要分割的维度，PyTorch 无此参数，Paddle 需要设置为 2。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expm1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expm1.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.special.expm1
+## [ torch 参数更多 ]torch.special.expm1
 ### [torch.special.expm1](https://pytorch.org/docs/1.13/special.html#torch.special.expm1)
 
 ```python
@@ -14,13 +14,12 @@ paddle.expm1(x,
         name=None)
 ```
 
-两者功能一致但参数不一致，具体如下：
+其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | input          |  x           | 该 OP 的输入为多维 Tensor。数据类型为：float16、float32、float64，仅参数名不一致。  |
 | out         | -         | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。 |
-| -   |   name  |        可选，一般无需设置，默认值为 None，PyTorch 无此参数， Paddle 保持默认即可。    |
 
 ### 转写示例
 #### out：指定输出

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expm1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expm1.md
@@ -1,0 +1,33 @@
+## [ 参数不一致 ]torch.special.expm1
+### [torch.special.expm1](https://pytorch.org/docs/1.13/special.html#torch.special.expm1)
+
+```python
+torch.special.expm1(input,
+                *,
+                out=None)
+```
+
+### [paddle.expm1](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/expm1_cn.html)
+
+```python
+paddle.expm1(x,
+        name=None)
+```
+
+两者功能一致但参数不一致，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| input          |  x           | 该 OP 的输入为多维 Tensor。数据类型为：float16、float32、float64，仅参数名不一致。  |
+| out         | -         | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。 |
+| -   |   name  |        可选，一般无需设置，默认值为 None，PyTorch 无此参数， Paddle 保持默认即可。    |
+
+### 转写示例
+#### out：指定输出
+```python
+# Pytorch 写法
+torch.special.expm1([2, 3, 8, 7], [1, 5, 3, 3], out=y)
+
+# Paddle 写法
+paddle.assign(paddle.expm1([2, 3, 8, 7], [1, 5, 3, 3]), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CUDAExtension.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CUDAExtension.md
@@ -20,7 +20,7 @@ Pytorch 相比 Paddle 支持更多其他参数，具体如下：
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
-| name          | -            | 参数 name，PaddlePaddle 无此参数。  |
-| sources         | sources         | 用于指定自定义 OP 对应的源码文件   |
+| name          | -            | 参数 name，PaddlePaddle 无此参数，一般对网络训练结果影响不大，可直接删除。  |
+| sources         | sources         | 用于指定自定义 OP 对应的源码文件。   |
 |*args         | *args          |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |
 | **kwargs      | **kwargs        |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CUDAExtension.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CUDAExtension.md
@@ -1,0 +1,26 @@
+## [ torch 参数更多 ]torch.utils.cpp_extension.CUDAExtension
+### [torch.utils.cpp_extension.CUDAExtension](https://pytorch.org/docs/1.13/cpp_extension.html?highlight=torch+utils+cpp_extension+cudaextension#torch.utils.cpp_extension.CUDAExtension)
+
+```python
+torch.utils.cpp_extension.CUDAExtension(name,
+                                    sources,
+                                    *args,
+                                    **kwargs)
+```
+
+### [paddle.utils.cpp_extension.CUDAExtension](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/cpp_extension/CUDAExtension_cn.html)
+
+```python
+paddle.utils.cpp_extension.CUDAExtension(sources,
+                                    *args,
+                                    **kwargs)
+```
+
+Pytorch 相比 Paddle 支持更多其他参数，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| name          | -            | 参数 name，PaddlePaddle 无此参数。  |
+| sources         | sources         | 用于指定自定义 OP 对应的源码文件   |
+|*args         | *args          |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |
+| **kwargs      | **kwargs        |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CppExtension.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CppExtension.md
@@ -20,7 +20,7 @@ Pytorch 相比 Paddle 支持更多其他参数，具体如下：
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
-| name          | -            | 参数 name，PaddlePaddle 无此参数。  |
-| sources         | sources         | 用于指定自定义 OP 对应的源码文件   |
+| name          | -            | 参数 name，PaddlePaddle 无此参数，一般对网络训练结果影响不大，可直接删除。  |
+| sources         | sources         | 用于指定自定义 OP 对应的源码文件。   |
 |*args         | *args          |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |
 | **kwargs      | **kwargs        |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CppExtension.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.CppExtension.md
@@ -1,0 +1,26 @@
+## [ torch 参数更多 ]torch.utils.cpp_extension.CppExtension
+### [torch.utils.cpp_extension.CppExtension](https://pytorch.org/docs/1.13/cpp_extension.html?highlight=torch+utils+cpp_extension+cppextension#torch.utils.cpp_extension.CppExtension)
+
+```python
+torch.utils.cpp_extension.CppExtension(name,
+                                    sources,
+                                    *args,
+                                    **kwargs)
+```
+
+### [paddle.utils.cpp_extension.CppExtension](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/cpp_extension/CppExtension_cn.html)
+
+```python
+paddle.utils.cpp_extension.CppExtension(sources,
+                                    *args,
+                                    **kwargs)
+```
+
+Pytorch 相比 Paddle 支持更多其他参数，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| name          | -            | 参数 name，PaddlePaddle 无此参数。  |
+| sources         | sources         | 用于指定自定义 OP 对应的源码文件   |
+|*args         | *args          |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |
+| **kwargs      | **kwargs        |   用于指定 Extension 的其他参数，支持的参数与 setuptools.Extension 一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.load.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.cpp_extension.load.md
@@ -1,0 +1,47 @@
+## [ torch 参数更多 ]torch.utils.cpp_extension.load
+### [torch.utils.cpp_extension.load](https://pytorch.org/docs/1.13/cpp_extension.html?highlight=torch+utils+cpp_extension+load#torch.utils.cpp_extension.load)
+
+```python
+torch.utils.cpp_extension.load(name,
+                            sources,
+                            extra_cflags=None,
+                            extra_cuda_cflags=None,
+                            extra_ldflags=None,
+                            extra_include_paths=None,
+                            build_directory=None,
+                            verbose=False,
+                            with_cuda=None,
+                            is_python_module=True,
+                            is_standalone=False,
+                            keep_intermediates=True)
+```
+
+### [paddle.utils.cpp_extension.load](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/cpp_extension/load_cn.html)
+
+```python
+paddle.utils.cpp_extension.load(name,
+                            sources,
+                            extra_cxx_cflags=None,
+                            extra_cuda_cflags=None,
+                            extra_ldflags=None,
+                            extra_include_paths=None,
+                            build_directory=None,
+                            verbose=False)
+```
+
+Pytorch 相比 Paddle 支持更多其他参数，具体如下：
+### 参数映射
+| PyTorch                     | PaddlePaddle            | 备注                                                   |
+| -------------               | ------------            | ------------------------------------------------------ |
+| name                        | name                    |  用于指定编译自定义 OP 时，生成的动态链接库的名字。                                    |
+| sources                     | sources                 |   用于指定自定义 OP 对应的源码文件。                           |
+| extra_cflags          | extra_cxx_cflags        |   用于指定编译 cuda 源文件时额外的编译选项。          |
+| extra_cuda_cflags          | extra_cuda_cflags    |         用于指定编译 cuda 源文件时额外的编译选项。                      |
+| extra_ldflags                 |extra_ldflags         |  用于指定编译自定义 OP 时额外的链接选项。                                 |
+| extra_include_paths    | extra_include_paths   |  用于指定编译 cpp 或 cuda 源文件时，额外的头文件搜索目录。                               |
+| build_directory       | build_directory       |    用于指定存放生成动态链接库的目录。                                    |
+| verbose                 | verbose             | 用于指定是否需要输出编译过程中的日志信息，默认为 False。   |
+| with_cuda                 | -                          | 决定是否将 CUDA 头文件和库添加到 build。 PaddlePaddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| is_python_module          | -                          | 默认为 True，将生成的共享库作为 Python 模块导入，PaddlePaddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| is_standalone             | -                          | 默认为 False，将构建的扩展作为一个普通的动态库加载到进程中，如果是 True，则构建一个独立的可执行文件，PaddlePaddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
+| keep_intermediates        | -                          | 默认为 True，保留中间文件，PaddlePaddle 无此参数，一般对网络训练结果影响不大，可直接删除。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.random_split.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.random_split.md
@@ -19,6 +19,6 @@ paddle.io.random_split(dataset,
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
-| dataset          | dataset            | 此参数必须是 paddle.io.Dataset 或 paddle.io.IterableDataset 的一个子类实例或实现了 __len__ 的 Python 对象，用于生成样本下标。默认值为 None。  |
+| dataset          | dataset            |  表示可迭代数据集。  |
 | lengths         | lengths         | 总和为原数组长度的，子集合长度数组。 |
 | generator         | generator         |   指定采样 data_source 的采样器。默认值为 None。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.random_split.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.random_split.md
@@ -1,0 +1,24 @@
+## [ 参数完全一致 ]torch.utils.data.random_split
+### [torch.utils.data.random_split](https://pytorch.org/docs/1.13/data.html?highlight=torch+utils+data+random_split#torch.utils.data.random_split)
+
+```python
+torch.utils.data.random_split(dataset,
+                            lengths,
+                            generator=<torch._C.Generator object>)
+```
+
+### [paddle.io.random_split](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/io/random_split_cn.html)
+
+```python
+paddle.io.random_split(dataset,
+                    lengths,
+                    generator=None)
+```
+
+两者参数和用法完全一致，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| dataset          | dataset            | 此参数必须是 paddle.io.Dataset 或 paddle.io.IterableDataset 的一个子类实例或实现了 __len__ 的 Python 对象，用于生成样本下标。默认值为 None。  |
+| lengths         | lengths         | 总和为原数组长度的，子集合长度数组。 |
+| generator         | generator         |   指定采样 data_source 的采样器。默认值为 None。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.dlpack.from_dlpack.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.dlpack.from_dlpack.md
@@ -1,0 +1,18 @@
+## [ 仅参数名不一致 ]torch.utils.dlpack.from_dlpack
+### [torch.utils.dlpack.from_dlpack](https://pytorch.org/docs/1.13/dlpack.html?highlight=torch+utils+dlpack+from_dlpack#torch.utils.dlpack.from_dlpack)
+
+```python
+torch.utils.dlpack.from_dlpack(ext_tensor)
+```
+
+### [paddle.utils.dlpack.from_dlpack](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/dlpack/from_dlpack_cn.html)
+
+```python
+paddle.utils.dlpack.from_dlpack(dlpack)
+```
+
+两者功能一致，参数名不一致，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| ext_tensor        | dlpack        | DLPack，即带有 dltensor 的 PyCapsule 对象，仅参数名不一致。   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.dlpack.to_dlpack.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.dlpack.to_dlpack.md
@@ -1,0 +1,18 @@
+## [ 仅参数名不一致 ]torch.utils.dlpack.to_dlpack
+### [torch.utils.dlpack.to_dlpack](https://pytorch.org/docs/1.13/dlpack.html?highlight=torch+utils+dlpack+to_dlpack#torch.utils.dlpack.to_dlpack)
+
+```python
+torch.utils.dlpack.to_dlpack(tensor)
+```
+
+### [paddle.utils.dlpack.to_dlpack](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/dlpack/to_dlpack_cn.html)
+
+```python
+paddle.utils.dlpack.to_dlpack(x)
+```
+
+两者功能一致，参数名不一致，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| tensor        | x        | Paddle Tensor，仅参数名不一致。   |


### PR DESCRIPTION
 https://github.com/PaddlePaddle/docs/issues/5691
完成分组No.27文档映射，新提交10个md文件。 
paddle.utils.cpp_extension.load函数中出现interpreter 参数，源代码中没有这个参数，文档中没有添加。
















































































