### PR TITLE
映射文档 添加部分 inplace Tensor method api PART.02

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lcm_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lcm_.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.lcm_
+
+### [torch.Tensor.lcm_](https://pytorch.org/docs/stable/generated/torch.Tensor.lcm_.html)
+
+```python
+torch.Tensor.lcm_(other)
+```
+
+### [paddle.Tensor.lcm_]()
+
+```python
+paddle.Tensor.lcm_(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ldexp_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ldexp_.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.ldexp_
+
+### [torch.Tensor.ldexp_](https://pytorch.org/docs/stable/generated/torch.Tensor.ldexp_.html)
+
+```python
+torch.Tensor.ldexp_(other)
+```
+
+### [paddle.Tensor.ldexp_]()
+
+```python
+paddle.Tensor.ldexp_(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.le_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.le_.md
@@ -1,0 +1,29 @@
+## [ 参数不一致 ]torch.Tensor.le_
+
+### [torch.Tensor.le_](https://pytorch.org/docs/stable/generated/torch.Tensor.le_.html)
+
+```python
+torch.Tensor.le_(other)
+```
+
+### [paddle.Tensor.less_equal_]()
+
+```python
+paddle.Tensor.less_equal_(y)
+```
+
+其中 Paddle 和 PyTorch 的 `other` 参数所支持的数据类型不一致，具体如下：
+### 参数映射
+| PyTorch                          | PaddlePaddle                 | 备注                                                   |
+|----------------------------------|------------------------------| ------------------------------------------------------ |
+| other  |  y  | 表示输入的 Tensor ，PyTorch 支持 Python Number 和 Tensor 类型， Paddle 仅支持 Tensor 类型。当输入为 Python Number 类型时，需要转写。  |
+
+### 转写示例
+#### other：输入为 Number
+```python
+# Pytorch 写法
+result = x.le_(2)
+
+# Paddle 写法
+result = x.less_equal_(paddle.to_tensor(2))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.less_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.less_.md
@@ -1,0 +1,29 @@
+## [ 参数不一致 ]torch.Tensor.less_
+
+### [torch.Tensor.less_](https://pytorch.org/docs/stable/generated/torch.Tensor.less_.html)
+
+```python
+torch.Tensor.less_(other)
+```
+
+### [paddle.Tensor.less_than_]()
+
+```python
+paddle.Tensor.less_than_(y)
+```
+
+其中 Paddle 和 PyTorch 的 `other` 参数所支持的数据类型不一致，具体如下：
+### 参数映射
+| PyTorch                          | PaddlePaddle                 | 备注                                                   |
+|----------------------------------|------------------------------| ------------------------------------------------------ |
+| other  |  y  | 表示输入的 Tensor ，PyTorch 支持 Python Number 和 Tensor 类型， Paddle 仅支持 Tensor 类型。当输入为 Python Number 类型时，需要转写。  |
+
+### 转写示例
+#### other：输入为 Number
+```python
+# Pytorch 写法
+result = x.less_(2)
+
+# Paddle 写法
+result = x.less_than_(paddle.to_tensor(2))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.less_equal_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.less_equal_.md
@@ -1,0 +1,29 @@
+## [ 参数不一致 ]torch.Tensor.less_equal_
+
+### [torch.Tensor.less_equal_](https://pytorch.org/docs/stable/generated/torch.Tensor.less_equal_.html)
+
+```python
+torch.Tensor.less_equal_(other)
+```
+
+### [paddle.Tensor.less_equal_]()
+
+```python
+paddle.Tensor.less_equal_(y)
+```
+
+其中 Paddle 和 PyTorch 的 `other` 参数所支持的数据类型不一致，具体如下：
+### 参数映射
+| PyTorch                          | PaddlePaddle                 | 备注                                                   |
+|----------------------------------|------------------------------| ------------------------------------------------------ |
+| other  |  y  | 表示输入的 Tensor ，PyTorch 支持 Python Number 和 Tensor 类型， Paddle 仅支持 Tensor 类型。当输入为 Python Number 类型时，需要转写。  |
+
+### 转写示例
+#### other：输入为 Number
+```python
+# Pytorch 写法
+result = x.less_equal_(2)
+
+# Paddle 写法
+result = x.less_equal_(paddle.to_tensor(2))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lgamma_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lgamma_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.lgamma_
+
+### [torch.Tensor.lgamma_](https://pytorch.org/docs/stable/generated/torch.Tensor.lgamma_.html)
+
+```python
+torch.Tensor.lgamma_()
+```
+
+### [paddle.Tensor.lgamma_]()
+
+```python
+paddle.Tensor.lgamma_()
+```
+
+两者功能一致，均无参数，用于计算张量中每个元素的自然对数伽马函数值的函数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log10_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log10_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.log10_
+
+### [torch.Tensor.log10_](https://pytorch.org/docs/stable/generated/torch.Tensor.log10_.html)
+
+```python
+torch.Tensor.log10_()
+```
+
+### [paddle.Tensor.log10_](e)
+
+```python
+paddle.Tensor.log10_()
+```
+
+两者功能一致，均无参数，用于计算张量中每个元素的以 10 为底的对数的函数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log1p_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log1p_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.log1p_
+
+### [torch.Tensor.log1p_](https://pytorch.org/docs/stable/generated/torch.Tensor.log1p_.html)
+
+```python
+torch.Tensor.log1p_()
+```
+
+### [paddle.Tensor.log1p_]()
+
+```python
+paddle.Tensor.log1p_()
+```
+
+两者功能一致，均无参数，用于计算张量中每个元素加 1 后的自然对数的函数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log2_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log2_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.log2_
+
+### [torch.Tensor.log2_](https://pytorch.org/docs/stable/generated/torch.Tensor.log2_.html)
+
+```python
+torch.Tensor.log2_()
+```
+
+### [paddle.Tensor.log2_]()
+
+```python
+paddle.Tensor.log2_()
+```
+
+两者功能一致，均无参数，用于计算张量中每个元素的以 2 为底的对数的函数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.log_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.log_
+
+### [torch.Tensor.log_](https://pytorch.org/docs/stable/generated/torch.Tensor.log_.html)
+
+```python
+torch.Tensor.log_()
+```
+
+### [paddle.Tensor.log_]()
+
+```python
+paddle.Tensor.log_()
+```
+
+两者功能一致，均无参数，用于计算张量中每个元素的自然对数的函数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_and_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_and_.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ] torch.Tensor.logical_and_
+
+### [torch.Tensor.logical_and_](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_and_.html)
+
+```python
+torch.Tensor.logical_and_(other)
+```
+
+### [paddle.Tensor.logical_and_]()
+
+```python
+paddle.Tensor.logical_and_(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_not_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_not_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.logical_not_
+
+### [torch.Tensor.logical_not_](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_not_.html)
+
+```python
+torch.Tensor.logical_not_()
+```
+
+### [paddle.Tensor.logical_not_]()
+
+```python
+paddle.Tensor.logical_not_()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_or_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_or_.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.logical_or_
+
+### [torch.Tensor.logical_or_](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_or_.html)
+
+```python
+torch.Tensor.logical_or_(other)
+```
+
+### [paddle.Tensor.logical_or_]()
+
+```python
+paddle.Tensor.logical_or_(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_xor_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_xor_.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.logical_xor_
+
+### [torch.Tensor.logical_xor_](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_xor_.html)
+
+```python
+torch.Tensor.logical_xor_(other)
+```
+
+### [paddle.Tensor.logical_xor_]()
+
+```python
+paddle.Tensor.logical_xor_(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit_.md
@@ -3,13 +3,13 @@
 ### [torch.Tensor.logit_](https://pytorch.org/docs/stable/generated/torch.Tensor.logit_.html)
 
 ```python
-torch.Tensor.logit_(input, eps=None, *, out=None)
+torch.Tensor.logit_(eps=None)
 ```
 
 ### [paddle.Tensor.logit_](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/logit_cn.html)
 
 ```python
-paddle.Tensor.logit_(x, eps=None, name=None)
+paddle.Tensor.logit_(eps=None)
 ```
 
 两者功能一致，参数完全一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit_.md
@@ -1,0 +1,21 @@
+## [ 参数完全一致 ]torch.Tensor.logit_
+
+### [torch.Tensor.logit_](https://pytorch.org/docs/stable/generated/torch.Tensor.logit_.html)
+
+```python
+torch.Tensor.logit_(input, eps=None, *, out=None)
+```
+
+### [paddle.Tensor.logit_](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/logit_cn.html)
+
+```python
+paddle.Tensor.logit_(x, eps=None, name=None)
+```
+
+两者功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch                             | PaddlePaddle | 备注                                                                    |
+| ----------------------------------- | ------------ | ----------------------------------------------------------------------- |
+| eps     | eps           | 将输入向量的范围控制在 [eps,1−eps]                        |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lt_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lt_.md
@@ -1,0 +1,29 @@
+## [ 参数不一致 ]torch.Tensor.lt_
+
+### [torch.Tensor.lt_](https://pytorch.org/docs/stable/generated/torch.Tensor.lt_.html)
+
+```python
+torch.Tensor.lt_(other)
+```
+
+### [paddle.Tensor.less_than_]()
+
+```python
+paddle.Tensor.less_than_(y)
+```
+
+其中 Paddle 和 PyTorch 的 `other` 参数所支持的数据类型不一致，具体如下：
+### 参数映射
+| PyTorch                          | PaddlePaddle                 | 备注                                                   |
+|----------------------------------|------------------------------| ------------------------------------------------------ |
+| other  |  y  | 表示输入的 Tensor ，PyTorch 支持 Python Number 和 Tensor 类型， Paddle 仅支持 Tensor 类型。当输入为 Python Number 类型时，需要转写。  |
+
+### 转写示例
+#### other：输入为 Number
+```python
+# Pytorch 写法
+result = x.lt_(2)
+
+# Paddle 写法
+result = x.less_than_(paddle.to_tensor(2))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nan_to_num_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nan_to_num_.md
@@ -1,0 +1,23 @@
+## [参数完全一致]torch.Tensor.nan_to_num_
+
+### [torch.Tensor.nan_to_num_](https://pytorch.org/docs/stable/generated/torch.Tensor.nan_to_num_.html#torch.Tensor.nan_to_num_)
+
+```python
+torch.Tensor.nan_to_num_(nan=0.0, posinf=None, neginf=None)
+```
+
+### [paddle.Tensor.nan_to_num_]()
+
+```python
+paddle.Tensor.nan_to_num_(nan=0.0, posinf=None, neginf=None)
+```
+
+两者功能一致，且参数用法一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注            |
+| ------- | ------------ | --------------- |
+| nan     | nan          | NaN 的替换值。  |
+| posinf  | posinf       | +inf 的替换值。 |
+| neginf  | neginf       | -inf 的替换值。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ne_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ne_.md
@@ -1,0 +1,29 @@
+## [ 参数不一致 ] torch.Tensor.ne_
+### [torch.Tensor.ne_](https://pytorch.org/docs/stable/generated/torch.Tensor.ne_.html)
+
+```python
+torch.Tensor.ne_(other)
+```
+
+### [paddle.Tensor.not_equal_]()
+
+```python
+paddle.Tensor.not_equal_(y)
+```
+
+其中，Paddle 与 PyTorch 的 `other` 参数所支持类型不一致，具体如下：
+
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                             |
+| ------------- | ------------ | ----------------------------------------------- |
+| other         | y            | 比较的元素，PyTorch 支持 Tensor 和 Python Number，Paddle 仅支持 Tensor，需要转写。                       |
+
+### 转写示例
+#### other：比较的元素
+```python
+# PyTorch 写法
+y = x.ne_(other=2)
+
+# Paddle 写法
+y = x.not_equal_(y=paddle.to_tensor(2))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.neg_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.neg_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.neg_
+
+### [torch.Tensor.neg_](https://pytorch.org/docs/stable/generated/torch.Tensor.neg_.html)
+
+```python
+torch.Tensor.neg_()
+```
+
+### [paddle.Tensor.neg_]()
+
+```python
+paddle.Tensor.neg_()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.negative_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.negative_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.negative_
+
+### [torch.Tensor.negative_](https://pytorch.org/docs/stable/generated/torch.Tensor.negative_.html)
+
+```python
+torch.Tensor.negative_()
+```
+
+### [paddle.Tensor.neg_]()
+
+```python
+paddle.Tensor.neg_()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.not_equal_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.not_equal_.md
@@ -1,0 +1,29 @@
+## [ 参数不一致 ] torch.Tensor.not_equal_
+### [torch.Tensor.not_equal_](https://pytorch.org/docs/stable/generated/torch.Tensor.not_equal_.html)
+
+```python
+torch.Tensor.not_equal_(other)
+```
+
+### [paddle.Tensor.not_equal_]()
+
+```python
+paddle.Tensor.not_equal_(y)
+```
+
+其中，Paddle 与 PyTorch 的 `other` 参数所支持类型不一致，具体如下：
+
+### 参数映射
+| PyTorch       | PaddlePaddle | 备注                                             |
+| ------------- | ------------ | ----------------------------------------------- |
+| other         | y            | 比较的元素，PyTorch 支持 Tensor 和 Python Number，Paddle 仅支持 Tensor，需要转写。                       |
+
+### 转写示例
+#### other：比较的元素
+```python
+# PyTorch 写法
+y = x.not_equal_(other=2)
+
+# Paddle 写法
+y = x.not_equal_(y=paddle.to_tensor(2))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.polygamma_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.polygamma_.md
@@ -1,0 +1,21 @@
+## [ 参数完全一致 ]torch.Tensor.polygamma_
+
+### [torch.Tensor.polygamma_](https://pytorch.org/docs/stable/generated/torch.Tensor.polygamma_.html)
+
+```python
+torch.Tensor.polygamma_(n)
+```
+
+### [paddle.Tensor.polygamma_]()
+
+```python
+paddle.Tensor.polygamma_(n)
+```
+
+两者功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+|   n   |  n  | 指定需要求解 n 阶多伽马函数。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pow_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pow_.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ] torch.Tensor.pow_
+
+### [torch.Tensor.pow_](https://pytorch.org/docs/stable/generated/torch.Tensor.pow_.html)
+
+```python
+torch.Tensor.pow_(exponent)
+```
+
+### [paddle.Tensor.pow_]()
+
+```python
+paddle.Tensor.pow_(y)
+```
+
+两者功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch  | PaddlePaddle | 备注                                               |
+| -------- | ------------ | -------------------------------------------------- |
+| exponent | y            | 一个 N 维 Tensor 或者标量 Tensor，仅参数名不一致。 |


### PR DESCRIPTION
添加 23 个 inplace Tensor method api 映射：

> - [x] `torch.Tensor.lcm_`
> - [x] `torch.Tensor.ldexp_`
> - [x] `torch.Tensor.le_`
> - [x] `torch.Tensor.less_equal_`
> - [x] `torch.Tensor.lgamma_`
> - [x] `torch.Tensor.log_`
> - [x] `torch.Tensor.log10_`
> - [x] `torch.Tensor.log1p_`
> - [x] `torch.Tensor.log2_`
> - [x] `torch.Tensor.logical_and_`
> - [x] `torch.Tensor.logical_not_`
> - [x] `torch.Tensor.logical_or_`
> - [x] `torch.Tensor.logical_xor_`
> - [x] `torch.Tensor.logit_`
> - [x] `torch.Tensor.lt_`
> - [x] `torch.Tensor.less_`
> - [x] `torch.Tensor.nan_to_num_`
> - [x] `torch.Tensor.ne_`
> - [x] `torch.Tensor.not_equal_`
> - [x] `torch.Tensor.neg_`
> - [x] `torch.Tensor.negative_`
> - [x] `torch.Tensor.polygamma_`
> - [x] `torch.Tensor.pow_`