### PR TITLE
remove redundant `:code-example8` in `paddle.profiler.Profiler.summary` COPY-FROM

### DIFF
--- a/docs/api/paddle/profiler/Profiler_cn.rst
+++ b/docs/api/paddle/profiler/Profiler_cn.rst
@@ -143,4 +143,4 @@ summary(sorted_by=SortedKeys.CPUTotal, op_detail=True, thread_sep=False, time_un
 
 **代码示例**
 
-COPY-FROM: paddle.profiler.Profiler.summary:code-example8
+COPY-FROM: paddle.profiler.Profiler.summary


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
xdoctest-177中删除代码":code-example8"，此PR 修改其对应对应中文文档代码
PADDLEPADDLE_PR=56159


