### PR TITLE
修复 paddle.nn.GRU 的文档

### DIFF
--- a/docs/api/paddle/nn/GRU_cn.rst
+++ b/docs/api/paddle/nn/GRU_cn.rst
@@ -3,7 +3,7 @@
 GRU
 -------------------------------
 
-.. py:class:: paddle.nn.GRU(input_size, hidden_size, num_layers=1, direction="forward", dropout=0., time_major=False, weight_ih_attr=None, weight_hh_attr=None, bias_ih_attr=None, bias_hh_attr=None, name=None)
+.. py:class:: paddle.nn.GRU(input_size, hidden_size, num_layers=1, direction="forward", time_major=False, dropout=0.0, weight_ih_attr=None, weight_hh_attr=None, bias_ih_attr=None, bias_hh_attr=None, name=None)
 
 
 


### PR DESCRIPTION
[英文文档](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/nn/GRU_en.html#gru)参数正确（与代码参数顺序对应），[中文文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/GRU_cn.html)参数顺序`dropout=0., time_major=False,`反了