### PR TITLE
update `cmake-lint` to PFCCLab forked version

### DIFF
--- a/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
+++ b/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
@@ -93,7 +93,7 @@ Date:   xxx
 | [cpplint](https://github.com/cpplint/cpplint) | C++ 代码风格检查 | 1.6.0 |
 | [clang-tidy](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-tidy) | C++ 代码风格检查 | 15.0.2.1 |
 | [cmake-format](https://github.com/cheshirekow/cmake-format-precommit) | CMake 代码格式化 | 0.6.13 |
-| [cmake-lint](https://github.com/cmake-lint/cmake-lint)| CMake 代码风格检查 | 1.4.2 |
+| [cmake-lint](https://github.com/PFCCLab/cmake-lint-paddle)| CMake 代码风格检查 | 1.5.1 |
 
 > 注：这些工具可能会更新，详细配置请查看：[https://github.com/PaddlePaddle/Paddle/blob/develop/.pre-commit-config.yaml](https://github.com/PaddlePaddle/Paddle/blob/develop/.pre-commit-config.yaml)。
 


### PR DESCRIPTION
见 PaddlePaddle/Paddle#59072，替换为 fork 后的 https://github.com/PFCCLab/cmake-lint-paddle