### PR TITLE
修复api 文档错误

### DIFF
--- a/docs/api/paddle/utils/cpp_extension/load_cn.rst
+++ b/docs/api/paddle/utils/cpp_extension/load_cn.rst
@@ -3,7 +3,7 @@
 load
 -------------------------------
 
-.. py:function:: paddle.utils.cpp_extension.load(name, sources, extra_cxx_cflags=None, extra_cuda_cflags=None, extra_ldflags=None, extra_include_paths=None, build_directory=None, interpreter=None, verbose=False)
+.. py:function:: paddle.utils.cpp_extension.load(name, sources, extra_cxx_cflags=None, extra_cuda_cflags=None, extra_ldflags=None, extra_include_paths=None, build_directory=None, verbose=False)
 
 此接口将即时编译（Just-In-Time）传入的自定义 OP 对应的 cpp 和 cuda 源码文件，返回一个包含自定义算子 API 的 ``Module`` 对象。
 


### PR DESCRIPTION
fix api/paddle/utils/cpp_extension/load_cn.rst
参数 interpreter=None 在源码中不存在。
https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/cpp_extension/load_cn.html https://github.com/PaddlePaddle/Paddle/blob/release/2.4/python/paddle/utils/cpp_extension/cpp_extension.py#L805 查阅文档发现，2.0版本有参数interpreter， 之后2.1， 2.2， 2.3， 2.4 版本没有这个参数。