### PR TITLE
[Change] remove blank ps

### DIFF
--- a/ci_scripts/doc-build-config/en/conf.py
+++ b/ci_scripts/doc-build-config/en/conf.py
@@ -356,14 +356,17 @@ def remove_doctest_directives(app, what, name, obj, options, lines):
     """
     Remove `doctest` directives from docstring
     """
-    pattern_doctest = re.compile(r"\s*>>>\s*#\s*doctest:\s*.*")
-
     # Modify the lines inplace
-    lines[:] = [
-        line
-        for line in lines
-        if not (pattern_doctest.match(line) or line.strip() == ">>>")
-    ]
+    # remove doctest directive
+    pattern_doctest = re.compile(r"\s*>>>\s*#\s*x?doctest:\s*.*")
+    lines[:] = [line for line in lines if not pattern_doctest.match(line)]
+
+    # remove blank ps(`>>>`)
+    lines[:] = [line for line in lines if not line.strip() == ">>>"]
+
+    # make sure there is a blank line at the end
+    if lines and lines[-1]:
+        lines.append('')
 
 
 def setup(app):
@@ -390,5 +393,5 @@ def setup(app):
     )
     app.add_transform(AutoStructify)
 
-    # remove doctest directives
+    # remove doctest directives and blank ps
     app.connect("autodoc-process-docstring", remove_doctest_directives)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

示例代码渲染 `# doctest: XXX` 的时候，会出现空白行。这里在之前过滤逻辑的基础上：

- 把空 `>>>` 单独过滤。
- 过滤的正则增加 `# xdoctest`，不影响目前的过滤方式。
- 最后增加一个空行。sphinx 官方的例子有这个东西，之前没有加，不知道是不是这个导致的bug?

https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/distributed/barrier_en.html

等看看效果吧 ～

@sunzhongkai588 @SigureMo 