### PR TITLE
修复 映射文档 No.53 `torch.nn.PoissonNLLLoss` 的bug

### DIFF
--- a/docs/api/paddle/nn/PoissonNLLLoss_cn.rst
+++ b/docs/api/paddle/nn/PoissonNLLLoss_cn.rst
@@ -3,7 +3,7 @@
 PoissonNLLLoss
 -------------------------------
 
-.. py:class:: paddle.nn.PoissonNLLLoss(log_input=False, full=False, eps=1e-8, reduction='mean', name=None)
+.. py:class:: paddle.nn.PoissonNLLLoss(log_input=True, full=False, eps=1e-8, reduction='mean', name=None)
 
 该接口可创建一个 PoissonNLLLoss 可调用类，计算输入 :attr:`input` 和标签 :attr:`label` 间的 `Poisson negative log likelihood loss` 损失。该 loss 适用于真实标签服从于泊松分布时，即
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.PoissonNLLLoss.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.PoissonNLLLoss.md
@@ -9,7 +9,7 @@ torch.nn.PoissonNLLLoss(log_input=True, full=False, size_average=None, eps=1e-08
 ### [paddle.nn.PoissonNLLLoss](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/PoissonNLLLoss_cn.html)
 
 ```python
-paddle.nn.PoissonNLLLoss(log_input=False, full=False, eps=1e-8, reduction='mean', name=None)
+paddle.nn.PoissonNLLLoss(log_input=True, full=False, eps=1e-8, reduction='mean', name=None)
 ```
 
 其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -23,7 +23,7 @@ paddle.nn.PoissonNLLLoss(log_input=False, full=False, eps=1e-8, reduction='mean'
 | size_average       | -                  | 已废弃（可用 `reduction` 代替）。表示是否采用 batch 中各样本 loss 平均值作为最终的 loss。如果置 False，则采用加和作为 loss。默认为 True，paddle 需要转写。    |
 | eps                | eps                | 在 `log_input` 为 True 时使用的常数小量。默认值为 1e-8。                            |
 | reduce             | -                  | 已废弃（可用 `reduction` 代替）。表示是否采用输出单个值作为 loss。如果置 False，则每个元素输出一个 loss 并忽略 `size_average`。默认为 True，paddle 需要转写。 |
-| reduction          | reduction          | 指定应用于输出结果的计算方式，可选值有 `none`、`mean` 和 `sum`。默认为 `mean`，计算 mini-batch loss 均值。设置为 `sum` 时，计算 mini-batch loss 的总和。设置为 `none` 时，则返回 loss Tensor。默认值下为 `mean`。   |
+| reduction          | reduction          | 指定应用于输出结果的计算方式，可选值有 `none`、`mean` 和 `sum`。默认为 `mean`，计算 mini-batch loss 均值。设置为 `sum` 时，计算 mini-batch loss 的总和。设置为 `none` 时，则返回 loss Tensor。默认值下为 `mean`。两者完全一致。   |
 
 ### 转写示例
 


### PR DESCRIPTION
- https://github.com/PaddlePaddle/PaConvert/issues/112
- #6055

修复存在的两个问题：
- 添加对 `reduction` 参数的转写描述
- 修复 `PoissonNLLLoss` 中文文档与 `docstring` 不一致的错误

@zhwesky2010 