### PR TITLE
[Cleanup] cleanup unused `convert-jinja2-into-html` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,6 @@ repos:
     hooks:
     -   id: insert-whitespace-between-cn-and-en-char
         files: \.md$|\.rst$
--   repo: https://github.com/reyoung/pre-commit-hooks-jinja-compile.git
-    rev: 4a369cc72a4a2b8d3813ab8cc17abb5f5b21ef6c
-    hooks:
-    -   id: convert-jinja2-into-html
-        # The argument means repleace filename from pattern `.*/([^/]*)\.tmpl` to `\1`
-        args: ['--filename_pattern=.*/([^/]*)\.tmpl', '--filename_repl=\1']
 -   repo: local
     hooks:
     -   id: convert-markdown-into-html


### PR DESCRIPTION
清理 `convert-jinja2-into-html` hook，该 hook 仅对 `tmpl` 文件生效，但我们已经没有这样的文件了