### PR TITLE
remove useless shell script

### DIFF
--- a/docs/api/gen_doc.sh
+++ b/docs/api/gen_doc.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-python3 gen_doc.py


### PR DESCRIPTION
由于 `docs/api/gen_doc.sh` 已在 [历史改动 #4211 ](#4211) 中失去了所有调用，其功能由 `ci_scripts/gendoc.sh`  代替。

https://github.com/PaddlePaddle/docs/blob/765ed12b662814260097e5642d0c1eec5a1c99ee/ci_scripts/gendoc.sh#L24-L25

因此移除该文件以避免历史遗留因素增加开发理解成本。

@sunzhongkai588  @SigureMo 