### PR TITLE
映射文档 No. 40

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.logical_xor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.logical_xor.md
@@ -1,26 +1,23 @@
 ## [ 仅参数名不一致 ]torch.logical_xor
-### [torch.logical_xor](https://pytorch.org/docs/1.13/generated/torch.logical_xor.html?highlight=logical_xor#torch.logical_xor)
+
+### [torch.logical_xor](https://pytorch.org/docs/1.13/generated/torch.logical_xor.html?highlight=torch+logical_xor#torch.logical_xor)
 
 ```python
-torch.logical_xor(input,
-                  other,
-                  *,
-                  out=None)
+torch.logical_xor(input, other, *, out=None)
 ```
 
-### [paddle.logical_xor](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/logical_xor_cn.html#logical-xor)
+### [paddle.logical_xor](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/logical_xor_cn.html)
 
 ```python
-paddle.logical_xor(x,
-                   y,
-                   out=None,
-                   name=None)
+paddle.logical_xor(x, y, out=None, name=None)
 ```
 
-两者功能一致且参数用法一致，仅参数名不同，具体如下：
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
 ### 参数映射
-| PyTorch       | PaddlePaddle | 备注                                                   |
-| ------------- | ------------ | ------------------------------------------------------ |
-| <font color='red'> input </font> | <font color='red'> x </font> | 表示输入的 Tensor ，仅参数名不一致。  |
-| <font color='red'> other </font> | <font color='red'> y </font> | 表示输入的 Tensor ，仅参数名不一致。  |
-| out | out | 表示输出的 Tensor 。|
+
+| PyTorch                             | PaddlePaddle | 备注                                                                    |
+| ----------------------------------- | ------------ | ----------------------------------------------------------------------- |
+| input     | x           | 表示输入的 Tensor ，仅参数名不一致。                         |
+| other     | y           | 表示输入的 Tensor ，仅参数名不一致。                         |
+| out     | out           | 表示输出的 Tensor 。                         |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.logit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.logit.md
@@ -22,6 +22,7 @@ Pytorch 相比 Paddle 支持更多其他参数，具体如下：
 | eps     | eps           | 将输入向量的范围控制在 [eps,1−eps]                        |
 | out           | -      | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。         |
 
+### 转写示例
 #### out：指定输出
 ```python
 # Pytorch 写法

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.logit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.logit.md
@@ -1,15 +1,15 @@
-## [ torch 参数更多 ]torch.multiply
+## [ torch 参数更多 ]torch.logit
 
-### [torch.multiply](https://pytorch.org/docs/1.13/generated/torch.multiply.html?highlight=torch+multiply#torch.multiply)
+### [torch.logit](https://pytorch.org/docs/1.13/generated/torch.logit.html?highlight=torch+logit#torch.logit)
 
 ```python
-torch.multiply(input, other, *, out=None)
+torch.logit(input, eps=None, *, out=None)
 ```
 
-### [paddle.multiply](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/multiply_cn.html)
+### [paddle.logit](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/logit_cn.html)
 
 ```python
-paddle.multiply(x, y, name=None)
+paddle.logit(x, eps=None, name=None)
 ```
 
 Pytorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -19,15 +19,14 @@ Pytorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch                             | PaddlePaddle | 备注                                                                    |
 | ----------------------------------- | ------------ | ----------------------------------------------------------------------- |
 | input     | x           | 表示输入的 Tensor ，仅参数名不一致。                         |
-| other     | y           | 表示输入的 Tensor ，仅参数名不一致。                         |
+| eps     | eps           | 将输入向量的范围控制在 [eps,1−eps]                        |
 | out           | -      | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。         |
 
-### 转写示例
 #### out：指定输出
 ```python
 # Pytorch 写法
-torch.multiply([3, 5], [1, 2], out = y)
+torch.logit(x, out=y)
 
 # Paddle 写法
-paddle.assign(paddle.multiply([3, 5], [1, 2]) , y)
+paddle.assign(paddle.logit(x),y)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.mul.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.mul.md
@@ -1,29 +1,26 @@
-## [torch 参数更多 ]torch.mul
-### [torch.mul](https://pytorch.org/docs/stable/generated/torch.mul.html?highlight=mul#torch.mul)
+## [ torch 参数更多 ]torch.mul
+
+### [torch.mul](https://pytorch.org/docs/1.13/generated/torch.mul.html?highlight=torch+mul#torch.mul)
 
 ```python
-torch.mul(input,
-          other,
-          *,
-          out=None)
+torch.mul(input, other, *, out=None)
 ```
 
-### [paddle.multiply](https://vpaddlepaddle.org.cn/documentation/docs/zh/api/paddle/multiply_cn.html#multiply)
+### [paddle.multiply](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/multiply_cn.html)
 
 ```python
-paddle.multiply(x,
-                y,
-                name=None)
+paddle.multiply(x, y, name=None)
 ```
 
-其中 Pytorch 相比 Paddle 支持更多其他参数，具体如下：
+Pytorch 相比 Paddle 支持更多其他参数，具体如下：
+
 ### 参数映射
-| PyTorch       | PaddlePaddle | 备注                                                   |
-| ------------- | ------------ | ------------------------------------------------------ |
-| <font color='red'> input </font> | <font color='red'> x </font> | 表示输入的 Tensor ，仅参数名不一致。  |
-| <font color='red'> other </font> | <font color='red'> y </font> | 表示输入的 Tensor ，仅参数名不一致。  |
-| <font color='red'> out </font> | -  | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。    |
 
+| PyTorch                             | PaddlePaddle | 备注                                                                    |
+| ----------------------------------- | ------------ | ----------------------------------------------------------------------- |
+| input     | x           | 表示输入的 Tensor ，仅参数名不一致。                         |
+| other     | y           | 表示输入的 Tensor ，仅参数名不一致。                         |
+| out           | -      | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。         |
 
 ### 转写示例
 #### out：指定输出
@@ -32,5 +29,5 @@ paddle.multiply(x,
 torch.mul([3, 5], [1, 2], out=y)
 
 # Paddle 写法
-paddle.assign(paddle.multiply([3, 5], [1, 2]), y)
+paddle.assign(paddle.multiply([3, 5], [1, 2]),y)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.nan_to_num.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.nan_to_num.md
@@ -1,0 +1,34 @@
+## [torch 参数更多 ]torch.nan_to_num
+
+### [torch.nan_to_num](https://pytorch.org/docs/1.13/generated/torch.nan_to_num.html?highlight=nan_to_num#torch.nan_to_num)
+
+```python
+torch.nan_to_num(input, nan=0.0, posinf=None, neginf=None, *, out=None)
+```
+
+### [paddle.nan_to_num]()
+
+```python
+paddle.nan_to_num(x, nan=0.0, posinf=None, neginf=None, name=None)
+```
+
+其中 Pytorch 相比 Paddle 支持更多其他参数，具体如下：
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| input  | x  | 表示输入的 Tensor ，仅参数名不一致。  |
+| nan  |  nan  | 表示用于替换 nan 的值。  |
+| posinf  |  posinf  | 表示+inf 的替换值。  |
+| neginf  |  neginf  | 表示-inf 的替换值。  |
+| out  | -  | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。    |
+
+
+### 转写示例
+#### out：指定输出
+```python
+# Pytorch 写法
+torch.nan_to_num(x, n, pos, neg, out = y)
+
+# Paddle 写法
+paddle.assign(paddle.nan_to_num(x, n, pos, neg), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.neg.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.neg.md
@@ -1,15 +1,15 @@
-## [ torch 参数更多 ]torch.multiply
+## [ torch 参数更多 ]torch.neg
 
-### [torch.multiply](https://pytorch.org/docs/1.13/generated/torch.multiply.html?highlight=torch+multiply#torch.multiply)
+### [torch.neg](https://pytorch.org/docs/1.13/generated/torch.neg.html?highlight=neg#torch.neg)
 
 ```python
-torch.multiply(input, other, *, out=None)
+torch.neg(input, *, out=None)
 ```
 
-### [paddle.multiply](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/multiply_cn.html)
+### [paddle.neg](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/neg_cn.html)
 
 ```python
-paddle.multiply(x, y, name=None)
+paddle.neg(x, name=None)
 ```
 
 Pytorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -19,15 +19,14 @@ Pytorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch                             | PaddlePaddle | 备注                                                                    |
 | ----------------------------------- | ------------ | ----------------------------------------------------------------------- |
 | input     | x           | 表示输入的 Tensor ，仅参数名不一致。                         |
-| other     | y           | 表示输入的 Tensor ，仅参数名不一致。                         |
 | out           | -      | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。         |
 
-### 转写示例
+###  转写示例
 #### out：指定输出
 ```python
 # Pytorch 写法
-torch.multiply([3, 5], [1, 2], out = y)
+torch.neg(x , out=y)
 
 # Paddle 写法
-paddle.assign(paddle.multiply([3, 5], [1, 2]) , y)
+paddle.assign(paddle.neg(x) , y)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.negative.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.negative.md
@@ -1,15 +1,15 @@
-## [ torch 参数更多 ]torch.multiply
+## [ torch 参数更多 ]torch.negative
 
-### [torch.multiply](https://pytorch.org/docs/1.13/generated/torch.multiply.html?highlight=torch+multiply#torch.multiply)
+### [torch.negative](https://pytorch.org/docs/1.13/generated/torch.negative.html?highlight=torch+negative#torch.negative)
 
 ```python
-torch.multiply(input, other, *, out=None)
+torch.negative(input, *, out=None)
 ```
 
-### [paddle.multiply](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/multiply_cn.html)
+### [paddle.neg](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/neg_cn.html)
 
 ```python
-paddle.multiply(x, y, name=None)
+paddle.neg(x, name=None)
 ```
 
 Pytorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -19,15 +19,14 @@ Pytorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch                             | PaddlePaddle | 备注                                                                    |
 | ----------------------------------- | ------------ | ----------------------------------------------------------------------- |
 | input     | x           | 表示输入的 Tensor ，仅参数名不一致。                         |
-| other     | y           | 表示输入的 Tensor ，仅参数名不一致。                         |
 | out           | -      | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。         |
 
-### 转写示例
+###  转写示例
 #### out：指定输出
 ```python
 # Pytorch 写法
-torch.multiply([3, 5], [1, 2], out = y)
+torch.negative(x ,out = y)
 
 # Paddle 写法
-paddle.assign(paddle.multiply([3, 5], [1, 2]) , y)
+paddle.assign(paddle.neg(x), y)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.pow.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.pow.md
@@ -1,4 +1,5 @@
 ## [torch 参数更多 ]torch.pow
+
 ### [torch.pow](https://pytorch.org/docs/1.13/generated/torch.pow.html?highlight=pow#torch.pow)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rad2deg.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rad2deg.md
@@ -1,19 +1,14 @@
-## [torch 参数更多 ]torch.pow
-### [torch.pow](https://pytorch.org/docs/1.13/generated/torch.pow.html?highlight=pow#torch.pow)
+## [torch 参数更多 ]torch.rad2deg
+### [torch.rad2deg](https://pytorch.org/docs/1.13/generated/torch.rad2deg.html?highlight=torch+rad2deg#torch.rad2deg)
 
 ```python
-torch.pow(input,
-          exponent,
-          *,
-          out=None)
+torch.rad2deg(input, *, out=None)
 ```
 
-### [paddle.pow](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/pow_cn.html)
+### [paddle.rad2deg](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/rad2deg_cn.html)
 
 ```python
-paddle.pow(x,
-           y,
-           name=None)
+paddle.rad2deg(x, name=None)
 ```
 
 其中 Pytorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -21,7 +16,6 @@ paddle.pow(x,
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | input  | x  | 表示输入的 Tensor ，仅参数名不一致。  |
-| exponent  |  y  | 表示输入的 Tensor ，仅参数名不一致。  |
 | out  | -  | 表示输出的 Tensor ， Paddle 无此参数，需要进行转写。    |
 
 
@@ -29,8 +23,8 @@ paddle.pow(x,
 #### out：指定输出
 ```python
 # Pytorch 写法
-torch.pow([3, 5], 2, out=y)
+torch.rad2deg(x, out=y)
 
 # Paddle 写法
-paddle.assign(paddle.pow([3, 5], 2), y)
+paddle.assign(paddle.rad2deg(x), y)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rad2deg.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rad2deg.md
@@ -1,4 +1,5 @@
 ## [torch 参数更多 ]torch.rad2deg
+
 ### [torch.rad2deg](https://pytorch.org/docs/1.13/generated/torch.rad2deg.html?highlight=torch+rad2deg#torch.rad2deg)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.reciprocal.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.reciprocal.md
@@ -1,4 +1,5 @@
 ## [torch 参数更多]torch.reciprocal
+
 ### [torch.reciprocal](https://pytorch.org/docs/1.13/generated/torch.reciprocal.html?highlight=torch+reciprocal#torch.reciprocal)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.reciprocal.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.reciprocal.md
@@ -1,5 +1,5 @@
 ## [torch 参数更多]torch.reciprocal
-### [torch.reciprocal](https://pytorch.org/docs/stable/generated/torch.reciprocal.html?highlight=reciprocal#torch.reciprocal)
+### [torch.reciprocal](https://pytorch.org/docs/1.13/generated/torch.reciprocal.html?highlight=torch+reciprocal#torch.reciprocal)
 
 ```python
 torch.reciprocal(input,
@@ -7,7 +7,7 @@ torch.reciprocal(input,
                  out=None)
 ```
 
-### [paddle.reciprocal](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/reciprocal_cn.html#reciprocal)
+### [paddle.reciprocal](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/reciprocal_cn.html)
 
 ```python
 paddle.reciprocal(x,


### PR DESCRIPTION
完成分组No.40文档映射，其中提交9个md文件。
torch.nan_to_num因Paddle功能缺失，未添加。