### PR TITLE
映射文档 更新部分 inplace api 的映射错误

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cumprod_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cumprod_.md
@@ -3,7 +3,7 @@
 ### [torch.Tensor.cumprod_](https://pytorch.org/docs/stable/generated/torch.Tensor.cumprod_.html)
 
 ```python
-torch.Tensor.cumprod_(dim, dtype=None)
+torch.Tensor.cumprod_(dim, *, dtype=None)
 ```
 
 ### [paddle.Tensor.cumprod_]()

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.divide_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.divide_.md
@@ -33,6 +33,6 @@ z2 = x.divide_(y, rounding_mode='trunc') # 向零取整
 # paddle 写法
 x = paddle.to_tensor([4, 8, 12], dtype='float32')
 y = paddle.to_tensor([3, 4, 5], dtype='float32')
-z1 = x.divide_(y).floor()  # 向下取整
-z2 = x.divide_(y).trunc()  # 向零取整
+z1 = paddle.assign(paddle.floor(x.divide_(y)), x)  # 向下取整
+z2 = paddle.assign(paddle.trunc(x.divide_(y)), x)  # 向零取整
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.divide_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.divide_.md
@@ -33,6 +33,6 @@ z2 = x.divide_(y, rounding_mode='trunc') # 向零取整
 # paddle 写法
 x = paddle.to_tensor([4, 8, 12], dtype='float32')
 y = paddle.to_tensor([3, 4, 5], dtype='float32')
-z1 = paddle.assign(paddle.floor(x.divide_(y)), x)  # 向下取整
-z2 = paddle.assign(paddle.trunc(x.divide_(y)), x)  # 向零取整
+z1 = x.divide_(y).floor_()  # 向下取整
+z2 = x.divide_(y).trunc_()  # 向零取整
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_put_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_put_.md
@@ -14,6 +14,7 @@ paddle.Tensor.index_put_(indices, value, accumulate=False)
 两者功能一致且参数用法一致，仅参数名不一致，具体如下：
 
 ### 参数映射
+
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | <font color='red'> indices </font> | <font color='red'> indices </font> | 包含用来索引的 tensors 的元组。数据类型为 int32，int64，bool。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_put_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_put_.md
@@ -1,8 +1,8 @@
-## [ 参数完全一致 ]torch.Tensor.index_put_
+## [ 仅参数名不一致 ]torch.Tensor.index_put_
 ### [torch.Tensor.index_put_](https://pytorch.org/docs/stable/generated/torch.Tensor.index_put_.html#torch.Tensor.index_put_)
 
 ```python
-torch.Tensor.index_put_(indices, value, accumulate=False)
+torch.Tensor.index_put_(indices, values, accumulate=False)
 ```
 
 ### [paddle.Tensor.index_put_]()
@@ -11,11 +11,11 @@ torch.Tensor.index_put_(indices, value, accumulate=False)
 paddle.Tensor.index_put_(indices, value, accumulate=False)
 ```
 
-两者功能一致，参数完全一致，具体如下：
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
 
 ### 参数映射
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | <font color='red'> indices </font> | <font color='red'> indices </font> | 包含用来索引的 tensors 的元组。数据类型为 int32，int64，bool。 |
-| <font color='red'> value </font> | <font color='red'> value </font> | 用来给 x 赋值的 Tensor。  |
+| <font color='red'> values </font> | <font color='red'> value </font> | 用来给 x 赋值的 Tensor，仅参数名不一致。  |
 | <font color='red'> accumulate </font> | <font color='red'> accumulate </font> | 指定是否将 value 加到 x 的参数。 默认值为 False。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pow_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pow_.md
@@ -18,4 +18,4 @@ paddle.Tensor.pow_(y)
 
 | PyTorch  | PaddlePaddle | 备注                                               |
 | -------- | ------------ | -------------------------------------------------- |
-| exponent | y            | 一个 N 维 Tensor 或者标量 Tensor，仅参数名不一致。 |
+| exponent | y            | 一个标量 Tensor，仅参数名不一致。 |


### PR DESCRIPTION
更新 [映射文档 inplace api PART.01]( https://github.com/PaddlePaddle/docs/pull/6169 ) 中两个 `inplace api` 的映射错误：

1. `torch.Tensor.divide_` 更新转写实现；
2. `torch.Tensor.index_put_` 映射类型更新为 “仅参数名不一致”。
3. `torch.Tensor.cumprod_` 参数列表添加 `"*"`

更新 [映射文档 inplace api PART.02](https://github.com/PaddlePaddle/docs/pull/6174) 中一个映射错误：
1. `torch.Tensor.pow_` 更新参数描述。