### PR TITLE
映射文档 No.243-300 其他未领取项

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.set_stream.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.set_stream.md
@@ -1,0 +1,21 @@
+## [参数完全一致]torch.cuda.set_stream
+
+### [torch.cuda.set_stream](https://pytorch.org/docs/stable/generated/torch.cuda.set_stream.html#torch.cuda.set_stream)
+
+```python
+torch.cuda.set_stream(stream)
+```
+
+### [paddle.device.set_stream](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/device/set_stream_cn.html#set-stream)
+
+```python
+paddle.device.set_stream(stream=None)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                |
+| ------- | ------------ | ------------------- |
+| stream  | stream       | 希望设置的 stream。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.svdvals.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.svdvals.md
@@ -1,0 +1,47 @@
+## [ torch 参数更多 ] torch.linalg.svdvals
+
+### [torch.linalg.svdvals](https://pytorch.org/docs/stable/generated/torch.linalg.svdvals.html#torch.linalg.svdvals)
+
+```python
+torch.linalg.svdvals(A, *, driver=None, out=None)
+```
+
+### [paddle.linalg.svd](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/svd_cn.html)
+
+```python
+paddle.linalg.svd(x, full_matrices=False, name=None)
+```
+
+其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle  | 备注                                                                                 |
+| ------- | ------------- | ------------------------------------------------------------------------------------ |
+| A       | x             | 输入 Tensor，仅参数名不一致。                                                        |
+| driver  | -             | cuSOLVER 方法名，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。           |
+| -       | full_matrices | 是否计算完整的 U 和 V 矩阵，Paddle 为 False，Pytorch 无此参数，Paddle 使用默认即可。 |
+| out     | -             | 表示输出的 Tensor，Paddle 无此参数，需要转写。                                       |
+| 返回值  | 返回值        | PyTorch 返回值为 S，Paddle 返回 U、S、VH，需要转写。                                 |
+
+### 转写示例
+
+#### out 参数：输出的 Tensor
+
+```python
+# PyTorch 写法:
+torch.linalg.svdvals(x, out=y)
+
+# Paddle 写法:
+paddle.assign(paddle.linalg.svd(x)[1], y)
+```
+
+#### 返回值
+
+```python
+# PyTorch 写法:
+y = torch.linalg.svdvals(x)
+
+# Paddle 写法:
+y = paddle.linalg.svd(x)[1]
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.backward.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.backward.md
@@ -1,0 +1,23 @@
+## [仅 Paddle 参数更多]torch.autograd.Function.backward
+
+### [torch.autograd.Function.backward](https://pytorch.org/docs/stable/generated/torch.autograd.Function.backward.html#torch.autograd.Function.backward)
+
+```python
+torch.autograd.Function.backward(ctx, *grad_outputs)
+```
+
+### [paddle.autograd.PyLayer.backward](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/PyLayer_cn.html#backward-ctx-args-kwargs)
+
+```python
+paddle.autograd.PyLayer.backward(ctx, *args, **kwargs)
+```
+
+Paddle 相比 PyTorch 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch      | PaddlePaddle | 备注                                                                |
+| ------------ | ------------ | ------------------------------------------------------------------- |
+| ctx          | ctx          | 上下文对象。                                                        |
+| grad_outputs | args         | forward 输出 Tensor 的梯度，仅参数名不一致。                        |
+| -            | kwargs       | forward 输出 Tensor 的梯度，PyTorch 无此参数，Paddle 保持默认即可。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.forward.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.forward.md
@@ -1,0 +1,23 @@
+## [参数完全一致]torch.autograd.Function.forward
+
+### [torch.autograd.Function.forward](https://pytorch.org/docs/stable/generated/torch.autograd.Function.forward.html#torch.autograd.Function.forward)
+
+```python
+torch.autograd.Function.forward(ctx, *args, **kwargs)
+```
+
+### [paddle.autograd.PyLayer.forward](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/PyLayer_cn.html#forward-ctx-args-kwargs)
+
+```python
+paddle.autograd.PyLayer.forward(ctx, *args, **kwargs)
+```
+
+两者功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注               |
+| ------- | ------------ | ------------------ |
+| ctx     | ctx          | 上下文对象。       |
+| args    | args         | 自定义算子的输入。 |
+| kwargs  | kwargs       | 自定义算子的输入。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.md
@@ -1,0 +1,22 @@
+## [torch 参数更多]torch.autograd.Function
+
+### [torch.autograd.Function](https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)
+
+```python
+torch.autograd.Function(*args, **kwargs)
+```
+
+### [paddle.autograd.PyLayer](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/PyLayer_cn.html#paddle.autograd.PyLayer)
+
+```python
+paddle.autograd.PyLayer()
+```
+
+其中 PyTorch 相比 Paddle 支持更多其他参数，但该类一般用于继承实现，不会调用其参数。
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                      |
+| ------- | ------------ | ----------------------------------------- |
+| args    | -            | 自定义参数，Paddle 无此参数，可直接删除。 |
+| kwargs  | -            | 自定义参数，Paddle 无此参数，可直接删除。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.function.FunctionCtx.mark_non_differentiable.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.function.FunctionCtx.mark_non_differentiable.md
@@ -1,0 +1,21 @@
+## [仅参数名不一致]torch.autograd.function.FunctionCtx.mark_non_differentiable
+
+### [torch.autograd.function.FunctionCtx.mark_non_differentiable](https://pytorch.org/docs/stable/generated/torch.autograd.function.FunctionCtx.mark_non_differentiable.html#torch.autograd.function.FunctionCtx.mark_non_differentiable)
+
+```python
+torch.autograd.function.FunctionCtx.mark_non_differentiable(*args)
+```
+
+### [paddle.autograd.PyLayerContext.mark_non_differentiable](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/PyLayerContext_cn.html#mark-non-differentiable-self-tensors)
+
+```python
+paddle.autograd.PyLayerContext.mark_non_differentiable(*tensors)
+```
+
+两者功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                          |
+| ------- | ------------ | ----------------------------- |
+| args    | tensors      | 需要标记不需要反向的 Tensor。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.function.FunctionCtx.save_for_backward.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.function.FunctionCtx.save_for_backward.md
@@ -1,0 +1,21 @@
+## [参数完全一致]torch.autograd.function.FunctionCtx.save_for_backward
+
+### [torch.autograd.function.FunctionCtx.save_for_backward](https://pytorch.org/docs/stable/generated/torch.autograd.function.FunctionCtx.save_for_backward.html#torch.autograd.function.FunctionCtx.save_for_backward)
+
+```python
+torch.autograd.function.FunctionCtx.save_for_backward(*tensors)
+```
+
+### [paddle.autograd.PyLayerContext.save_for_backward](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/PyLayerContext_cn.html#save-for-backward-tensors)
+
+```python
+paddle.autograd.PyLayerContext.save_for_backward(*tensors)
+```
+
+两者功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                  |
+| ------- | ------------ | --------------------- |
+| tensors | tensors      | 需要被暂存的 Tensor。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.function.FunctionCtx.set_materialize_grads.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.function.FunctionCtx.set_materialize_grads.md
@@ -1,0 +1,21 @@
+## [参数完全一致]torch.autograd.function.FunctionCtx.set_materialize_grads
+
+### [torch.autograd.function.FunctionCtx.set_materialize_grads](https://pytorch.org/docs/stable/generated/torch.autograd.function.FunctionCtx.set_materialize_grads.html#torch.autograd.function.FunctionCtx.set_materialize_grads)
+
+```python
+torch.autograd.function.FunctionCtx.set_materialize_grads(value)
+```
+
+### [paddle.autograd.PyLayerContext.set_materialize_grads](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/PyLayerContext_cn.html#set-materialize-grads-self-value)
+
+```python
+paddle.autograd.PyLayerContext.set_materialize_grads(value)
+```
+
+两者功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                   |
+| ------- | ------------ | -------------------------------------- |
+| value   | value        | 是否要框架来初始化未初始化的反向梯度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.graph.saved_tensors_hooks.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.graph.saved_tensors_hooks.md
@@ -1,0 +1,22 @@
+## [参数完全一致]torch.autograd.graph.saved_tensors_hooks
+
+### [torch.autograd.graph.saved_tensors_hooks](https://pytorch.org/docs/stable/autograd.html?highlight=saved_tensors_hooks#torch.autograd.graph.saved_tensors_hooks)
+
+```python
+torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook)
+```
+
+### [paddle.autograd.saved_tensors_hooks](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/autograd/saved_tensors_hooks_cn.html)
+
+```python
+paddle.autograd.saved_tensors_hooks(pack_hook, unpack_hook)
+```
+
+两者功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch     | PaddlePaddle | 备注                                                                                      |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------- |
+| pack_hook   | pack_hook    | 当某个算子的前向执行时，存在 Tensor 需要保留给反向计算梯度使用时， pack_hook 将会被调用。 |
+| unpack_hook | unpack_hook  | 当反向执行，需要用到前向保留的 Tensor 时， unpack_hook 会被调用。                         |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.erfc.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.erfc.md
@@ -1,0 +1,19 @@
+## [组合替代实现]torch.special.erfc
+
+### [torch.special.erfc](https://pytorch.org/docs/stable/special.html#torch.special.erfc)
+
+```python
+torch.special.erfc(input, *, out=None)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# Pytorch 写法
+y = torch.special.erfc(x)
+
+# Paddle 写法
+y = 1 - paddle.erf(x)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.exp2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.exp2.md
@@ -1,0 +1,19 @@
+## [组合替代实现]torch.special.exp2
+
+### [torch.special.exp2](https://pytorch.org/docs/stable/special.html#torch.special.exp2)
+
+```python
+torch.special.exp2(input, *, out=None)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# Pytorch 写法
+y = torch.special.exp2(x)
+
+# Paddle 写法
+y = 2 ** x
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expit.md
@@ -1,0 +1,19 @@
+## [组合替代实现]torch.special.expit
+
+### [torch.special.expit](https://pytorch.org/docs/stable/special.html#torch.special.expit)
+
+```python
+torch.special.expit(input, *, out=None)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# Pytorch 写法
+y = torch.special.expit(x)
+
+# Paddle 写法
+y = 1 / (1 + 1 / paddle.exp(x))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.gammaln.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.gammaln.md
@@ -1,0 +1,34 @@
+## [torch 参数更多]torch.special.gammaln
+
+### [torch.special.gammaln](https://pytorch.org/docs/stable/special.html#torch.special.gammaln)
+
+```python
+torch.special.gammaln(input, *, out=None)
+```
+
+### [paddle.lgamma](https://pytorch.org/docs/stable/special.html#torch.special.gammaln)
+
+```python
+paddle.lgamma(x, name=None)
+```
+
+其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                 |
+| ------- | ------------ | ---------------------------------------------------- |
+| input   | x            | 输入的 Tensor，仅参数名不一致。                      |
+| out     | -            | 表示输出的 Tensor ， Paddle 无此参数，需要转写。 |
+
+### 转写示例
+
+#### out：指定输出
+
+```python
+# Pytorch 写法
+torch.special.gammaln(x, out=y)
+
+# Paddle 写法
+paddle.assign(paddle.lgamma(x), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.nn.utils.parametrizations.spectral_norm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.nn.utils.parametrizations.spectral_norm.md
@@ -1,0 +1,25 @@
+## [ 仅参数名不一致 ]torch.nn.utils.parametrizations.spectral_norm
+
+### [torch.nn.utils.parametrizations.spectral_norm](https://pytorch.org/docs/stable/generated/torch.nn.utils.parametrizations.spectral_norm.html#torch.nn.utils.parametrizations.spectral_norm)
+
+```python
+torch.nn.utils.parametrizations.spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=None)
+```
+
+### [paddle.nn.utils.spectral_norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/utils/spectral_norm_cn.html#spectral-norm)
+
+```python
+paddle.nn.utils.spectral_norm(layer, name='weight', n_power_iterations=1, eps=1e-12, dim=None)
+```
+
+PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch            | PaddlePaddle       | 备注                                     |
+| ------------------ | ------------------ | ---------------------------------------- |
+| module             | layer              | 要添加权重谱归一化的层，仅参数名不一致。 |
+| name               | name               | 权重参数的名字。                         |
+| n_power_iterations | n_power_iterations | 将用于计算的 SpectralNorm 幂迭代次数。   |
+| eps                | eps                | 用于保证计算中的数值稳定性。             |
+| dim                | dim                | 重塑为矩阵之前应排列到第一个的维度索引。 |

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -17,6 +17,7 @@
 | [torch.nn.utils.XX](#id5) | 主要为`torch.nn.utils.XX`类 API |
 | [torch.nn.Module.XX](#id15) | 主要为`torch.nn.Module.XX`类 API |
 | [torch.Tensor.XX](#id6) | 主要为`torch.Tensor.XX`类 API |
+| [torch.autograd.XX](#id20) | 主要为`torch.autograd.XX`类 API |
 | [torch.cuda.XX](#id7) | 主要为`torch.cuda.XX`类 API |
 | [torch.distributed.XX](#id8) | 主要为`torch.distributed.XX`类 API |
 | [torch.distributions.XX](#id9)    | 主要为`torch.distributions.XX`类 API |
@@ -24,6 +25,7 @@
 | [torch.hub.XX](#id14)    | 主要为`torch.hub.XX`类 API |
 | [torch.linalg.XX](#id11)    | 主要为`torch.linalg.XX`类 API |
 | [torch.onnx.XX](#id15)    | 主要为`torch.onnx.XX`类 API |
+| [torch.profiler.XX](#id21)    | 主要为`torch.profiler.XX`类 API |
 | [torch.optim.XX](#id22)    | 主要为`torch.optim.XX`类 API |
 | [torch.sparse.XX](#id12)    | 主要为`torch.sparse.XX`类 API |
 | [其他](#id13)    | 其他 API |
@@ -299,6 +301,8 @@
 | 263   |  [torch.vsplit](https://pytorch.org/docs/stable/generated/torch.vsplit.html#torch.vsplit)  |  | 功能缺失        |
 | 264   |  [torch.hsplit](https://pytorch.org/docs/stable/generated/torch.hsplit.html#torch.hsplit)  |  | 功能缺失        |
 | 265   |  [torch.histogram](https://pytorch.org/docs/stable/generated/torch.histogram.html#torch.histogram)  |  | 功能缺失        |
+| 266    | [torch.gradient](https://pytorch.org/docs/stable/generated/torch.gradient.html#torch.gradient) |  | 功能缺失        |
+| 267    | [torch.positive](https://pytorch.org/docs/stable/generated/torch.positive.html#torch.positive) |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -397,9 +401,11 @@
 | 87   |  [torch.nn.MarginRankingLoss](https://pytorch.org/docs/stable/generated/torch.nn.MarginRankingLoss.html#marginrankingloss)  |  [paddle.nn.MarginRankingLoss](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/MarginRankingLoss_cn.html#marginrankingloss)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MarginRankingLoss.md)  |
 | 88   |  [torch.nn.NLLLoss](https://pytorch.org/docs/stable/generated/torch.nn.NLLLoss.html?highlight=nllloss#torch.nn.NLLLoss)  |  [paddle.nn.NLLLoss](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/NLLLoss_cn.html#nllloss)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.NLLLoss.md)  |
 | 89   |  [torch.nn.SoftMarginLoss](https://pytorch.org/docs/stable/generated/torch.nn.SoftMarginLoss.html#torch.nn.SoftMarginLoss)  |  [paddle.nn.SoftMarginLoss](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/SoftMarginLoss_cn.html#softmarginloss)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.SoftMarginLoss.md)  |
-| 90   |  [troch.nn.Mish](https://pytorch.org/docs/stable/generated/torch.nn.Mish.html?highlight=troch+nn+mish)  |  [paddle.nn.Mish](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/Mish_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Mish.md)  |
-| 91   |  [troch.nn.GLU](https://pytorch.org/docs/stable/generated/torch.nn.GLU.html#torch.nn.GLU)  |  | 功能缺失        |
-
+| 90   |  [torch.nn.Mish](https://pytorch.org/docs/stable/generated/torch.nn.Mish.html?highlight=torch+nn+mish)  |  [paddle.nn.Mish](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/Mish_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Mish.md)  |
+| 91   |  [torch.nn.GLU](https://pytorch.org/docs/stable/generated/torch.nn.GLU.html#torch.nn.GLU)  |  | 功能缺失        |
+| 92   |  [torch.nn.LazyBatchNorm1d](https://pytorch.org/docs/stable/generated/torch.nn.LazyBatchNorm1d.html#torch.nn.LazyBatchNorm1d)  |  | 功能缺失        |
+| 93   |  [torch.nn.LazyBatchNorm2d](https://pytorch.org/docs/stable/generated/torch.nn.LazyBatchNorm2d.html#torch.nn.LazyBatchNorm2d)  |  | 功能缺失        |
+| 94   |  [torch.nn.LazyBatchNorm3d](https://pytorch.org/docs/stable/generated/torch.nn.LazyBatchNorm3d.html#torch.nn.LazyBatchNorm3d)  |  | 功能缺失        |
 
 
 ***持续更新...***
@@ -462,6 +468,7 @@
 | 51   | [torch.nn.functional.binary_cross_entropy_with_logits](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/binary_cross_entropy_with_logits_cn.html) | [paddle.nn.functional.binary_cross_entropy_with_logits](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/binary_cross_entropy_with_logits_cn.html) | 功能一致，仅参数命名不一致 [差异对比](https://github.com/PaddlePaddle/docs/blob/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.binary_cross_entropy_with_logits.md) |
 | 52   | [torch.nn.functional.l1_loss](https://pytorch.org/docs/stable/generated/torch.nn.functional.l1_loss.html?highlight=l1_loss#torch.nn.functional.l1_loss) | [paddle.nn.functional.l1_loss](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/l1_loss_cn.html) | 功能一致，仅参数命名不一致 [差异对比](https://github.com/PaddlePaddle/docs/blob/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.l1_loss.md) |
 | 53   | [torch.nn.functional.mish](https://pytorch.org/docs/stable/generated/torch.nn.functional.mish.html?highlight=torch+nn+functional+mish#torch.nn.functional.mish) | [paddle.nn.functional.mish](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/mish_cn.html) | 功能一致，torch 参数更多 [差异对比](https://github.com/PaddlePaddle/docs/blob/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.mish.md) |
+| 54   | [torch.nn.functional.group_norm](https://pytorch.org/docs/stable/generated/torch.nn.functional.group_norm.html#torch.nn.functional.group_norm) |  | 功能缺失 |
 
 ***持续更新...***
 
@@ -649,6 +656,8 @@
 | 177   |  [torch.Tensor.is_coalesced](https://pytorch.org/docs/stable/generated/torch.Tensor.is_coalesced.html#torch.Tensor.is_coalesced)  |  | 功能缺失        |
 | 178   |  [torch.Tensor.histogram](https://pytorch.org/docs/stable/generated/torch.Tensor.histogram.html#torch.Tensor.histogram)  |  | 功能缺失        |
 | 179   |  [torch.Tensor.geqrf](https://pytorch.org/docs/1.13/generated/torch.Tensor.geqrf.html?highlight=torch+tensor+geqrf#torch.Tensor.geqrf)  |  | 功能缺失        |
+| 180   |  [torch.Tensor.sparse_resize_](https://pytorch.org/docs/stable/generated/torch.Tensor.sparse_resize_.html#torch.Tensor.sparse_resize_)  |  | 功能缺失        |
+| 181   |  [torch.Tensor.sparse_resize_and_clear_](https://pytorch.org/docs/stable/generated/torch.Tensor.sparse_resize_and_clear_.html#torch.Tensor.sparse_resize_and_clear_)  |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -682,6 +691,7 @@
 | 14   |  [torch.utils.dlpack.to_dlpack](https://pytorch.org/docs/stable/dlpack.html?highlight=torch+utils+dlpack+to_dlpack#torch.utils.dlpack.to_dlpack)  |  [paddle.utils.dlpack.to_dlpack](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/utils/dlpack/to_dlpack_cn.html)  |    功能一致, 仅参数名不一致 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.dlpack.to_dlpack.md)  |
 | 15   |  [torch.utils.cpp_extension.load_inline](https://pytorch.org/docs/stable/cpp_extension.html#torch.utils.cpp_extension.load_inline)  |   | 功能缺失  |
 | 16   |  [torch.utils.cpp_extension.include_paths](https://pytorch.org/docs/stable/cpp_extension.html#torch.utils.cpp_extension.include_paths)  |   | 功能缺失  |
+| 17   |  [torch.nn.utils.parametrize.is_parametrized](https://pytorch.org/docs/stable/generated/torch.nn.utils.parametrize.is_parametrized.html#torch.nn.utils.parametrize.is_parametrized)  |   | 功能缺失  |
 
 
 ***持续更新...***
@@ -696,6 +706,16 @@
 | 3   |  [torch.nn.Module.register_full_backward_hook](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook)  |   | 功能缺失  |
 | 4   |  [torch.nn.Module.requires_grad_](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.requires_grad_)  |   | 功能缺失  |
 
+
+***持续更新...***
+
+## torch.autograd.XX API 映射列表
+梳理了`torch.autograd.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
+
+| 序号 | PyTorch API | PaddlePaddle API | 备注 |
+ |--- | --- | --- | --- |
+| 1   |  [torch.autograd.profiler.profile.self_cpu_time_total](https://pytorch.org/docs/stable/generated/torch.autograd.profiler.profile.self_cpu_time_total.html#torch.autograd.profiler.profile.self_cpu_time_total)  |   | 功能缺失  |
+| 2   |  [torch.autograd.function.FunctionCtx.mark_dirty](https://pytorch.org/docs/stable/generated/torch.autograd.function.FunctionCtx.mark_dirty.html#torch.autograd.function.FunctionCtx.mark_dirty)  |   | 功能缺失  |
 
 ***持续更新...***
 
@@ -725,6 +745,7 @@
 | 19   | [torch.cuda.default_stream](https://pytorch.org/docs/stable/generated/torch.cuda.default_stream.html?highlight=torch+cuda+default_stream#torch.cuda.default_stream) | | 功能缺失 |
 | 20   | [torch.cuda.get_arch_list](https://pytorch.org/docs/stable/generated/torch.cuda.get_arch_list.html?highlight=torch+cuda+get_arch_list#torch.cuda.get_arch_list) | | 功能缺失 |
 | 21   | [torch.cuda.is_initialized](https://pytorch.org/docs/stable/generated/torch.cuda.is_initialized.html?highlight=torch+cuda+is_initialized#torch.cuda.is_initialized) | | 功能缺失 |
+| 22   | [torch.cuda.StreamContext](https://pytorch.org/docs/stable/generated/torch.cuda.StreamContext.html#torch.cuda.StreamContext) | | 功能缺失 |
 
 ***持续更新...***
 
@@ -806,6 +827,10 @@
 | 9   |  [torch.linalg.eig](https://pytorch.org/docs/stable/generated/torch.linalg.eig.html?highlight=torch+linalg+eig#torch.linalg.eig)  |  [paddle.linalg.eig](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/eig_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.eig.md)  |
 | 10   |  [torch.linalg.multi_dot](https://pytorch.org/docs/stable/generated/torch.linalg.multi_dot.html?highlight=torch+linalg+multi_dot#torch.linalg.multi_dot)  |  [paddle.linalg.multi_dot](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/multi_dot_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.multi_dot.md)  |
 | 11   |  [torch.linalg.matrix_exp](https://pytorch.org/docs/stable/generated/torch.linalg.matrix_exp.html#torch.linalg.matrix_exp)  |  | 功能缺失        |
+| 12    | [torch.linalg.matrix_norm](https://pytorch.org/docs/stable/generated/torch.linalg.matrix_norm.html#torch.linalg.matrix_norm) |  | 功能缺失        |
+| 13    | [torch.linalg.vector_norm](https://pytorch.org/docs/stable/generated/torch.linalg.vector_norm.html#torch.linalg.vector_norm) |  | 功能缺失        |
+| 14    | [torch.linalg.cholesky_ex](https://pytorch.org/docs/stable/generated/torch.linalg.cholesky_ex.html#torch.linalg.cholesky_ex) |  | 功能缺失        |
+| 15    | [torch.linalg.inv_ex](https://pytorch.org/docs/stable/generated/torch.linalg.inv_ex.html#torch.linalg.inv_ex) |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -825,6 +850,16 @@
 | 序号 | PyTorch API                                                  | PaddlePaddle API                                             | 备注                                                         |
 | ---- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | 1    | [torch.optim.lr_scheduler.LinearLR](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.LinearLR.html#torch.optim.lr_scheduler.LinearLR) |  | 功能缺失        |
+
+***持续更新...***
+
+## torch.profiler.XX API 映射列表
+梳理了`torch.profiler.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
+
+| 序号 | PyTorch API                                                  | PaddlePaddle API                                             | 备注                                                         |
+| ---- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| 1    | [torch.profiler.ProfilerActivity](https://pytorch.org/docs/stable/profiler.html#torch.profiler.ProfilerActivity) |  | 功能缺失        |
+| 2    | [torch.profiler.ProfilerAction](https://pytorch.org/docs/stable/profiler.html#torch.profiler.ProfilerAction) |  | 功能缺失        |
 
 ***持续更新...***
 
@@ -854,5 +889,6 @@
 | 7   |  [torch.special.expm1](https://pytorch.org/docs/stable/special.html#torch.special.expm1)  |  [paddle.expm1](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/expm1_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.expm1.md)  |
 | 8   |  [torch.backends.cudnn.version](https://pytorch.org/docs/stable/backends.html?highlight=torch+backends+cudnn+version#torch.backends.cudnn.version)  |    |    功能缺失  |
 | 9   |  [torch.special.erf](https://pytorch.org/docs/stable/special.html?highlight=torch+special+erf#torch.special.erf)  |  [paddle.erf](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/erf_cn.html)  |    功能一致, torch 参数更多 , [差异对比](https://github.com/PaddlePaddle/docs/tree/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.erf.md)  |
+| 10    | [torch.special.entr](https://pytorch.org/docs/stable/special.html#torch.special.entr) |  | 功能缺失        |
 
 ***持续更新...***


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaConvert/issues/112

转换规则 https://github.com/PaddlePaddle/PaConvert/pull/217

243 torch.linalg.inv_ex 功能缺失
246 torch.nn.LazyBatchNorm1d 功能缺失
247 torch.Tensor.sparse_resize_and_clear_ 功能缺失
248 torch.linalg.svdvals
251 torch.linalg.matrix_norm 功能缺失
254 torch.gradient 功能缺失
255 torch.special.gammaln
257 torch.nn.utils.parametrize.is_parametrized 功能缺失
259 torch.special.erfc 组合替代实现
260 torch.linalg.vector_norm 功能缺失
262 torch.nn.functional.group_norm 功能缺失
265 torch.special.expit 组合替代实现
266 torch.nn.Mish 已有文档
268 torch.linalg.cholesky_ex 功能缺失
269 torch.Tensor.sparse_resize_ 功能缺失
270 torch.positive 功能缺失
275 torch.special.exp2 组合替代实现
276 torch.nn.utils.parametrizations.spectral_norm
277 torch.cuda.StreamContext 功能缺失
278 torch.nn.LazyBatchNorm2d 功能缺失
281 torch.autograd.profiler.profile.self_cpu_time_total 功能缺失
284 torch.profiler.ProfilerActivity 功能缺失
286 torch.special.entr 功能缺失
287 torch.nn.LazyBatchNorm3d 功能缺失
288 torch.autograd.function.FunctionCtx.mark_dirty 功能缺失
289 torch.autograd.function.FunctionCtx.mark_non_differentiable
290 torch.autograd.Function.forward
291 torch.autograd.function.Function  名称应为 torch.autograd.Function https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function
292 torch.autograd.function.FunctionCtx.set_materialize_grads
293 torch.autograd.function.FunctionCtx.save_for_backward
294 torch.autograd.Function.backward
295 torch.profiler.ProfilerAction 功能缺失
296 torch.cuda.set_stream
300 torch.autograd.graph.saved_tensors_hooks