### PR TITLE
[Fix] fix docker relative doc when build from source

### DIFF
--- a/docs/install/compile/linux-compile-by-make.md
+++ b/docs/install/compile/linux-compile-by-make.md
@@ -37,7 +37,8 @@ Docker 环境中已预装好编译 Paddle 需要的各种依赖，相较本机�
 
 - 在本地主机上[安装 Docker](https://docs.docker.com/engine/install/)
 
-- 如需在 Linux 开启 GPU 支持，请[安装 nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+- 如需在 Linux 开启 GPU 支持，请[安装 NVIDIA Container Toolkit
+](https://github.com/NVIDIA/nvidia-container-toolkit)
 
 请您按照以下步骤安装：
 
@@ -64,22 +65,22 @@ cd Paddle
 
 * GPU 版的 PaddlePaddle：
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82
+    docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2
     ```
 
-如果您的机器不在中国大陆地区，可以直接从 DockerHub 拉取镜像：
+如果您的机器不在中国大陆地区，可以直接从 [DockerHub 中的 paddle 镜像仓库](https://hub.docker.com/r/paddlepaddle/paddle/tags) 拉取镜像：
 
 * CPU 版的 PaddlePaddle：
     ```
     docker pull paddlepaddle/paddle:latest-dev
     ```
 
-* GPU 版的 PaddlePaddle：
+* GPU 版的 PaddlePaddle(**建议使用较新的镜像,并确保已经成功安装 NVIDIA Container Toolkit**)：
     ```
-    nvidia-docker pull paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82
+    docker pull paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2
     ```
 
-上例中，`latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82` 仅作示意用，表示安装 GPU 版的镜像。如果您还想安装其他 cuda/cudnn 版本的镜像，可以将其替换成`latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`等。
+上例中，`latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2` 仅作示意用，表示安装 GPU 版的镜像。如果您还想安装其他 cuda/cudnn 版本的镜像，可以将其替换成其他版本（建议拉取最新的 GPU 版本）。
 您可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取与您机器适配的镜像。
 
 
@@ -87,6 +88,7 @@ cd Paddle
 
 * 编译 CPU 版本的 PaddlePaddle：
 
+    用从百度拉取的镜像创建容器：
     ```
     docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
     ```
@@ -99,11 +101,16 @@ cd Paddle
 
     - `registry.baidubce.com/paddlepaddle/paddle:latest-dev`：使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
 
+    若使用的是从 DockerHub 拉取的镜像创建容器，则修改镜像名即可：
+    ```
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it paddlepaddle/paddle:latest-dev /bin/bash
+    ```
 
 * 编译 GPU 版本的 PaddlePaddle：
 
+    用从百度拉取的镜像创建容器
     ```
-    nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82 /bin/bash
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
     ```
 
     - `--name paddle-test`：为您创建的 Docker 容器命名为 paddle-test;
@@ -112,11 +119,17 @@ cd Paddle
 
     - `-it`： 与宿主机保持交互状态;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82`：使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
+    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`：使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
 
+    若使用的是从 DockerHub 拉取的镜像创建容器，则修改镜像名即可：
+    ```
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
+    ```
 
 注意：
 请确保至少为 docker 分配 4g 以上的内存，否则编译过程可能因内存不足导致失败。
+
+**使用 GPU 版本镜像时，请确保成功安装 NVIDIA Container Toolkit ，否则无法在镜像中启用 GPU ，并且建议选择最新的 CPU 或者 GPU 镜像，否则可能会由于代码迭代较快，出现编译相关问题。**
 
 #### 5. 进入 Docker 后进入 paddle 目录下：
 

--- a/docs/install/compile/linux-compile-by-make_en.md
+++ b/docs/install/compile/linux-compile-by-make_en.md
@@ -37,7 +37,7 @@ Compiling PaddlePaddle with Docker，you need:
 
 - On the local host [Install Docker](https://docs.docker.com/engine/install/)
 
-- To enable GPU support on Linux, please [Install nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+- To enable GPU support on Linux, please [Install NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
 
 Please follow the steps below to install:
 
@@ -63,7 +63,7 @@ For domestic users, when downloading docker is slow due to network problems, you
 
 * GPU version of PaddlePaddle：
     ```
-    docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82
+    docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2
     ```
 
 If your machine is not in mainland China, you can pull the image directly from DockerHub:
@@ -75,7 +75,7 @@ If your machine is not in mainland China, you can pull the image directly from D
 
 * GPU version of PaddlePaddle：
     ```
-    docker pull paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82
+    docker pull paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2
     ```
 
 In the above example, `latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82` is only for illustration, indicating that the GPU version of the image is installed. If you want to install another `cuda/cudnn` version of the image, you can replace it with `latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2` etc.
@@ -88,6 +88,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
 * Compile CPU version of PaddlePaddle：
 
+    Using the image pulled from Baidu.
     ```
     docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
     ```
@@ -102,12 +103,17 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `registry.baidubce.com/paddlepaddle/paddle:latest-dev`: use the image named `registry.baidubce.com/paddlepaddle/paddle:latest-dev` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
 
+    If you are using the image pulled from DockerHub, just modify the image name.
+    ```
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it paddlepaddle/paddle:latest-dev /bin/bash
+    ```
 
 
 * Compile GPU version of PaddlePaddle:
 
+    Using the image pulled from Baidu.
     ```
-    nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82 /bin/bash
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
     ```
 
     - `--name paddle-test`: names the Docker container you created as paddle-test;
@@ -119,11 +125,17 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-it`: keeps interaction with the host;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82`: use the image named `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
+    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`: use the image named `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2` to create Docker container, /bin/bash start the /bin/bash command after entering the container.
 
+    If you are using the image pulled from DockerHub, just modify the image name.
+    ```
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
+    ```
 
 Note:
 Please make sure to allocate at least 4g of memory for docker, otherwise the compilation process may fail due to insufficient memory.
+
+**When using GPU version of image, please make sure the NVIDIA Container Toolkit is successfully installed, or GPU can not be used in docker container. And the latest version of image is recommended, or some compiling error may occur.**
 
 #### 5. After entering Docker, go to the paddle directory:
 ```

--- a/docs/install/compile/linux-compile-by-ninja.md
+++ b/docs/install/compile/linux-compile-by-ninja.md
@@ -37,7 +37,8 @@ Docker 环境中已预装好编译 Paddle 需要的各种依赖，相较本机�
 
 - 在本地主机上[安装 Docker](https://docs.docker.com/engine/install/)
 
-- 如需在 Linux 开启 GPU 支持，请[安装 nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+- 如需在 Linux 开启 GPU 支持，请[安装 NVIDIA Container Toolkit
+](https://github.com/NVIDIA/nvidia-container-toolkit)
 
 请您按照以下步骤安装：
 
@@ -61,40 +62,75 @@ cd Paddle
     ```
     docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev
     ```
+
 * GPU 版的 PaddlePaddle：
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82
+    docker pull registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2
     ```
-如果您的机器不在中国大陆地区，可以直接从 DockerHub 拉取镜像：
+
+如果您的机器不在中国大陆地区，可以直接从 [DockerHub 中的 paddle 镜像仓库](https://hub.docker.com/r/paddlepaddle/paddle/tags) 拉取镜像：
+
 * CPU 版的 PaddlePaddle：
     ```
     docker pull paddlepaddle/paddle:latest-dev
     ```
-* GPU 版的 PaddlePaddle：
+
+* GPU 版的 PaddlePaddle(**建议使用较新的镜像,并确保已经成功安装 NVIDIA Container Toolkit**)：
     ```
-    nvidia-docker pull paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82
+    docker pull paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2
     ```
-上例中，`latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82` 仅作示意用，表示安装 GPU 版的镜像。如果您还想安装其他 cuda/cudnn 版本的镜像，可以将其替换成`latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`等。
+
+上例中，`latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2` 仅作示意用，表示安装 GPU 版的镜像。如果您还想安装其他 cuda/cudnn 版本的镜像，可以将其替换成其他版本（建议拉取最新的 GPU 版本）。
 您可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取与您机器适配的镜像。
+
+
 #### 4. 创建并进入已配置好编译环境的 Docker 容器：
+
 * 编译 CPU 版本的 PaddlePaddle：
+
+    用从百度拉取的镜像创建容器
     ```
     docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev /bin/bash
     ```
+
     - `--name paddle-test`：为您创建的 Docker 容器命名为 paddle-test;
+
     - `-v $PWD:/paddle`： 将当前目录挂载到 Docker 容器中的/paddle 目录下（Linux 中 PWD 变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185));
+
     - `-it`： 与宿主机保持交互状态;
+
     - `registry.baidubce.com/paddlepaddle/paddle:latest-dev`：使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
+
+    若使用的是从 DockerHub 拉取的镜像创建容器，则修改镜像名即可：
+    ```
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it paddlepaddle/paddle:latest-dev /bin/bash
+    ```
+
 * 编译 GPU 版本的 PaddlePaddle：
+
+    用从百度拉取的镜像创建容器
     ```
-    nvidia-docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82 /bin/bash
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
     ```
+
     - `--name paddle-test`：为您创建的 Docker 容器命名为 paddle-test;
+
     - `-v $PWD:/paddle`： 将当前目录挂载到 Docker 容器中的/paddle 目录下（Linux 中 PWD 变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185));
+
     - `-it`： 与宿主机保持交互状态;
-    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82`：使用名为`registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8.2-trt8.0-gcc82`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
+
+    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`：使用名为`registry.baidubce.com/paddlepaddle/paddle`, tag 为`latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
+
+    若使用的是从 DockerHub 拉取的镜像创建容器，则修改镜像名即可：
+    ```
+    docker run --name paddle-test -v $PWD:/paddle --network=host -it paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
+    ```
+
 注意：
 请确保至少为 docker 分配 4g 以上的内存，否则编译过程可能因内存不足导致失败。
+
+**使用 GPU 版本镜像时，请确保成功安装 NVIDIA Container Toolkit ，否则无法在镜像中启用 GPU ，并且建议选择最新的 CPU 或者 GPU 镜像，否则可能会由于代码迭代较快，出现编译相关问题**
+
 #### 5. 进入 Docker 后进入 paddle 目录下：
 ```
 cd /paddle

--- a/docs/install/docker/linux-docker.md
+++ b/docs/install/docker/linux-docker.md
@@ -9,7 +9,7 @@
 
 - 在本地主机上[安装 Docker](https://docs.docker.com/engine/install/)
 
-- 如需在 Linux 开启 GPU 支持，请[安装 nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+- 如需在 Linux 开启 GPU 支持，请[安装 NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
 
 - 镜像中 Python 版本为 3.10
 
@@ -29,15 +29,15 @@
     docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-jupyter
     ```
 
-* GPU 版的 PaddlePaddle：
+* GPU 版的 PaddlePaddle(**建议拉取最新版本镜像，并确保已经成功安装 NVIDIA Container Toolkit**)：
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
-    ```
-    ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    ```
+    ```
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
     ```
 
 如果您的机器不在中国大陆地区，可以直接从 DockerHub 拉取镜像：
@@ -52,15 +52,15 @@
     docker pull paddlepaddle/paddle:2.6.0-jupyter
     ```
 
-* GPU 版的 PaddlePaddle：
+* GPU 版的 PaddlePaddle(**建议拉取最新版本镜像，并确保已经成功安装 NVIDIA Container Toolkit**)：
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
-    ```
-    ```
-    nvidia-docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
+    docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    ```
+    ```
+    docker pull paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
     ```
 
 您还可以访问[DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/)获取更多镜像。
@@ -115,18 +115,17 @@
 * 使用 GPU 版本的 PaddlePaddle：
 
     ```
-    nvidia-docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
+    docker run --name paddle_docker -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
     ```
 
     - `--name paddle_docker`：设定 Docker 的名称，`paddle_docker` 是自己设置的名称；
 
 
-    - `-it`：参数说明容器已和本机交互式运行；
+    - `-v $PWD:/paddle`： 将当前目录挂载到 Docker 容器中的/paddle 目录下（Linux 中 PWD 变量会展开为当前路径的[绝对路径](https://baike.baidu.com/item/绝对路径/481185));
 
+    - `-it`： 与宿主机保持交互状态;
 
-    - `-v $PWD:/paddle`：指定将当前路径（PWD 变量会展开为当前路径的绝对路径）挂载到容器内部的 /paddle 目录；
-
-    - `registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6`：指定需要使用的 image 名称，如果您希望使用 CUDA 11.2 或 CUDA 11.7 的镜像，也可以将其替换成`registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0` 或 `registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4`。您可以通过`docker images`命令查看镜像。/bin/bash 是在 Docker 中要执行的命令
+    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`：使用名为`registry.baidubce.com/paddlepaddle/paddle`, tag 为`latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`的镜像创建 Docker 容器，/bin/bash 进入容器后启动/bin/bash 命令。
 
 
 

--- a/docs/install/docker/linux-docker_en.md
+++ b/docs/install/docker/linux-docker_en.md
@@ -9,7 +9,7 @@ In the following Docker installation and use process, a specific version of Padd
 
 - On the local host [Install Docker](https://docs.docker.com/engine/install/)
 
-- To enable GPU support on Linux, please [Install nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+- To enable GPU support on Linux, please [Install NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
 
 - Python version in the image is 3.10
 
@@ -29,15 +29,15 @@ For domestic users, when downloading docker is slow due to network problems, you
     docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-jupyter
     ```
 
-* GPU version of PaddlePaddle：
+* GPU version of PaddlePaddle(**Latest version of gpu image is recommended， and make sure NVIDIA Container Toolkit is installed successfully**)：
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
-    ```
-    ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    ```
+    ```
+    docker pull registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
     ```
 
 If your machine is not in mainland China, you can pull the image directly from DockerHub:
@@ -52,15 +52,15 @@ If your machine is not in mainland China, you can pull the image directly from D
     docker pull paddlepaddle/paddle:2.6.0-jupyter
     ```
 
-* GPU version of PaddlePaddle：
+* GPU version of PaddlePaddle(**Latest version of gpu image is recommended， and make sure NVIDIA Container Toolkit is installed successfully**)：
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
-    ```
-    ```
-    nvidia-docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.2-cudnn8.2-trt8.0
     ```
     ```
-    nvidia-docker pull paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
+    docker pull paddlepaddle/paddle:2.6.0-gpu-cuda11.7-cudnn8.4-trt8.4
+    ```
+    ```
+    docker pull paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
     ```
 
 You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to get more images.
@@ -91,7 +91,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
 
     ```
-    nvidia-docker run --name paddle_docker -it -v $PWD:/paddle registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6
+    docker run --name paddle_docker -v $PWD:/paddle --network=host -it registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2 /bin/bash
     ```
 
     - `--name paddle_docker`: set name of Docker, `paddle_docker` is name of docker you set;
@@ -102,7 +102,7 @@ You can see [DockerHub](https://hub.docker.com/r/paddlepaddle/paddle/tags/) to g
 
     - `-v $PWD:/paddle`: Specifies to mount the current path of the host (PWD variable in Linux will expand to the absolute path of the current path) to the /paddle directory inside the container;
 
-    - `registry.baidubce.com/paddlepaddle/paddle:2.6.0-gpu-cuda12.0-cudnn8.9-trt8.6`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
+    - `registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda12.0-cudnn8.9-trt8.6-gcc12.2`: Specify the name of the image to be used. You can view it through the 'docker images' command. /bin/Bash is the command to be executed in Docker
 
 
 * Use CPU version of PaddlePaddle with jupyter：


### PR DESCRIPTION
1. 主要更新了一下源码编译安装的docker部分，原先的`nvidia-docker`已弃用，被`NVIDIA Container Toolkit`取代。

![image](https://github.com/PaddlePaddle/docs/assets/69197635/9bcfd9a7-0db8-42c7-b6f3-6cc7474a387c)


2. 另外更新了一下doc中的镜像版本，稍旧版本的镜像可能会有编译相关问题：
+ https://github.com/PaddlePaddle/Paddle/issues/60035