### PR TITLE
 映射文档 No. 271/273/280/283/297/298/301/325/337/339-348

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -285,6 +285,7 @@
 | 253   |  [torch.nanmean](https://pytorch.org/docs/1.13/generated/torch.nanmean.html?highlight=nanmean#torch.nanmean)  |  [paddle.nanmean](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nanmean_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.nanmean.md)  |
 | 254   |  [torch.take_along_dim](https://pytorch.org/docs/1.13/generated/torch.take_along_dim.html?highlight=torch+take_along_dim#torch.take_along_dim)  |  [paddle.take_along_axis](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/take_along_axis_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.take_along_dim.md)  |
 | 254   |  [torch.geqrf](https://pytorch.org/docs/stable/generated/torch.geqrf.html?highlight=geqrf#torch.geqrf)  |   |    功能缺失  |
+| 255   |  [torch.bitwise_right_shift](https://pytorch.org/docs/1.13/generated/torch.bitwise_right_shift.html#torch.bitwise_right_shift)  |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -622,6 +623,7 @@
 | 165   |  [torch.Tensor.less](https://pytorch.org/docs/1.13/generated/torch.Tensor.less.html)  |  [paddle.Tensor.less_than](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/Tensor_cn.html#less-than-y-name-none)  |    功能一致, 参数不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.less.md)  |
 | 166   |  [torch.Tensor.all](https://pytorch.org/docs/1.13/generated/torch.Tensor.all.html?highlight=torch+tensor+all#torch.Tensor.all)  |  [paddle.Tensor.all](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/Tensor_cn.html#all-axis-none-keepdim-false-name-none)  |    功能一致, 参数不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.all.md)  |
 | 167   |  [torch.Tensor.any](https://pytorch.org/docs/1.13/generated/torch.Tensor.any.html?highlight=torch+tensor+any#torch.Tensor.any)  |  [paddle.Tensor.any](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/Tensor_cn.html#any-axis-none-keepdim-false-name-none)  |    功能一致, 参数不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.any.md)  |
+| 168   |  [torch.Tensor.bitwise_right_shift](https://pytorch.org/docs/1.13/generated/torch.Tensor.bitwise_right_shift.html#torch.Tensor.bitwise_right_shift)  |  | 功能缺失        |
 
 ***持续更新...***
 

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -293,6 +293,8 @@
 | 260   |  [torch.scatter_reduce](https://pytorch.org/docs/1.13/generated/torch.scatter_reduce.html#torch.scatter_reduce)  |  | 功能缺失        |
 | 261   |  [torch.set_deterministic_debug_mode](https://pytorch.org/docs/1.13/generated/torch.set_deterministic_debug_mode.html#torch.set_deterministic_debug_mode)  |  | 功能缺失        |
 | 262   |  [torch.get_deterministic_debug_mode](https://pytorch.org/docs/1.13/generated/torch.get_deterministic_debug_mode.html#torch.get_deterministic_debug_mode)  |  | 功能缺失        |
+| 263   |  [torch.vsplit](https://pytorch.org/docs/1.13/generated/torch.vsplit.html#torch.vsplit)  |  | 功能缺失        |
+| 264   |  [torch.hsplit](https://pytorch.org/docs/1.13/generated/torch.hsplit.html#torch.hsplit)  |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -636,6 +638,9 @@
 | 171   |  [torch.Tensor.scatter_reduce](https://pytorch.org/docs/1.13/generated/torch.Tensor.scatter_reduce.html#torch.Tensor.scatter_reduce)  |  | 功能缺失        |
 | 172   |  [torch.Tensor.select_scatter](https://pytorch.org/docs/1.13/generated/torch.Tensor.select_scatter.html#torch.Tensor.select_scatter)  |  | 功能缺失        |
 | 173   |  [torch.Tensor.slice_scatter](https://pytorch.org/docs/1.13/generated/torch.Tensor.slice_scatter.html#torch.Tensor.slice_scatter)  |  | 功能缺失        |
+| 174   |  [torch.Tensor.hsplit](https://pytorch.org/docs/1.13/generated/torch.Tensor.hsplit.html#torch.Tensor.hsplit)  |  | 功能缺失        |
+| 175   |  [torch.Tensor.vsplit](https://pytorch.org/docs/1.13/generated/torch.Tensor.vsplit.html#torch.Tensor.vsplit)  |  | 功能缺失        |
+| 176   |  [torch.Tensor.dsplit](https://pytorch.org/docs/1.13/generated/torch.Tensor.dsplit.html#torch.Tensor.dsplit)  |  | 功能缺失        |
 
 ***持续更新...***
 

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -286,6 +286,7 @@
 | 254   |  [torch.take_along_dim](https://pytorch.org/docs/1.13/generated/torch.take_along_dim.html?highlight=torch+take_along_dim#torch.take_along_dim)  |  [paddle.take_along_axis](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/take_along_axis_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.take_along_dim.md)  |
 | 254   |  [torch.geqrf](https://pytorch.org/docs/stable/generated/torch.geqrf.html?highlight=geqrf#torch.geqrf)  |   |    功能缺失  |
 | 255   |  [torch.bitwise_right_shift](https://pytorch.org/docs/1.13/generated/torch.bitwise_right_shift.html#torch.bitwise_right_shift)  |  | 功能缺失        |
+| 256   |  [torch.is_conj](https://pytorch.org/docs/1.13/generated/torch.is_conj.html#torch.is_conj)  |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -624,6 +625,7 @@
 | 166   |  [torch.Tensor.all](https://pytorch.org/docs/1.13/generated/torch.Tensor.all.html?highlight=torch+tensor+all#torch.Tensor.all)  |  [paddle.Tensor.all](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/Tensor_cn.html#all-axis-none-keepdim-false-name-none)  |    功能一致, 参数不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.all.md)  |
 | 167   |  [torch.Tensor.any](https://pytorch.org/docs/1.13/generated/torch.Tensor.any.html?highlight=torch+tensor+any#torch.Tensor.any)  |  [paddle.Tensor.any](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/Tensor_cn.html#any-axis-none-keepdim-false-name-none)  |    功能一致, 参数不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.any.md)  |
 | 168   |  [torch.Tensor.bitwise_right_shift](https://pytorch.org/docs/1.13/generated/torch.Tensor.bitwise_right_shift.html#torch.Tensor.bitwise_right_shift)  |  | 功能缺失        |
+| 169   |  [torch.Tensor.is_conj](https://pytorch.org/docs/1.13/generated/torch.Tensor.is_conj.html#torch.Tensor.is_conj)  |  | 功能缺失        |
 
 ***持续更新...***
 

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -287,6 +287,12 @@
 | 254   |  [torch.geqrf](https://pytorch.org/docs/stable/generated/torch.geqrf.html?highlight=geqrf#torch.geqrf)  |   |    功能缺失  |
 | 255   |  [torch.bitwise_right_shift](https://pytorch.org/docs/1.13/generated/torch.bitwise_right_shift.html#torch.bitwise_right_shift)  |  | 功能缺失        |
 | 256   |  [torch.is_conj](https://pytorch.org/docs/1.13/generated/torch.is_conj.html#torch.is_conj)  |  | 功能缺失        |
+| 257   |  [torch.diagonal_scatter](https://pytorch.org/docs/1.13/generated/torch.diagonal_scatter.html#torch.diagonal_scatter)  |  | 功能缺失        |
+| 258   |  [torch.select_scatter](https://pytorch.org/docs/1.13/generated/torch.select_scatter.html#torch.select_scatter)  |  | 功能缺失        |
+| 259   |  [torch.slice_scatter](https://pytorch.org/docs/1.13/generated/torch.slice_scatter.html#torch.slice_scatter)  |  | 功能缺失        |
+| 260   |  [torch.scatter_reduce](https://pytorch.org/docs/1.13/generated/torch.scatter_reduce.html#torch.scatter_reduce)  |  | 功能缺失        |
+| 261   |  [torch.set_deterministic_debug_mode](https://pytorch.org/docs/1.13/generated/torch.set_deterministic_debug_mode.html#torch.set_deterministic_debug_mode)  |  | 功能缺失        |
+| 262   |  [torch.get_deterministic_debug_mode](https://pytorch.org/docs/1.13/generated/torch.get_deterministic_debug_mode.html#torch.get_deterministic_debug_mode)  |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -626,6 +632,10 @@
 | 167   |  [torch.Tensor.any](https://pytorch.org/docs/1.13/generated/torch.Tensor.any.html?highlight=torch+tensor+any#torch.Tensor.any)  |  [paddle.Tensor.any](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/Tensor_cn.html#any-axis-none-keepdim-false-name-none)  |    功能一致, 参数不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.any.md)  |
 | 168   |  [torch.Tensor.bitwise_right_shift](https://pytorch.org/docs/1.13/generated/torch.Tensor.bitwise_right_shift.html#torch.Tensor.bitwise_right_shift)  |  | 功能缺失        |
 | 169   |  [torch.Tensor.is_conj](https://pytorch.org/docs/1.13/generated/torch.Tensor.is_conj.html#torch.Tensor.is_conj)  |  | 功能缺失        |
+| 170   |  [torch.Tensor.diagonal_scatter](https://pytorch.org/docs/1.13/generated/torch.Tensor.diagonal_scatter.html#torch.Tensor.diagonal_scatter)  |  | 功能缺失        |
+| 171   |  [torch.Tensor.scatter_reduce](https://pytorch.org/docs/1.13/generated/torch.Tensor.scatter_reduce.html#torch.Tensor.scatter_reduce)  |  | 功能缺失        |
+| 172   |  [torch.Tensor.select_scatter](https://pytorch.org/docs/1.13/generated/torch.Tensor.select_scatter.html#torch.Tensor.select_scatter)  |  | 功能缺失        |
+| 173   |  [torch.Tensor.slice_scatter](https://pytorch.org/docs/1.13/generated/torch.Tensor.slice_scatter.html#torch.Tensor.slice_scatter)  |  | 功能缺失        |
 
 ***持续更新...***
 


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaConvert/issues/112

271 torch.vsplit
273 torch.hsplit
280 torch.Tensor.hsplit
283 torch.Tensor.vsplit
297 torch.Tensor.dsplit
hsplit vsplit dsplit 在torch中对应torch.tensor_split，indices_or_sections 参数是序号，不是区块数，paddle.split中为区块数，所以不匹配

298 torch.Tensor.bitwise_right_shift
301 torch.bitwise_right_shift
325 torch.Tensor.is_conj
337 torch.is_conj
339 torch.diagonal_scatter
340 torch.select_scatter
341 torch.slice_scatter
342 torch.scatter_reduce
343 torch.set_deterministic_debug_mode
344 torch.get_deterministic_debug_mode
345 torch.Tensor.diagona_scatter
346 torch.Tensor.scatter_reduce
347 torch.Tensor.select_scatter
348 torch.Tensor.slice_scatter

paddle列表没有 bitwise_right_shift
![图片](https://github.com/PaddlePaddle/docs/assets/4617245/0ed8d70d-a491-4d46-9144-503580280777)

is_conj搜索结果为空
![图片](https://github.com/PaddlePaddle/docs/assets/4617245/b420180f-aac3-4d85-a95d-860786cbe61d)

scatter没有匹配api
![图片](https://github.com/PaddlePaddle/docs/assets/4617245/4d2eb450-2947-4828-a892-416b5046a52e)

deterministic_debug
![图片](https://github.com/PaddlePaddle/docs/assets/4617245/67fa9e88-17e8-4606-82e9-ba16e42950ba)
