### PR TITLE
[doc] Deprecated py37

### DIFF
--- a/docs/api/paddle/sysconfig/get_lib_cn.rst
+++ b/docs/api/paddle/sysconfig/get_lib_cn.rst
@@ -5,7 +5,7 @@ get_lib
 
 .. py:function:: paddle.sysconfig.get_lib()
 
-获取包含飞浆 lib 框架的目录。
+获取包含飞桨 lib 框架的目录。
 
 返回
 ::::::::::

--- a/docs/dev_guides/custom_device_docs/custom_device_example_en.md
+++ b/docs/dev_guides/custom_device_docs/custom_device_example_en.md
@@ -251,9 +251,9 @@ project(paddle-custom_cpu CXX C)
 set(PLUGIN_NAME        "paddle_custom_cpu")
 set(PLUGIN_VERSION      "0.0.1")
 
-set(PADDLE_PLUGIN_DIR  "/opt/conda/lib/python3.7/site-packages/paddle-plugins/")
-set(PADDLE_INC_DIR     "/opt/conda/lib/python3.7/site-packages/paddle/include/")
-set(PADDLE_LIB_DIR     "/opt/conda/lib/python3.7/site-packages/paddle/fluid/")
+set(PADDLE_PLUGIN_DIR  "/opt/conda/lib/python3.8/site-packages/paddle-plugins/")
+set(PADDLE_INC_DIR     "/opt/conda/lib/python3.8/site-packages/paddle/include/")
+set(PADDLE_LIB_DIR     "/opt/conda/lib/python3.8/site-packages/paddle/fluid/")
 
 ############ Third-party dependencies
 set(BOOST_INC_DIR      "/path/to/Paddle/build/third_party/boost/src/extern_boost")
@@ -377,8 +377,8 @@ for pkg_dir in ['build/python/paddle-plugins/']:
 
 ext_modules = [Extension(name='paddle-plugins.libpaddle_custom_cpu',
                          sources=['runtime.cc', 'add_kernel.cc'],
-                         include_dirs=['/opt/conda/lib/python3.7/site-packages/paddle/include/'],
-                         library_dirs=['/opt/conda/lib/python3.7/site-packages/paddle/fluid/'],
+                         include_dirs=['/opt/conda/lib/python3.8/site-packages/paddle/include/'],
+                         library_dirs=['/opt/conda/lib/python3.8/site-packages/paddle/base/'],
                          libraries=['libpaddle.so'])]
 
 setup(
@@ -428,7 +428,7 @@ After the compilation, make a wheel package under the directory of dist.
 Use pip to install a wheel package.
 
 ```
-$ pip install build/dist/paddle_custom_cpu-0.0.1-cp37-cp37m-linux_aarch64.whl
+$ pip install build/dist/paddle_custom_cpu-0.0.1-cp38-cp38-linux_aarch64.whl
 ```
 
 ## Step Four：Load and Use

--- a/docs/guides/hardware_support/ipu_docs/paddle_install_cn.md
+++ b/docs/guides/hardware_support/ipu_docs/paddle_install_cn.md
@@ -76,8 +76,8 @@ PaddlePaddle is installed successfully! Let's start deep learning with PaddlePad
 # PATH 中存在 GCC/G++ 8.2
 export PATH=/opt/compiler/gcc-8.2/bin:${PATH}
 
-# PATH 中存在 cmake 3.16.0
-export PATH=/opt/cmake-3.16/bin:${PATH}
+# PATH 中存在 cmake 3.18.0
+export PATH=/opt/cmake-3.18/bin:${PATH}
 
 # PATH 与 LD_LIBRARY_PATH 中存在 popart 与 poplar
 export PATH=/opt/popart/bin:/opt/poplar/lib:${PATH}

--- a/docs/guides/hardware_support/ipu_docs/paddle_install_cn.md
+++ b/docs/guides/hardware_support/ipu_docs/paddle_install_cn.md
@@ -7,7 +7,7 @@
 
 ## Docker 镜像方式启动
 
-当前 Docker 镜像包含预编译的飞桨框架 IPU 版，镜像基于 Ubuntu18.04 基础镜像构建，内置的 Python 版本为 Python3.7。
+当前 Docker 镜像包含预编译的飞桨框架 IPU 版，镜像基于 Ubuntu18.04 基础镜像构建，内置的 Python 版本为 Python3.8。
 
 **第一步**：拉取飞桨框架 IPU 版镜像
 
@@ -83,8 +83,8 @@ export PATH=/opt/cmake-3.16/bin:${PATH}
 export PATH=/opt/popart/bin:/opt/poplar/lib:${PATH}
 export LD_LIBRARY_PATH=/opt/popart/lib:/opt/poplar/lib:${LD_LIBRARY_PATH}
 
-# PATH 中存在 Python 3.7
-# 注意：镜像中的 python 3.7 通过 miniconda 安装，请通过 conda activate base 命令加载 Python 3.7 环境
+# PATH 中存在 Python 3.8
+# 注意：镜像中的 python 3.8 通过 miniconda 安装，请通过 conda activate base 命令加载 Python 3.8 环境
 export PATH=/opt/conda/bin:${PATH}
 ```
 

--- a/docs/guides/hardware_support/mlu_docs/paddle_install_cn.md
+++ b/docs/guides/hardware_support/mlu_docs/paddle_install_cn.md
@@ -115,7 +115,7 @@ make -j$(nproc)
 
 ```bash
 # 安装命令
-python -m pip install -U paddlepaddle_mlu-0.0.0-cp37-cp37-linux_x86_64.whl
+python -m pip install -U paddlepaddle_mlu-0.0.0-cp38-cp38-linux_x86_64.whl
 
 # 验证命令
 python -c "import paddle; paddle.utils.run_check()"

--- a/docs/guides/hardware_support/mlu_docs/paddle_install_cn.md
+++ b/docs/guides/hardware_support/mlu_docs/paddle_install_cn.md
@@ -115,7 +115,7 @@ make -j$(nproc)
 
 ```bash
 # 安装命令
-python -m pip install -U paddlepaddle_mlu-0.0.0-cp38-cp38-linux_x86_64.whl
+python -m pip install -U paddlepaddle_mlu-0.0.0-cp37-cp37-linux_x86_64.whl
 
 # 验证命令
 python -c "import paddle; paddle.utils.run_check()"

--- a/docs/guides/hardware_support/mlu_docs/train_example_cn.md
+++ b/docs/guides/hardware_support/mlu_docs/train_example_cn.md
@@ -19,7 +19,7 @@ git clone https://github.com/PaddlePaddle/PaddleClas.git
 
 **第三步**：运行训练
 
-使用飞浆 PaddleXXX 套件运行 MLU 可以通过设置 Global.device 参数为 mlu 来指定设备，其他模型也可以参考该使用方式
+使用飞桨 PaddleXXX 套件运行 MLU 可以通过设置 Global.device 参数为 mlu 来指定设备，其他模型也可以参考该使用方式
 
 ```bash
 export MLU_VISIBLE_DEVICES=0,1,2,3

--- a/docs/guides/hardware_support/rocm_docs/infer_example_cn.md
+++ b/docs/guides/hardware_support/rocm_docs/infer_example_cn.md
@@ -19,7 +19,7 @@ cd Paddle
 mkdir build && cd build
 
 # 执行 cmake，注意这里需打开预测优化选项 ON_INFER
-cmake .. -DPY_VERSION=3.7 -DWITH_ROCM=ON -DWITH_TESTING=OFF -DON_INFER=ON \
+cmake .. -DPY_VERSION=3.8 -DWITH_ROCM=ON -DWITH_TESTING=OFF -DON_INFER=ON \
          -DWITH_MKL=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 # 使用以下命令来编译

--- a/docs/guides/hardware_support/rocm_docs/paddle_install_cn.md
+++ b/docs/guides/hardware_support/rocm_docs/paddle_install_cn.md
@@ -9,7 +9,7 @@
 
 ## 安装方式一：通过 wheel 包安装
 
-**注意**：当前提供基于 CentOS 7.8 & ROCm 4.0.1 的 docker 镜像，与 Python 3.7 的 wheel 安装包。同时提供基于 CentOS 7.6 & DTK 22.10.1 的 docker 镜像，镜像中包含 Python 3.7 的飞浆 2.3.2 wheel 安装包（ image.sourcefind.cn:5000/dcu/admin/base/paddlepaddle:2.3.2-centos7.6-dtk-22.10.1-py37-latest ）
+**注意**：当前提供基于 CentOS 7.8 & ROCm 4.0.1 的 docker 镜像，与 Python 3.7 的 wheel 安装包。同时提供基于 CentOS 7.6 & DTK 22.10.1 的 docker 镜像，镜像中包含 Python 3.7 的飞桨 2.3.2 wheel 安装包（ image.sourcefind.cn:5000/dcu/admin/base/paddlepaddle:2.3.2-centos7.6-dtk-22.10.1-py37-latest ）
 
 **第一步**：准备 ROCm 4.0.1 运行环境 (推荐使用 Paddle 镜像)
 

--- a/docs/guides/model_convert/convert_from_pytorch/cv_experience_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/cv_experience_cn.md
@@ -146,9 +146,9 @@ reprod_log 主要功能如下：
 进入文件夹
 cd pipeline/reprod_log_demo
 随机生成矩阵，写入文件中
-python3.7 write_log.py
+python3 write_log.py
 进行文件对比，输出日志
-python3.7 check_log_diff.py
+python3 check_log_diff.py
 ```
 
 
@@ -1267,7 +1267,7 @@ if paddle.distributed.get_rank() == 0:
 
 ```shell
 export CUDA_VISIBLE_DEVICES=0
-python3.7 train.py \
+python3 train.py \
     --data-path /paddle/data/ILSVRC2012_torch \
     --lr 0.00125 \
     --batch-size 32 \
@@ -1279,7 +1279,7 @@ python3.7 train.py \
 ```shell
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
-python3.7 -m paddle.distributed.launch \
+python3 -m paddle.distributed.launch \
     --gpus="0,1,2,3,4,5,6,7" \
     train.py \
     --data-path /paddle/data/ILSVRC2012_torch \

--- a/docs/guides/model_convert/convert_from_pytorch/nlp_migration_experiences_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/nlp_migration_experiences_cn.md
@@ -152,9 +152,9 @@ reprod_log 主要功能如下：
 进入文件夹
 cd pipeline/reprod_log_demo
 随机生成矩阵，写入文件中
-python3.7 write_log.py
+python3 write_log.py
 进行文件对比，输出日志
-python3.7 check_log_diff.py
+python3 check_log_diff.py
 ```
 
 

--- a/docs/guides/model_convert/convert_train_code/cv_experience_cn.md
+++ b/docs/guides/model_convert/convert_train_code/cv_experience_cn.md
@@ -146,9 +146,9 @@ reprod_log 主要功能如下：
 进入文件夹
 cd pipeline/reprod_log_demo
 随机生成矩阵，写入文件中
-python3.7 write_log.py
+python3 write_log.py
 进行文件对比，输出日志
-python3.7 check_log_diff.py
+python3 check_log_diff.py
 ```
 
 
@@ -1267,7 +1267,7 @@ if paddle.distributed.get_rank() == 0:
 
 ```shell
 export CUDA_VISIBLE_DEVICES=0
-python3.7 train.py \
+python3 train.py \
     --data-path /paddle/data/ILSVRC2012_torch \
     --lr 0.00125 \
     --batch-size 32 \
@@ -1279,7 +1279,7 @@ python3.7 train.py \
 ```shell
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
-python3.7 -m paddle.distributed.launch \
+python3 -m paddle.distributed.launch \
     --gpus="0,1,2,3,4,5,6,7" \
     train.py \
     --data-path /paddle/data/ILSVRC2012_torch \


### PR DESCRIPTION
* `docs/guides/hardware_support/mlu_docs` mlu 这玩意看看要不要删

* `docs/guides/hardware_support/npu_docs` npu 这玩意看看要不要删

* `docs/guides/hardware_support/xpu_docs` xpu 这玩意看看要不要删，包都下不到 paddle 2.1 之后的版本了

* `docs/guides/hardware_support/rocm_docs/paddle_install_cn.md` docker 镜像都拉不下来，不知道咋改

* `docs/guides/infer/paddleslim` 包下不到 paddle 2.3 之后的版本了，中英文不同步

* `docs/dev_guides/custom_device_docs/custom_device_example_*.md` 中英不同步

* `docs/release_note_en.md`报错的存档信息不改

* `docs/guides/performance_improving/training_improving_model_*.md` Quick start也没修改（这些最好重新跑一遍）

* `docs/eval/*` Hackathon 部分也没修改（这部分或许应该要迁移？）

* `docs/guides/custom_op/new_cpp_op_cn.md` 原因是有弃用警告，最好重新跑一遍，且这是个开发文档需要对应自己的python版本，不影响使用


