### PR TITLE
[Docathon][ApiLabel][task 1-4] clean some legacy concepts and api labels

### DIFF
--- a/docs/advanced_guide/performance_improving/multinode_training_improving/cpu_train_best_practice.rst
+++ b/docs/advanced_guide/performance_improving/multinode_training_improving/cpu_train_best_practice.rst
@@ -12,7 +12,7 @@
 
 提高 CPU 使用率主要依赖 :code:`ParallelExecutor`，可以充分利用多个 CPU 的计算能力来加速计算。
 
-API 详细使用方法参考 :ref:`cn_api_fluid_ParallelExecutor` ，简单实例用法：
+简单实例用法：
 
 .. code-block:: python
 

--- a/docs/api/paddle/static/BuildStrategy_cn.rst
+++ b/docs/api/paddle/static/BuildStrategy_cn.rst
@@ -5,7 +5,7 @@ BuildStrategy
 
 .. py:class:: paddle.static.BuildStrategy
 
-``BuildStrategy`` 使用户更方便地控制 :ref:`cn_api_fluid_ParallelExecutor` 中计算图的建造方法，可通过设置 ``ParallelExecutor`` 中的 ``BuildStrategy`` 成员来实现此功能。
+``BuildStrategy`` 使用户更方便地控制 ``ParallelExecutor`` 中计算图的建造方法，可通过设置 ``ParallelExecutor`` 中的 ``BuildStrategy`` 成员来实现此功能。
 
 返回
 :::::::::

--- a/docs/api/paddle/static/Overview_cn.rst
+++ b/docs/api/paddle/static/Overview_cn.rst
@@ -42,9 +42,7 @@ Executor 相关 API
 
     " :ref:`BuildStrategy <cn_api_paddle_static_BuildStrategy>` ", "控制 ParallelExecutor 中计算图的建造方法"
     " :ref:`CompiledProgram <cn_api_paddle_static_CompiledProgram>` ", "转化和优化 Program 或 Graph"
-    " :ref:`ExecutionStrategy <cn_api_fluid_ExecutionStrategy>` ", "调整 Executor 执行配置"
     " :ref:`Executor <cn_api_paddle_static_Executor>` ", "执行器"
-    " :ref:`ParallelExecutor <cn_api_fluid_ParallelExecutor>` ", "支持基于数据并行的多节点模型训练和测试的执行器"
 
 .. _about_nn:
 

--- a/docs/api/paddle/static/Variable_cn.rst
+++ b/docs/api/paddle/static/Variable_cn.rst
@@ -212,7 +212,7 @@ lod_level
 .. note::
 该属性是只读属性。
 
-此 :ref:`api_guide_Variable` 的 ``LoD`` 信息，关于 ``LoD`` 可以参考 :ref:`api_fluid_LoDTensor` 相关内容。
+此 :ref:`api_guide_Variable` 的 ``LoD`` 信息。
 
 type
 '''''''''
@@ -220,7 +220,7 @@ type
 .. note::
 该属性是只读属性。
 
-此 :ref:`api_guide_Variable` 的内存模型，例如是：:ref:`api_fluid_LoDTensor`，或者 SelectedRows。
+此 :ref:`api_guide_Variable` 的内存模型，例如是：``LoDTensor``，或者 ``SelectedRows``。
 
 ndim
 '''''''''

--- a/docs/api_guides/low_level/layers/data_in_out.rst
+++ b/docs/api_guides/low_level/layers/data_in_out.rst
@@ -29,5 +29,4 @@ Fluid 支持在训练/预测阶段获取当前 batch 的数据。
 fetch 期望的输出变量，通过设置 :code:`return_numpy` 参数设置是否将输出数据转为 numpy array。
 若 :code:`return_numpy` 为 :code:`False` ，则返回 :code:`LoDTensor` 类型数据。
 
-具体使用方式请参考相关 API 文档 :ref:`cn_api_fluid_executor_Executor` 和
-:ref:`cn_api_fluid_ParallelExecutor`。
+具体使用方式请参考相关 API 文档 :ref:`cn_api_paddle_static_Executor`。

--- a/docs/api_guides/low_level/layers/sequence.rst
+++ b/docs/api_guides/low_level/layers/sequence.rst
@@ -7,7 +7,7 @@
 在深度学习领域许多问题涉及到对 `序列（sequence） <https://en.wikipedia.org/wiki/Sequence>`_ 的处理。
 从 Wiki 上的释义可知，序列可以表征多种物理意义，但在深度学习中，最常见的仍然是"时间序列"——一个序列包含多个时间步的信息。
 
-在 Paddle Fluid 中，我们将序列表示为 :ref:`cn_api_fluid_LoDTensor` 。
+在 Paddle Fluid 中，我们将序列表示为 ``LoDTensor``。
 因为一般进行神经网络计算时都是一个 batch 一个 batch 地计算，所以我们用一个 LoDTensor 来存储一个 mini batch 的序列。
 一个 LoDTensor 的第 0 维包含该 mini batch 中所有序列的所有时间步，并且用 LoD 来记录各个序列的长度，区分不同序列。
 而在运算时，还需要根据 LoD 信息将 LoDTensor 中一个 mini batch 的第 0 维拆开成多个序列。（具体请参考上述 LoD 相关的文档。）

--- a/docs/api_guides/low_level/layers/sequence_en.rst
+++ b/docs/api_guides/low_level/layers/sequence_en.rst
@@ -7,7 +7,7 @@ Sequence
 Many problems in the field of deep learning involve the processing of the `sequence <https://en.wikipedia.org/wiki/Sequence>`_.
 From Wiki's definition, sequences can represent a variety of physical meanings, but in deep learning, the most common is still "time sequence" - a sequence containing information of multiple time steps.
 
-In Paddle Fluid, we represent the sequence as :ref:`api_fluid_LoDTensor`.
+In Paddle Fluid, we represent the sequence as ``LoDTensor``.
 Because the general neural network performs computing batch by batch, we use a LoDTensor to store a mini batch of sequences.
 The 0th dimension of a LoDTensor contains all the time steps of all sequences in the mini batch, and LoD is used to record the length of each sequence to distinguish different sequences.
 In the calculation, it is also necessary to split the 0th dimension of a mini batch in the LoDTensor into a number of sequences according to the LoD information. (Please refer to the LoD related documents for details. )

--- a/docs/api_guides/low_level/parallel_executor.rst
+++ b/docs/api_guides/low_level/parallel_executor.rst
@@ -29,7 +29,7 @@
 
 **注意** ：如果在 Reduce 模式下使用 :code:`CPU` 多线程执行 :code:`Program` ， :code:`Program` 的参数在多个线程间是共享的，在某些模型上，Reduce 模式可以大幅节省内存。
 
-鉴于模型的执行速率和模型结构及执行器的执行策略有关，:code:`ParallelExecutor` 允许你修改执行器的相关参数，例如线程池的规模( :code:`num_threads` )、为清除临时变量 :code:`num_iteration_per_drop_scope` 需要进行的循环次数。更多信息请参照 :ref:`cn_api_fluid_ExecutionStrategy` 。
+鉴于模型的执行速率和模型结构及执行器的执行策略有关，:code:`ParallelExecutor` 允许你修改执行器的相关参数，例如线程池的规模( :code:`num_threads` )、为清除临时变量 :code:`num_iteration_per_drop_scope` 需要进行的循环次数。
 
 
 .. code-block:: python
@@ -63,5 +63,4 @@
     train_loss, = train_exe.run(fetch_list=[loss.name], feed=feed_dict)
     test_loss, = test_exe.run(fetch_list=[loss.name], feed=feed_dict)
 - 相关 API :
- - :ref:`cn_api_fluid_ParallelExecutor`
- - :ref:`cn_api_fluid_BuildStrategy`
+ - :ref:`cn_api_paddle_static_BuildStrategy`


### PR DESCRIPTION
## Description

清理过时的概念、API

- `LoD` 已经是过时的概念，我们已经清理过一次，见 https://github.com/PaddlePaddle/community/blob/master/pfcc/call-for-contributions/docs/tensor_concept_unification.md
- `ParallelExecutor` 已经是过时的执行器，新执行器统一为 `Executor`
- `ExecutionStrategy` 同样是过时的执行器所需要的参数，现在已经不存在

这几个因为有历史遗留问题，其他开发者可能并不了解，因此就直接清理了，其他的看起来比较简单，如果有类似历史问题也可以 @我

@ooooo-create @sunzhongkai588 

## Related links

- #6170