### PR TITLE
[Docs]move_diag_embed_from_functional_to_paddle

### DIFF
--- a/docs/api/paddle/diag_embed_cn.rst
+++ b/docs/api/paddle/diag_embed_cn.rst
@@ -1,9 +1,9 @@
-.. _cn_api_paddle_nn_functional_diag_embed:
+.. _cn_api_paddle_diag_embed:
 
 diag_embed
 -------------------------------
 
-.. py:function:: paddle.nn.functional.diag_embed(input, offset=0, dim1=-2, dim2=-1)
+.. py:function:: paddle.diag_embed(input, offset=0, dim1=-2, dim2=-1)
 
 创建一个 Tensor，其在指定的 2D 平面（由 ``dim1`` 和 ``dim2`` 指定）上的对角线由输入 ``input`` 填充。默认的，指定的 2D 平面由返回 Tensor 的最后两维组成。
 
@@ -28,4 +28,4 @@ diag_embed
 代码示例
 ::::::::::::
 
-COPY-FROM: paddle.nn.functional.diag_embed
+COPY-FROM: paddle.diag_embed


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Docs
### PR changes
Docs
### Description
Pcard-73263
diag_embedAPI的调用路径已从paddle.nn.functional.diag_embed换做paddle.diag_embed，现对文档进行修改。