### PR TITLE
[Fix] dsplit/vsplit 映射文档中书写错误

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.dsplit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.dsplit.md
@@ -1,6 +1,6 @@
-## [ 仅参数名不一致 ]torch.Tensor.split_size_or_sections
+## [ 仅参数名不一致 ]torch.Tensor.dsplit
 
-### [torch.Tensor.的 split](https://pytorch.org/docs/stable/generated/torch.Tensor.dsplit.html)
+### [torch.Tensor.dsplit](https://pytorch.org/docs/stable/generated/torch.Tensor.dsplit.html)
 
 ```python
 torch.Tensor.dsplit(split_size_or_sections)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.vsplit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.vsplit.md
@@ -1,4 +1,4 @@
-## [ 仅参数名不一致 ]torch.Tensor.split_size_or_sections
+## [ 仅参数名不一致 ]torch.Tensor.vsplit
 
 ### [torch.Tensor.vsplit](https://pytorch.org/docs/stable/generated/torch.Tensor.vsplit.html)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Description
<!-- Describe what you’ve done -->

修复 dsplit/vsplit 映射 torch 中的书写错误

@RedContritio @sunzhongkai588 

请评审 ～