### PR TITLE
修复 LinearWarmup 文档

### DIFF
--- a/docs/api/paddle/optimizer/lr/LinearWarmup_cn.rst
+++ b/docs/api/paddle/optimizer/lr/LinearWarmup_cn.rst
@@ -13,6 +13,7 @@ LinearWarmup
 
     lr = start\_lr + (end\_lr - start\_lr) * \frac{epoch}{warmup\_steps}
 
+其中 start_lr 是初始学习率，而 end_lr 是最终学习率；
 当训练步数大于等于热身步数（warmup_steps）时，学习率 lr 为：
 
 .. math::


### PR DESCRIPTION
**PR types**
Bug fixes

**PR changes**
Docs

**Describe**
where start_lr is the initial learning rate, and end_lr is the final learning rate;  It must be a positive integer. 中文没有
补上相应翻译

涉及到的 文档有：
docs\api\paddle\lr\LinearWarmup_cn.rst

**相关链接：**
https://github.com/PaddlePaddle/docs/issues/6187
https://github.com/PaddlePaddle/docs/issues/6165

@sunzhongkai588