### PR TITLE
Fix strip ps

### DIFF
--- a/ci_scripts/chinese_samplecode_processor.py
+++ b/ci_scripts/chinese_samplecode_processor.py
@@ -89,6 +89,7 @@ def _hasprefix(line, prefixes):
     return any(line == p or line.startswith(p + ' ') for p in prefixes)
 
 
+# TODO(megemini): skip test with PS1/PS2 when Paddle CI xdoctest finished.
 def strip_ps_from_codeblock(codeblock):
     """strip PS1(>>> ) and PS2(... ) from codeblock
 

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -1159,9 +1159,7 @@ def extract_code_blocks_from_docstr(docstr, google_style=True):
         # nonlocal code_blocks, cb_cur, cb_cur_name, cb_cur_seq_id, cb_required
         code_blocks.append(
             {
-                'codes': strip_ps_from_codeblock(
-                    inspect.cleandoc("\n" + "\n".join(cb_info['cb_cur']))
-                ),
+                'codes': inspect.cleandoc("\n" + "\n".join(cb_info['cb_cur'])),
                 'name': cb_info['cb_cur_name'],
                 'id': cb_info['cb_cur_seq_id'],
                 'required': cb_info['cb_required'],
@@ -1281,7 +1279,7 @@ def extract_sample_codes_into_dir():
                         )
                     else:
                         header = 'import os\nos.environ["CUDA_VISIBLE_DEVICES"] = ""\n\n'
-                    cb = cb_info['codes']
+                    cb = strip_ps_from_codeblock(cb_info['codes'])
                     last_future_line_end = find_last_future_line_end(cb)
                     if last_future_line_end:
                         f.write(cb[:last_future_line_end])

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -1030,6 +1030,7 @@ def _hasprefix(line, prefixes):
     return any(line == p or line.startswith(p + ' ') for p in prefixes)
 
 
+# TODO(megemini): skip test with PS1/PS2 when Paddle CI xdoctest finished.
 def strip_ps_from_codeblock(codeblock):
     """strip PS1(>>> ) and PS2(... ) from codeblock
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->

#### 问题描述
中文文档没有 copy 原始的 code-block。
英文文档：
 <img alt="image" width="924" src="https://user-images.githubusercontent.com/38436475/253816734-0049443b-e251-421e-a748-6054ed6d2165.png">
中文文档：
<img alt="image" width="880" src="https://user-images.githubusercontent.com/38436475/253816769-35e6336f-84e7-4ed6-a755-015ea471a81b.png">

#### 原因分析
Paddle docs `docs/api/gen_doc.py` 里面新加的这个 `strip_ps_from_codeblock` 不应该放在 `extract_code_blocks_from_docstr` 这个方法里面。

`strip_ps_from_codeblock` 的目的本来是防止代码检查的时候出错，但是放在 `extract_code_blocks_from_docstr` 里面导致 `docs/api/copy_codes_from_en_doc.py` copy 代码的时候也 strip 了，从而出现中文文档与英文文档不一致的情况...

#### 解决方案
将 `strip_ps_from_codeblock` 移到  `docs/api/gen_doc.py` 中实际进行代码检查的部分：`extract_sample_codes_into_dir`，保持
`extract_code_blocks_from_docstr` 功能为只提取 code-block，不进行 strip。

另外，`ci_scripts/chinese_samplecode_processor.py` 中也有 `strip_ps_from_codeblock` 方法，但不影响文档的生成，不做修改。

关联 PR： https://github.com/PaddlePaddle/Paddle/pull/55295
