### PR TITLE
映射文档 No.214 `torch.linalg.tensorinv`

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
@@ -16,24 +16,13 @@ PaddlePaddle 目前无对应 API，可使用如下代码组合实现该 API。
 A = torch.eye(4 * 6).reshape((4, 6, 8, 3))
 A_inv = torch.linalg.tensorinv(A, ind=2)
 
-# PyTorch 转写：
-A = torch.eye(4 * 6).reshape((4, 6, 8, 3))
-ind = 2
-A_dim_0 = torch.prod(torch.tensor(A.shape[ind:]))
-A_dim_1 = torch.prod(torch.tensor(A.shape[:ind]))
-# assert A_dim_0 == A_dim_1
-A_ = torch.reshape(A, [A_dim_0, A_dim_1])
-A_inv_ = torch.inverse(A_)
-
-A_inv = torch.reshape(A_inv_, A.shape[ind:] + A.shape[:ind])
-
-# Paddle 写法:
+# Paddle 转写：
 A = paddle.eye(4 * 6).reshape((4, 6, 8, 3))
 ind = 2
-A_dim_0 = paddle.prod(paddle.to_tensor(A.shape[ind:]))
-A_dim_1 = paddle.prod(paddle.to_tensor(A.shape[:ind]))
+A_dim_0 = prod(A.shape[ind:]) # 4 * 6 == 24
+A_dim_1 = prod(A.shape[:ind]) # 8 * 3 == 24
 # assert A_dim_0 == A_dim_1
-A_ = paddle.reshape(A, [int(A_dim_0), int(A_dim_1)])
+A_ = paddle.reshape(A, [A_dim_0, A_dim_1])
 A_inv_ = paddle.linalg.inv(A_)
 
 A_inv = paddle.reshape(A_inv_, A.shape[ind:] + A.shape[:ind])

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
@@ -6,12 +6,6 @@
 torch.linalg.tensorinv(A, ind=2, *, out=None)
 ```
 
-### [paddle.linalg.inv](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/inv_cn.html)
-
-```python
-paddle.linalg.inv(x, name=None)
-```
-
 PaddlePaddle 目前无对应 API，可使用如下代码组合实现该 API。
 
 ## 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
@@ -1,0 +1,46 @@
+## [组合替代实现]torch.linalg.tensorinv
+
+### [torch.linalg.inv](https://pytorch.org/docs/stable/generated/torch.linalg.tensorinv.html#torch-linalg-tensorinv)
+
+```python
+torch.linalg.tensorinv(A, ind=2, *, out=None)
+```
+
+### [paddle.linalg.inv](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/inv_cn.html)
+
+```python
+paddle.linalg.inv(x, name=None)
+```
+
+PaddlePaddle 目前无对应 API，可使用如下代码组合实现该 API。
+
+## 转写示例
+
+
+```python
+# PyTorch 写法:
+A = torch.eye(4 * 6).reshape((4, 6, 8, 3))
+A_inv = torch.linalg.tensorinv(A, ind=2)
+
+# PyTorch 转写：
+A = torch.eye(4 * 6).reshape((4, 6, 8, 3))
+ind = 2
+A_dim_0 = torch.prod(torch.tensor(A.shape[ind:]))
+A_dim_1 = torch.prod(torch.tensor(A.shape[:ind]))
+# assert A_dim_0 == A_dim_1
+A_ = torch.reshape(A, [A_dim_0, A_dim_1])
+A_inv_ = torch.inverse(A_)
+
+A_inv = torch.reshape(A_inv_, A.shape[ind:] + A.shape[:ind])
+
+# Paddle 写法:
+A = paddle.eye(4 * 6).reshape((4, 6, 8, 3))
+ind = 2
+A_dim_0 = paddle.prod(paddle.to_tensor(A.shape[ind:]))
+A_dim_1 = paddle.prod(paddle.to_tensor(A.shape[:ind]))
+# assert A_dim_0 == A_dim_1
+A_ = paddle.reshape(A, [int(A_dim_0), int(A_dim_1)])
+A_inv_ = paddle.linalg.inv(A_)
+
+A_inv = paddle.reshape(A_inv_, A.shape[ind:] + A.shape[:ind])
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.tensorinv.md
@@ -1,4 +1,4 @@
-## [组合替代实现]torch.linalg.tensorinv
+## [功能缺失]torch.linalg.tensorinv
 
 ### [torch.linalg.inv](https://pytorch.org/docs/stable/generated/torch.linalg.tensorinv.html#torch-linalg-tensorinv)
 
@@ -6,24 +6,4 @@
 torch.linalg.tensorinv(A, ind=2, *, out=None)
 ```
 
-PaddlePaddle 目前无对应 API，可使用如下代码组合实现该 API。
-
-## 转写示例
-
-
-```python
-# PyTorch 写法:
-A = torch.eye(4 * 6).reshape((4, 6, 8, 3))
-A_inv = torch.linalg.tensorinv(A, ind=2)
-
-# Paddle 转写：
-A = paddle.eye(4 * 6).reshape((4, 6, 8, 3))
-ind = 2
-A_dim_0 = prod(A.shape[ind:]) # 4 * 6 == 24
-A_dim_1 = prod(A.shape[:ind]) # 8 * 3 == 24
-# assert A_dim_0 == A_dim_1
-A_ = paddle.reshape(A, [A_dim_0, A_dim_1])
-A_inv_ = paddle.linalg.inv(A_)
-
-A_inv = paddle.reshape(A_inv_, A.shape[ind:] + A.shape[:ind])
-```
+PaddlePaddle 目前无对应 API。


### PR DESCRIPTION
- https://github.com/PaddlePaddle/PaConvert/issues/112

`torch.linalg.tensorinv` 特点：
- 无对应 API，映射到 `paddle.linalg.inv` 以组合替代实现。