### PR TITLE
 映射文档 No. 352/353

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -677,6 +677,9 @@
 | 13   |  [torch.cuda.memory_reserved](https://pytorch.org/docs/1.13/generated/torch.cuda.memory_reserved.html#torch.cuda.memory_reserved)  |  [paddle.device.cuda.memory_reserved](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/device/cuda/memory_reserved_cn.html)  |    功能一致, 参数完全一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.memory_reserved.md)  |
 | 14   |  [torch.cuda.memory_allocated](https://pytorch.org/docs/1.13/generated/torch.cuda.memory_allocated.html#torch.cuda.memory_allocated)  |  [paddle.device.cuda.memory_allocated](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/device/cuda/memory_allocated_cn.html)  |    功能一致, 参数完全一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.memory_allocated.md)  |
 | 15   |  [torch.cuda.synchronize](https://pytorch.org/docs/1.13/generated/torch.cuda.synchronize.html#torch.cuda.synchronize)  |  [paddle.device.cuda.synchronize](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/device/cuda/synchronize_cn.html)  |    功能一致, 参数完全一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.synchronize.md)  |
+| 16   |  [torch.cuda.memory_usage](https://pytorch.org/docs/1.13/generated/torch.cuda.memory_usage.html#torch.cuda.memory_usage)  |  | 功能缺失        |
+| 17   |  [torch.cuda.mem_get_info](https://pytorch.org/docs/1.13/generated/torch.cuda.mem_get_info.html#torch.cuda.mem_get_info)  |  | 功能缺失        |
+
 
 ***持续更新...***
 


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaConvert/issues/112

352 torch.cuda.memory_usage
353 torch.cuda.mem_get_info

paddle无匹配api
paddle 有paddle.device.cuda.memory_allocated, paddle.device.cuda. memory_reserved 获取已分配和 Allocator 管理的显存大小
和torch获取信息不同，torch获取总内存，和空闲内存