### PR TITLE
[fix] fix argument bugs `check_api_label_cn.py`

### DIFF
--- a/ci_scripts/check_api_label_cn.py
+++ b/ci_scripts/check_api_label_cn.py
@@ -126,7 +126,7 @@ def parse_args():
     parser.add_argument(
         'all_git_files',
         type=str,
-        nargs='+',
+        nargs='*',
         help='files need to check',
     )
     args = parser.parse_args()


### PR DESCRIPTION

![93c68a4b1eafb517ca11a7d6c5f4978b](https://github.com/PaddlePaddle/docs/assets/106524776/2d164de7-1faa-4c28-893f-d0e35231ce74)

修复 check_api_label_cn.py 传参中使用的 nargs = ‘+’,会在删除文件时，因为没有 `all_git_files` 参数传入而报错，因此使用 nargs = ‘*“
@SigureMo @sunzhongkai588 