### PR TITLE
add cmake argument for ROCM DCU environment

### DIFF
--- a/docs/guides/hardware_support/rocm_docs/paddle_install_cn.md
+++ b/docs/guides/hardware_support/rocm_docs/paddle_install_cn.md
@@ -5,7 +5,7 @@
 - 通过预编译的 wheel 包安装
 - 通过源代码编译安装
 
-**说明**：基于对应 DTK 版本的飞桨 wheel 包可在[光合开发者社区 ](https://developer.hpccube.com/tool/#sdk) AI 生态包中进行下载。
+**说明**：基于对应 DTK 版本的飞桨 wheel 包可在[光合开发者社区](https://developer.hpccube.com/tool/#sdk) AI 生态包中进行下载。
 
 ## 安装方式一：通过 wheel 包安装
 
@@ -116,8 +116,8 @@ cd Paddle
 mkdir build && cd build
 
 # 执行 cmake
-cmake .. -DPY_VERSION=3.7 -DWITH_ROCM=ON -DWITH_TESTING=ON -DWITH_DISTRIBUTE=ON \
-         -DWITH_MKL=ON -DCMAKE_BUILD_TYPE=Release
+cmake .. -DPY_VERSION=3.7 -DWITH_GPU=OFF -DWITH_ROCM=ON -DWITH_TESTING=ON -DWITH_DISTRIBUTE=ON \
+     -DWITH_MKL=ON -DCMAKE_BUILD_TYPE=Release
 
 # 使用以下命令来编译
 make -j$(nproc)


### PR DESCRIPTION
ROCM 设备上，cmake 编译命令指定 `-DWITH_GPU=OFF`，否则在 AIStudio 上编译 cmake 时会报错，因为会触发 `CMakelists.txt` 中的报错检查
![BD25908299901E0339160494AAE389E3](https://github.com/PaddlePaddle/docs/assets/23737287/636f5212-6aa3-49f3-afe7-bbf6bbe08117)

![image](https://github.com/PaddlePaddle/docs/assets/23737287/17c17744-082f-4848-98fd-1de3abdd74ad)
