### PR TITLE
【映射文档】新增与维护部分映射文档

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.addmm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.addmm.md
@@ -1,0 +1,24 @@
+## [ 仅参数名不一致 ]torch.Tensor.addmm
+
+### [torch.Tensor.addmm](https://pytorch.org/docs/stable/generated/torch.Tensor.addmm.html)
+
+```python
+torch.Tensor.addmm(mat1, mat2, *, beta=1, alpha=1)
+```
+
+### [paddle.Tensor.addmm]()
+
+```python
+paddle.Tensor.addmm(x, y, alpha=1.0, beta=1.0)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch  | PaddlePaddle |               备注               |
+| :------: | :----------: | :------------------------------: |
+| mat1 |      x       | 表示输入的 Tensor，仅参数名不一致。 |
+| mat2 |      y       | 表示输入的 Tensor，仅参数名不一致。 |
+| alpha |   alpha     | 乘以 x*y 的标量，数据类型支持 float32、float64，默认值为 1.0。|
+| beta  |    beta     | 乘以 input 的标量，数据类型支持 float32、float64，默认值为 1.0。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.addmm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.addmm.md
@@ -17,8 +17,8 @@ paddle.Tensor.addmm(x, y, alpha=1.0, beta=1.0)
 ### 参数映射
 
 | PyTorch  | PaddlePaddle |               备注               |
-| :------: | :----------: | :------------------------------: |
+| -------- | ------------ | -------------------------------- |
 | mat1 |      x       | 表示输入的 Tensor，仅参数名不一致。 |
 | mat2 |      y       | 表示输入的 Tensor，仅参数名不一致。 |
-| alpha |   alpha     | 乘以 x*y 的标量，数据类型支持 float32、float64，默认值为 1.0。|
-| beta  |    beta     | 乘以 input 的标量，数据类型支持 float32、float64，默认值为 1.0。|
+| beta  |    beta     | 乘以 input 的标量。|
+| alpha |   alpha     | 乘以 x*y 的标量。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.all.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.all.md
@@ -10,8 +10,8 @@ torch.Tensor.all(dim=None, keepdim=False)
 
 ```python
 paddle.Tensor.all(axis=None,
-           keepdim=False,
-           name=None)
+                  keepdim=False,
+                  name=None)
 ```
 
 其中 Paddle 与 PyTorch 运算 Tensor 所支持的类型不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amax.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.amax
+
+### [torch.Tensor.amax](https://pytorch.org/docs/stable/generated/torch.Tensor.amax.html)
+
+```python
+torch.Tensor.amax(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.amax](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#amax-axis-none-keepdim-false-name-none)
+
+```python
+paddle.Tensor.amax(axis=None, keepdim=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                               |
+| ------- | ------------ | ------------------                 |
+| dim     | axis         | 求最大值运算的维度。                 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amax.md
@@ -18,5 +18,5 @@ paddle.Tensor.amax(axis=None, keepdim=False, name=None)
 
 | PyTorch | PaddlePaddle | 备注                               |
 | ------- | ------------ | ------------------                 |
-| dim     | axis         | 求最大值运算的维度。                 |
+| dim     | axis         | 求最大值运算的维度，仅参数名不一致。  |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amin.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.amin
+
+### [torch.Tensor.amin](https://pytorch.org/docs/stable/generated/torch.Tensor.amin.html)
+
+```python
+torch.Tensor.amin(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.amin](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#amin-axis-none-keepdim-false-name-none)
+
+```python
+paddle.Tensor.amin(axis=None, keepdim=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                               |
+| ------- | ------------ | ------------------                 |
+| dim     | axis         | 求最小值运算的维度。                 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.amin.md
@@ -18,5 +18,5 @@ paddle.Tensor.amin(axis=None, keepdim=False, name=None)
 
 | PyTorch | PaddlePaddle | 备注                               |
 | ------- | ------------ | ------------------                 |
-| dim     | axis         | 求最小值运算的维度。                 |
+| dim     | axis         | 求最小值运算的维度，仅参数名不一致。  |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.angle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.angle.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.angle
+
+### [torch.Tensor.angle](https://pytorch.org/docs/stable/generated/torch.Tensor.angle.html)
+
+```python
+torch.Tensor.angle()
+```
+
+### [paddle.Tensor.angle](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#angle-name-none)
+
+```python
+paddle.Tensor.angle(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.any.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.any.md
@@ -10,8 +10,8 @@ torch.Tensor.any(dim=None, keepdim=False)
 
 ```python
 paddle.Tensor.any(axis=None,
-           keepdim=False,
-           name=None)
+                  keepdim=False,
+                  name=None)
 ```
 
 其中 Paddle 与 PyTorch 运算 Tensor 所支持的类型不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.arccos.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.arccos.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.arccos
+
+### [torch.Tensor.arccos](https://pytorch.org/docs/stable/generated/torch.Tensor.arccos.html)
+
+```python
+torch.Tensor.arccos()
+```
+
+### [paddle.Tensor.acos]()
+
+```python
+paddle.Tensor.acos()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.arcsin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.arcsin.md
@@ -1,0 +1,15 @@
+## [ 无参数 ] torch.Tensor.arcsin
+
+### [torch.Tensor.arcsin](https://pytorch.org/docs/stable/generated/torch.Tensor.arcsin.html)
+
+```python
+torch.Tensor.arcsin()
+```
+
+### [paddle.Tensor.arcsin]()
+
+```python
+paddle.Tensor.arcsin()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.arctan.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.arctan.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.arctan
+
+### [torch.Tensor.arctan](https://pytorch.org/docs/stable/generated/torch.Tensor.arctan.html)
+
+```python
+torch.Tensor.arctan()
+```
+
+### [paddle.Tensor.arctan]()
+
+```python
+paddle.Tensor.arctan()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmax.md
@@ -18,5 +18,5 @@ paddle.Tensor.argmax(axis=None, keepdim=False, dtype=int64, name=None)
 
 | PyTorch | PaddlePaddle | 备注                               |
 | ------- | ------------ | ------------------                 |
-| dim     | axis         | 指定对输入 Tensor 进行运算的轴，axis 的有效范围是\[-R, R），R 是输入 x 的维度个数  |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，仅参数名不一致。  |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmax.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.argmax
+
+### [torch.Tensor.argmax](https://pytorch.org/docs/stable/generated/torch.Tensor.argmax.html)
+
+```python
+torch.Tensor.argmax(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.argmax](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#argmax-axis-none-keepdim-false-dtype-int64-name-none)
+
+```python
+paddle.Tensor.argmax(axis=None, keepdim=False, dtype=int64, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                               |
+| ------- | ------------ | ------------------                 |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，axis 的有效范围是\[-R, R），R 是输入 x 的维度个数  |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmin.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.argmin
+
+### [torch.Tensor.argmin](https://pytorch.org/docs/stable/generated/torch.Tensor.argmin.html)
+
+```python
+torch.Tensor.argmin(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.argmin](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#argmin-axis-none-keepdim-false-dtype-int64-name-none)
+
+```python
+paddle.Tensor.argmin(axis=None, keepdim=False, dtype=int64, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                               |
+| ------- | ------------ | ------------------                 |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，axis 的有效范围是\[-R, R），R 是输入 x 的维度个数  |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argmin.md
@@ -18,5 +18,5 @@ paddle.Tensor.argmin(axis=None, keepdim=False, dtype=int64, name=None)
 
 | PyTorch | PaddlePaddle | 备注                               |
 | ------- | ------------ | ------------------                 |
-| dim     | axis         | 指定对输入 Tensor 进行运算的轴，axis 的有效范围是\[-R, R），R 是输入 x 的维度个数  |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，仅参数名不一致。  |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argsort.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argsort.md
@@ -18,5 +18,5 @@ paddle.Tensor.argsort(axis=-1, descending=False, name=None)
 
 | PyTorch    | PaddlePaddle | 备注 |
 | ---------- | ------------ | -- |
-| dim        | axis         | 指定对输入 Tensor 进行运算的轴。   |
+| dim        | axis         | 指定对输入 Tensor 进行运算的轴，仅参数名不一致。   |
 | descending | descending   | 指定算法排序的方向。如果设置为 True，算法按照降序排序。如果设置为 False 或者不设置，按照升序排序。默认值为 False。   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argsort.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argsort.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.argsort
+
+### [torch.Tensor.argsort](https://pytorch.org/docs/stable/generated/torch.Tensor.argsort.html)
+
+```python
+torch.Tensor.argsort(dim=-1, descending=False)
+```
+
+### [paddle.Tensor.argsort](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#argsort-axis-1-descending-false-name-none)
+
+```python
+paddle.Tensor.argsort(axis=-1, descending=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch    | PaddlePaddle | 备注 |
+| ---------- | ------------ | -- |
+| dim        | axis         | 指定对输入 Tensor 进行运算的轴。   |
+| descending | descending   | 指定算法排序的方向。如果设置为 True，算法按照降序排序。如果设置为 False 或者不设置，按照升序排序。默认值为 False。   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.as_strided.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.as_strided.md
@@ -3,17 +3,17 @@
 
 ```python
 torch.Tensor.as_strided(size,
-                stride,
-                storage_offset=None)
+                        stride,
+                        storage_offset=None)
 ```
 
 ### [paddle.Tensor.as_strided](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#as-strided-x-shape-stride-offset-0-name-none)
 
 ```python
 paddle.Tensor.as_strided(shape,
-                stride,
-                offset=0,
-                name=None)
+                         stride,
+                         offset=0,
+                         name=None)
 ```
 
 两者功能一致且参数用法一致，仅参数名不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bincount.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bincount.md
@@ -1,0 +1,22 @@
+## [ 参数完全一致 ]torch.Tensor.bincount
+
+### [torch.Tensor.bincount](https://pytorch.org/docs/stable/generated/torch.Tensor.bincount.html)
+
+```python
+torch.Tensor.bincount(weights=None, minlength=0)
+```
+
+### [paddle.Tensor.bincount](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#bincount-weights-none-minlength-0)
+
+```python
+paddle.Tensor.bincount(weights=None, minlength=0)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch   | PaddlePaddle | 备注 |
+| --------- | ------------ | -- |
+| weights   | weights      | 输入 Tensor 中每个元素的权重。  |
+| minlength | minlength    | 输出 Tensor 的最小长度。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_and.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_and.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.bitwise_and
+
+### [torch.Tensor.bitwise_and](https://pytorch.org/docs/stable/generated/torch.Tensor.bitwise_and.html)
+
+```python
+torch.Tensor.bitwise_and(other)
+```
+
+### [paddle.Tensor.bitwise_and]()
+
+```python
+paddle.Tensor.bitwise_and(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_not.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_not.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.bitwise_not
+
+### [torch.Tensor.bitwise_not](https://pytorch.org/docs/stable/generated/torch.Tensor.bitwise_not.html)
+
+```python
+torch.Tensor.bitwise_not()
+```
+
+### [paddle.Tensor.bitwise_not]()
+
+```python
+paddle.Tensor.bitwise_not()
+```
+
+两者功能一致，均无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_or.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_or.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.bitwise_or
+
+### [torch.Tensor.bitwise_or](https://pytorch.org/docs/stable/generated/torch.Tensor.bitwise_or.html)
+
+```python
+torch.Tensor.bitwise_or(other)
+```
+
+### [paddle.Tensor.bitwise_or]()
+
+```python
+paddle.Tensor.bitwise_or(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_xor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bitwise_xor.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.bitwise_xor
+
+### [torch.Tensor.bitwise_xor](https://pytorch.org/docs/stable/generated/torch.Tensor.bitwise_xor.html)
+
+```python
+torch.Tensor.bitwise_xor(other)
+```
+
+### [paddle.Tensor.bitwise_xor]()
+
+```python
+paddle.Tensor.bitwise_xor(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bmm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bmm.md
@@ -18,4 +18,4 @@ paddle.Tensor.bmm(y, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| mat2    | y            | 输入变量  |
+| mat2    | y            | 输入 Tensor，仅参数名不一致。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bmm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.bmm.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.bmm
+
+### [torch.Tensor.bmm](https://pytorch.org/docs/stable/generated/torch.Tensor.bmm.html)
+
+```python
+torch.Tensor.bmm(mat2)
+```
+
+### [paddle.Tensor.bmm](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#bmm-y-name-none)
+
+```python
+paddle.Tensor.bmm(y, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| mat2    | y            | 输入变量  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.broadcast_to.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.broadcast_to.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.broadcast_to
+
+### [torch.Tensor.broadcast\_to](https://pytorch.org/docs/stable/generated/torch.Tensor.broadcast_to.html)
+
+```python
+torch.Tensor.broadcast_to(size)
+```
+
+### [paddle.Tensor.broadcast\_to](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#broadcast-to-shape-name-none)
+
+```python
+paddle.Tensor.broadcast_to(shape, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| size    | shape        | 给定输入 x 扩展后的形状。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.broadcast_to.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.broadcast_to.md
@@ -18,4 +18,4 @@ paddle.Tensor.broadcast_to(shape, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| size    | shape        | 给定输入 x 扩展后的形状。  |
+| size    | shape        | 给定输入 x 扩展后的形状，仅参数名不一致。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ceil.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ceil.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.ceil
+
+### [torch.Tensor.ceil](https://pytorch.org/docs/stable/generated/torch.Tensor.ceil.html)
+
+```python
+torch.Tensor.ceil()
+```
+
+### [paddle.Tensor.ceil](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#ceil-name-none)
+
+```python
+paddle.Tensor.ceil(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ceil_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ceil_.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.ceil_
+
+### [torch.Tensor.ceil\_](https://pytorch.org/docs/stable/generated/torch.Tensor.ceil_.html)
+
+```python
+torch.Tensor.ceil_()
+```
+
+### [paddle.Tensor.ceil\_](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#id7)
+
+```python
+paddle.Tensor.ceil_(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cholesky.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cholesky.md
@@ -1,0 +1,21 @@
+## [ 参数完全一致 ]torch.Tensor.cholesky
+
+### [torch.Tensor.cholesky](https://pytorch.org/docs/stable/generated/torch.Tensor.cholesky.html)
+
+```python
+torch.Tensor.cholesky(upper=False)
+```
+
+### [paddle.Tensor.cholesky](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#cholesky-upper-false-name-none)
+
+```python
+paddle.Tensor.cholesky(upper=False, name=None)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| upper   | upper        | 指示是否返回上三角矩阵或下三角矩阵。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cov.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cov.md
@@ -5,11 +5,10 @@
 torch.Tensor.cov(*, correction=1, fweights=None, aweights=None)
 ```
 
-### [paddle.linalg.cov](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/linalg/cov_cn.html#cov)
+### [paddle.Tensor.cov]()
 
 ```python
-paddle.linalg.cov(x,
-                  rowvar=True,
+paddle.Tensor.cov(rowvar=True,
                   ddof=True,
                   fweights=None,
                   aweights=None,
@@ -17,7 +16,9 @@ paddle.linalg.cov(x,
 ```
 
 仅 paddle 参数更多，具体如下：
+
 ### 参数映射
+
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | <font color='red'> correction </font>    | <font color='red'> ddof </font>          | 样本量和样本自由度之间的差异， 若为 True ，返回无偏估计结果；若为 False ，返回普通平均值计算结果。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.diag.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.diag.md
@@ -9,7 +9,7 @@ torch.Tensor.diag(diagonal=0)
 ### [paddle.Tensor.diag](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/diag_cn.html#diag)
 
 ```python
-paddle.diag(x, offset=0, padding_value=0, name=None)
+paddle.Tensor.diag(offset=0, padding_value=0, name=None)
 ```
 
 两者功能一致，仅参数名不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.diag_embed.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.diag_embed.md
@@ -18,6 +18,6 @@ paddle.Tensor.diag_embed(offset=0, dim1=-2, dim2=-1, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| offset  | offset       | 从指定的二维平面中获取对角线的位置，默认值为 0，即主对角线。 |
-| dim1    | dim1         | 填充对角线的二维平面的第一维，默认值为 -2。 |
-| dim2    | dim2         | 填充对角线的二维平面的第二维，默认值为 -1。 |
+| offset  | offset       | 从指定的二维平面中获取对角线的位置。 |
+| dim1    | dim1         | 填充对角线的二维平面的第一维。 |
+| dim2    | dim2         | 填充对角线的二维平面的第二维。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.diag_embed.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.diag_embed.md
@@ -1,0 +1,23 @@
+## [ 参数完全一致 ]torch.Tensor.diag_embed
+
+### [torch.Tensor.diag\_embed](https://pytorch.org/docs/stable/generated/torch.Tensor.diag_embed.html)
+
+```python
+torch.Tensor.diag_embed(offset=0, dim1=-2, dim2=-1)
+```
+
+### [paddle.Tensor.diag\_embed]()
+
+```python
+paddle.Tensor.diag_embed(offset=0, dim1=-2, dim2=-1, name=None)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| offset  | offset       | 从指定的二维平面中获取对角线的位置，默认值为 0，即主对角线。 |
+| dim1    | dim1         | 填充对角线的二维平面的第一维，默认值为 -2。 |
+| dim2    | dim2         | 填充对角线的二维平面的第二维，默认值为 -1。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.erfinv_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.erfinv_.md
@@ -9,7 +9,7 @@ torch.Tensor.erfinv_()
 ### [paddle.Tensor.erfinv\_]()
 
 ```python
-paddle.Tensor.erfinv_(x)
+paddle.Tensor.erfinv_()
 ```
 
 两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.erfinv_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.erfinv_.md
@@ -6,10 +6,10 @@
 torch.Tensor.erfinv_()
 ```
 
-### [paddle.erfinv\_](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/erfinv__cn.html#erfinv)
+### [paddle.Tensor.erfinv\_]()
 
 ```python
-paddle.erfinv_(x)
+paddle.Tensor.erfinv_(x)
 ```
 
 两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_select.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_select.md
@@ -18,5 +18,5 @@ paddle.Tensor.index_select(index, axis=0, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| dim     | axis         | 索引轴，若未指定，则默认选取第 0 维。 |
+| dim     | axis         | 索引轴，仅参数名不一致。 |
 | index   | index        | 包含索引下标的 1-D Tensor。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_select.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_select.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.index_select
+
+### [torch.Tensor.index\_select](https://pytorch.org/docs/stable/generated/torch.Tensor.index_select.html)
+
+```python
+torch.Tensor.index_select(dim, index)
+```
+
+### [paddle.Tensor.index\_select](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#index-select-index-axis-0-name-none)
+
+```python
+paddle.Tensor.index_select(index, axis=0, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| dim     | axis         | 索引轴，若未指定，则默认选取第 0 维。 |
+| index   | index        | 包含索引下标的 1-D Tensor。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.inner.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.inner.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.inner
+
+### [torch.Tensor.inner](https://pytorch.org/docs/stable/generated/torch.Tensor.inner.html)
+
+```python
+torch.Tensor.inner(other)
+```
+
+### [paddle.Tensor.inner]()
+
+```python
+paddle.Tensor.inner(y, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| other   | y            | 计算内积的第二个 Tensor。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.inner.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.inner.md
@@ -18,4 +18,4 @@ paddle.Tensor.inner(y, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| other   | y            | 计算内积的第二个 Tensor。 |
+| other   | y            | 计算内积的第二个 Tensor，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.inverse.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.inverse.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.inverse
+
+### [torch.Tensor.inverse](https://pytorch.org/docs/stable/generated/torch.Tensor.inverse.html)
+
+```python
+torch.Tensor.inverse()
+```
+
+### [paddle.Tensor.inverse]()
+
+```python
+paddle.Tensor.inverse(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.is_complex.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.is_complex.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.is_complex
+
+### [torch.Tensor.is\_complex](https://pytorch.org/docs/stable/generated/torch.Tensor.is_complex.html)
+
+```python
+torch.Tensor.is_complex()
+```
+
+### [paddle.Tensor.is\_complex](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#is-complex)
+
+```python
+paddle.Tensor.is_complex()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.is_floating_point.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.is_floating_point.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.is_floating_point
+
+### [torch.Tensor.is\_floating\_point](https://pytorch.org/docs/stable/generated/torch.Tensor.is_floating_point.html)
+
+```python
+torch.Tensor.is_floating_point()
+```
+
+### [paddle.Tensor.is\_floating\_point](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#is-floating-point-x)
+
+```python
+paddle.Tensor.is_floating_point()
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isclose.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isclose.md
@@ -18,7 +18,7 @@ paddle.Tensor.isclose(y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None)
 
 | PyTorch   | PaddlePaddle | 备注 |
 | --------- | ------------ | -- |
-| other     | y            | 输入的 Tensor，数据类型为 float16、float32、float64、complex64 或 complex128。 |
-| rtol      | rtol         | 相对容忍误差，默认值为 1e-5。 |
-| atol      | atol         | 绝对容忍误差，默认值为 1e-8。 |
-| equal_nan | equal_nan    |  如果设置为 True，则两个 NaN 数值将被视为相等，默认值为 False。 |
+| other     | y            | 输入的 Tensor，仅参数名不一致。 |
+| rtol      | rtol         | 相对容忍误差。 |
+| atol      | atol         | 绝对容忍误差。 |
+| equal_nan | equal_nan    | 如果设置为 True，则两个 NaN 数值将被视为相等，默认值为 False。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isclose.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isclose.md
@@ -1,0 +1,24 @@
+## [ 仅参数名不一致 ]torch.Tensor.isclose
+
+### [torch.Tensor.isclose](https://pytorch.org/docs/stable/generated/torch.Tensor.isclose.html)
+
+```python
+torch.Tensor.isclose(other, rtol=1e-05, atol=1e-08, equal_nan=False)
+```
+
+### [paddle.Tensor.isclose](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#isclose-x-y-rtol-1e-05-atol-1e-08-equal-nan-false-name-none)
+
+```python
+paddle.Tensor.isclose(y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch   | PaddlePaddle | 备注 |
+| --------- | ------------ | -- |
+| other     | y            | 输入的 Tensor，数据类型为 float16、float32、float64、complex64 或 complex128。 |
+| rtol      | rtol         | 相对容忍误差，默认值为 1e-5。 |
+| atol      | atol         | 绝对容忍误差，默认值为 1e-8。 |
+| equal_nan | equal_nan    |  如果设置为 True，则两个 NaN 数值将被视为相等，默认值为 False。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isfinite.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isfinite.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.isfinite
+
+### [torch.Tensor.isfinite](https://pytorch.org/docs/stable/generated/torch.Tensor.isfinite.html)
+
+```python
+torch.Tensor.isfinite()
+```
+
+### [paddle.Tensor.isfinite](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#isfinite-name-none)
+
+```python
+paddle.Tensor.isfinite(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isinf.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isinf.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.isinf
+
+### [torch.Tensor.isinf](https://pytorch.org/docs/stable/generated/torch.Tensor.isinf.html)
+
+```python
+torch.Tensor.isinf()
+```
+
+### [paddle.Tensor.isinf](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#isinf-name-none)
+
+```python
+paddle.Tensor.isinf(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isnan.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.isnan.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.Tensor.isnan
+
+### [torch.Tensor.isnan](https://pytorch.org/docs/stable/generated/torch.Tensor.isnan.html)
+
+```python
+torch.Tensor.isnan()
+```
+
+### [paddle.Tensor.isnan](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#isnan-name-none)
+
+```python
+paddle.Tensor.isnan(name=None)
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.kthvalue.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.kthvalue.md
@@ -19,5 +19,5 @@ paddle.Tensor.kthvalue(k, axis=None, keepdim=False, name=None)
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
 | k       | k            | 需要沿轴查找的第 k 小，所对应的 k 值。 |
-| dim     | axis         | 指定对输入 Tensor 进行运算的轴，axis 的有效范围是[-R, R），R 是输入 x 的 Rank， axis 为负时与 axis + R 等价。默认值为-1。 |
-| keepdim | keepdim      | 是否保留指定的轴。如果是 True，维度会与输入 x 一致，对应所指定的轴的 size 为 1。否则，由于对应轴被展开，输出的维度会比输入小 1。默认值为 False。 |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，仅参数名不一致。 |
+| keepdim | keepdim      | 是否保留指定的轴。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.kthvalue.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.kthvalue.md
@@ -1,0 +1,23 @@
+## [ 仅参数名不一致 ]torch.Tensor.kthvalue
+
+### [torch.Tensor.kthvalue](https://pytorch.org/docs/stable/generated/torch.Tensor.kthvalue.html)
+
+```python
+torch.Tensor.kthvalue(k, dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.kthvalue](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#kthvalue-k-axis-none-keepdim-false-name-none)
+
+```python
+paddle.Tensor.kthvalue(k, axis=None, keepdim=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| k       | k            | 需要沿轴查找的第 k 小，所对应的 k 值。 |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，axis 的有效范围是[-R, R），R 是输入 x 的 Rank， axis 为负时与 axis + R 等价。默认值为-1。 |
+| keepdim | keepdim      | 是否保留指定的轴。如果是 True，维度会与输入 x 一致，对应所指定的轴的 size 为 1。否则，由于对应轴被展开，输出的维度会比输入小 1。默认值为 False。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lcm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lcm.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.lcm
+
+### [torch.Tensor.lcm](https://pytorch.org/docs/stable/generated/torch.Tensor.lcm.html)
+
+```python
+torch.Tensor.lcm(other)
+```
+
+### [paddle.Tensor.lcm]()
+
+```python
+paddle.Tensor.lcm(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.lerp
+
+### [torch.Tensor.lerp](https://pytorch.org/docs/stable/generated/torch.Tensor.lerp.html)
+
+```python
+torch.Tensor.lerp(end, weight)
+```
+
+### [paddle.Tensor.lerp](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#lerp-x-y-weight-name-none)
+
+```python
+paddle.Tensor.lerp(y, weight, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| end     | y            | 输入的 Tensor，作为线性插值结束的点。 |
+| weight  | weight       | 给定的权重值。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp.md
@@ -18,5 +18,5 @@ paddle.Tensor.lerp(y, weight, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| end     | y            | 输入的 Tensor，作为线性插值结束的点。 |
+| end     | y            | 输入的 Tensor，作为线性插值结束的点，仅参数名不一致。 |
 | weight  | weight       | 给定的权重值。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp_.md
@@ -18,5 +18,5 @@ paddle.Tensor.lerp_(y, weight, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| end     | y            | 输入的 Tensor，作为线性插值结束的点。 |
+| end     | y            | 输入的 Tensor，作为线性插值结束的点，仅参数名不一致。 |
 | weight  | weight       | 给定的权重值。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lerp_.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.lerp_
+
+### [torch.Tensor.lerp\_](https://pytorch.org/docs/stable/generated/torch.Tensor.lerp_.html)
+
+```python
+torch.Tensor.lerp_(end, weight)
+```
+
+### [paddle.Tensor.lerp\_](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#lerp-x-y-weight-name-none)
+
+```python
+paddle.Tensor.lerp_(y, weight, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| end     | y            | 输入的 Tensor，作为线性插值结束的点。 |
+| weight  | weight       | 给定的权重值。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_xor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_xor.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.logical_xor
+
+### [torch.Tensor.logical_xor](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_xor.html)
+
+```python
+torch.Tensor.logical_xor(other)
+```
+
+### [paddle.Tensor.logical_xor]()
+
+```python
+paddle.Tensor.logical_xor(y)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                   |
+| ------------- | ------------ | ------------------------------------------------------ |
+| other  |   y   | 表示输入的 Tensor ，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit.md
@@ -18,5 +18,4 @@ paddle.Tensor.logit(eps=None, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| eps     | eps          | 传入该参数后可将 x 的范围控制在 [eps,1−eps]
-，默认值为 None。 |
+| eps     | eps          | 传入该参数后可将 x 的范围控制在 [eps,1−eps]，默认值为 None。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logit.md
@@ -1,0 +1,22 @@
+## [ 参数完全一致 ]torch.Tensor.logit
+
+### [torch.Tensor.logit](https://pytorch.org/docs/stable/generated/torch.Tensor.logit.html)
+
+```python
+torch.Tensor.logit(eps=None)
+```
+
+### [paddle.Tensor.logit](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#logit-eps-none-name-none)
+
+```python
+paddle.Tensor.logit(eps=None, name=None)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| eps     | eps          | 传入该参数后可将 x 的范围控制在 [eps,1−eps]
+，默认值为 None。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.lu.md
@@ -1,0 +1,22 @@
+## [ 参数完全一致 ]torch.Tensor.lu
+
+### [torch.Tensor.lu](https://pytorch.org/docs/stable/generated/torch.Tensor.lu.html)
+
+```python
+torch.Tensor.lu(pivot=True, get_infos=False)
+```
+
+### [paddle.Tensor.lu]()
+
+```python
+paddle.Tensor.lu(pivot=True, get_infos=False, name=None)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch   | PaddlePaddle | 备注 |
+| --------- | ------------ | -- |
+| pivot     | pivot        | LU 分解时是否进行旋转。 |
+| get_infos | get_infos    | 是否返回分解状态信息，若为 True，则返回分解状态 Tensor，否则不返回。默认 False。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
@@ -1,0 +1,21 @@
+## [ 仅参数名不一致 ]torch.Tensor.matmul
+
+### [torch.Tensor.matmul](https://pytorch.org/docs/stable/generated/torch.Tensor.matmul.html)
+
+```python
+torch.Tensor.matmul(other)
+```
+
+### [paddle.Tensor.matmul](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#matmul-y-transpose-x-false-transpose-y-false-name-none)
+
+```python
+paddle.Tensor.matmul(y, transpose_x=False, transpose_y=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| other   | y            |  输入变量。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
@@ -1,4 +1,4 @@
-## [ 仅参数名不一致 ]torch.Tensor.matmul
+## [ 仅 paddle 参数更多 ]torch.Tensor.matmul
 
 ### [torch.Tensor.matmul](https://pytorch.org/docs/stable/generated/torch.Tensor.matmul.html)
 
@@ -12,10 +12,12 @@ torch.Tensor.matmul(other)
 paddle.Tensor.matmul(y, transpose_x=False, transpose_y=False, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+其中 PyTorch 和 Paddle 功能一致，仅 Paddle 参数更多，具体如下：
 
 ### 参数映射
 
 | PyTorch | PaddlePaddle | 备注 |
-| ------- | ------------ | -- |
+| ------- | ------------ | ---- |
 | other   | y            |  输入变量，仅参数名不一致。 |
+| -       | transpose_x  |  相乘前是否转置 x，仅 Paddle 参数更多，保持默认即可。 |
+| -       | transpose_y  |  相乘前是否转置 y，仅 Paddle 参数更多，保持默认即可。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
@@ -18,4 +18,4 @@ paddle.Tensor.matmul(y, transpose_x=False, transpose_y=False, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| other   | y            |  输入变量。 |
+| other   | y            |  输入变量，仅参数名不一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matrix_power.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matrix_power.md
@@ -1,0 +1,21 @@
+## [ 参数完全一致 ]torch.Tensor.matrix_power
+
+### [torch.Tensor.matrix\_power](https://pytorch.org/docs/stable/generated/torch.Tensor.matrix_power.html)
+
+```python
+torch.Tensor.matrix_power(n)
+```
+
+### [paddle.Tensor.matrix\_power](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#matrix-power-x-n-name-none)
+
+```python
+paddle.Tensor.matrix_power(n, name=None)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| n       | n            | 输入的幂次，类型为 int。它可以是任意整数。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mean.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mean.md
@@ -1,0 +1,34 @@
+## [ 参数不一致 ]torch.Tensor.mean
+
+### [torch.Tensor.mean](https://pytorch.org/docs/stable/generated/torch.Tensor.mean.html)
+
+```python
+torch.Tensor.mean(dim=None, keepdim=False, *, dtype=None)
+```
+
+### [paddle.Tensor.mean](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#mean-axis-none-keepdim-false-name-none)
+
+```python
+paddle.Tensor.mean(axis=None, keepdim=False, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| dim     | axis         | 指定对 x 进行计算的轴。 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
+| dtype   | -       | 输出 Tensor 的类型，Paddle 无此参数, 需要转写。  |
+
+### 转写示例
+
+#### dtype：输出数据类型
+```python
+# PyTorch 写法
+x.mean(dtype=torch.float32)
+
+# Paddle 写法
+x.mean().astype(paddle.float32)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mean.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mean.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.Tensor.mean
+## [ torch 参数更多 ]torch.Tensor.mean
 
 ### [torch.Tensor.mean](https://pytorch.org/docs/stable/generated/torch.Tensor.mean.html)
 
@@ -18,9 +18,9 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| dim     | axis         | 指定对 x 进行计算的轴。 |
+| dim     | axis         | 指定对 x 进行计算的轴，仅参数名不一致。 |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
-| dtype   | -       | 输出 Tensor 的类型，Paddle 无此参数, 需要转写。  |
+| dtype   | -            | 输出 Tensor 的类型，Paddle 无此参数, 需要转写。  |
 
 ### 转写示例
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.median.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.median.md
@@ -18,5 +18,5 @@ paddle.Tensor.median(axis=None, keepdim=False, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| dim     | axis         | 指定对 x 进行计算的轴。 |
+| dim     | axis         | 指定对 x 进行计算的轴，仅参数名不一致。 |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.median.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.median.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.median
+
+### [torch.Tensor.median](https://pytorch.org/docs/stable/generated/torch.Tensor.median.html)
+
+```python
+torch.Tensor.median(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.median](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#median-axis-none-keepdim-false-name-none)
+
+```python
+paddle.Tensor.median(axis=None, keepdim=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| dim     | axis         | 指定对 x 进行计算的轴。 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mode.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mode.md
@@ -18,5 +18,5 @@ paddle.Tensor.mode(axis=-1, keepdim=False, name=None)
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| dim     | axis         | 指定对输入 Tensor 进行运算的轴。 |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴，仅参数名不一致。 |
 | keepdim | keepdim      | 是否保留指定的轴。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mode.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mode.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.mode
+
+### [torch.Tensor.mode](https://pytorch.org/docs/stable/generated/torch.Tensor.mode.html)
+
+```python
+torch.Tensor.mode(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.mode](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#mode-axis-1-keepdim-false-name-none)
+
+```python
+paddle.Tensor.mode(axis=-1, keepdim=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| dim     | axis         | 指定对输入 Tensor 进行运算的轴。 |
+| keepdim | keepdim      | 是否保留指定的轴。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mul.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.mul.md
@@ -10,8 +10,8 @@ torch.Tensor.mul(other)
 
 ```python
 paddle.Tensor.multiply(y,
-                axis=-1,
-                name=None)
+                       axis=-1,
+                       name=None)
 ```
 
 其中，Paddle 与 PyTorch 的 `other` 参数所支持类型不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.multiply.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.multiply.md
@@ -10,8 +10,8 @@ torch.Tensor.multiply(other)
 
 ```python
 paddle.Tensor.multiply(y,
-                axis=-1,
-                name=None)
+                       axis=-1,
+                       name=None)
 ```
 
 其中，Paddle 与 PyTorch 的 `other` 参数所支持类型不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nanmedian.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nanmedian.md
@@ -1,4 +1,4 @@
-## [ 仅参数名不一致 ]torch.Tensor.nanmedian
+## [ 仅参数默认值不一致 ]torch.Tensor.nanmedian
 
 ### [torch.Tensor.nanmedian](https://pytorch.org/docs/stable/generated/torch.Tensor.nanmedian.html)
 
@@ -12,11 +12,11 @@ torch.Tensor.nanmedian(dim=None, keepdim=False)
 paddle.Tensor.nanmedian(axis=None, keepdim=True, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅参数名与参数默认值不一致，具体如下：
+其中 PyTorch 和 Paddle 功能一致，仅参数默认值不一致，具体如下：
 
 ### 参数映射
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| dim     | axis         | 指定对 x 进行计算的轴。 |
-| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度，PyTorch 默认值为 False，Paddle 默认值为 True。 |
+| dim     | axis         | 指定对 x 进行计算的轴，仅参数名不一致。 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度，PyTorch 默认值为 False，Paddle 默认值为 True。Paddle 需设置为与 PyTorch 一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nanmedian.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nanmedian.md
@@ -1,0 +1,22 @@
+## [ 仅参数名不一致 ]torch.Tensor.nanmedian
+
+### [torch.Tensor.nanmedian](https://pytorch.org/docs/stable/generated/torch.Tensor.nanmedian.html)
+
+```python
+torch.Tensor.nanmedian(dim=None, keepdim=False)
+```
+
+### [paddle.Tensor.nanmedian](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#nanmedian-axis-none-keepdim-true-name-none)
+
+```python
+paddle.Tensor.nanmedian(axis=None, keepdim=True, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名与参数默认值不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| dim     | axis         | 指定对 x 进行计算的轴。 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度，PyTorch 默认值为 False，Paddle 默认值为 True。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nansum.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nansum.md
@@ -3,16 +3,16 @@
 
 ```python
 torch.Tensor.nansum(dim=None,
-            keepdim=False,
-            dtype=None)
+                    keepdim=False,
+                    dtype=None)
 ```
 
 ### [paddle.Tensor.nansum]()
 
 ```python
 paddle.Tensor.nansum(axis=None,
-            keepdim=False,
-            dtype=None)
+                     keepdim=False,
+                     dtype=None)
 ```
 
 两者功能一致且参数用法一致，仅参数名不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter_add_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter_add_.md
@@ -14,7 +14,7 @@ torch.Tensor.scatter_add_(dim,
 paddle.Tensor.put_along_axis_(indices,
                               values,
                               axis,
-                              reduce='assign'，
+                              reduce='assign',
                               include_self=True)
 ```
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.to_sparse.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.to_sparse.md
@@ -9,7 +9,7 @@ torch.Tensor.to_sparse(sparseDims)
 ### [paddle.Tensor.to_sparse_coo]()
 
 ```
-paddleTensor.to_sparse_coo(sparseDims)
+paddle.Tensor.to_sparse_coo(sparseDims)
 ```
 
 两者功能一致，参数用法一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.AdaptiveMaxPool2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.AdaptiveMaxPool2d.md
@@ -2,16 +2,16 @@
 ### [torch.nn.AdaptiveMaxPool2d](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool2d.html?highlight=adaptivemaxpool2d#torch.nn.AdaptiveMaxPool2d)
 
 ```python
-class torch.nn.AdaptiveMaxPool2d(output_size,
-                                 return_indices=False)
+torch.nn.AdaptiveMaxPool2d(output_size,
+                           return_indices=False)
 ```
 
 ### [paddle.nn.AdaptiveMaxPool2D](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/AdaptiveMaxPool2D_cn.html#adaptivemaxpool2d)
 
 ```python
-class paddle.nn.AdaptiveMaxPool2D(output_size,
-                                  return_mask=False,
-                                  name=None)
+paddle.nn.AdaptiveMaxPool2D(output_size,
+                            return_mask=False,
+                            name=None)
 ```
 
 两者功能一致且参数用法一致，仅参数名不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Linear.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Linear.md
@@ -10,11 +10,11 @@ torch.nn.Linear(in_features,
 ### [paddle.nn.Linear](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/Linear_cn.html#linear)
 
 ```python
- paddle.nn.Linear(in_features,
-                  out_features,
-                  weight_attr=None,
-                  bias_attr=None,
-                  name=None)
+paddle.nn.Linear(in_features,
+                 out_features,
+                 weight_attr=None,
+                 bias_attr=None,
+                 name=None)
 ```
 
 其中 PyTorch 的 `bias` 与 Paddle 的 `bias_attr` 用法不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ModuleDict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ModuleDict.md
@@ -3,13 +3,13 @@
 ### [torch.nn.ModuleDict](https://pytorch.org/docs/stable/generated/torch.nn.ModuleDict.html?highlight=torch+nn+moduledict#torch.nn.ModuleDict)
 
 ```python
-class torch.nn.ModuleDict(modules=None)
+torch.nn.ModuleDict(modules=None)
 ```
 
 ### [paddle.nn.LayerDict](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/LayerDict_cn.html)
 
 ```python
-class paddle.nn.LayerDict(sublayers=None)
+paddle.nn.LayerDict(sublayers=None)
 ```
 
 两者功能一致，参数名不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ParameterList.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ParameterList.md
@@ -2,13 +2,13 @@
 ### [torch.nn.ParameterList](https://pytorch.org/docs/stable/generated/torch.nn.ParameterList.html?highlight=nn+parameterlist#torch.nn.ParameterList)
 
 ```python
-class torch.nn.ParameterList(values=None)
+torch.nn.ParameterList(values=None)
 ```
 
 ### [paddle.nn.ParameterList](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/ParameterList_cn.html#parameterlist)
 
 ```python
-class paddle.nn.ParameterList(parameters=None)
+paddle.nn.ParameterList(parameters=None)
 ```
 两者功能一致且参数用法一致，仅参数名不一致，具体如下：
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.SoftMarginLoss.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.SoftMarginLoss.md
@@ -11,7 +11,7 @@ torch.nn.SoftMarginLoss(size_average=None,
 ### [paddle.nn.SoftMarginLoss](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/SoftMarginLoss_cn.html#softmarginloss)
 
 ```python
-paddle.nn.SoftMarginloss(reduction='mean',
+paddle.nn.SoftMarginLoss(reduction='mean',
                          name=None)
 ```
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.functional.softmax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.functional.softmax.md
@@ -9,7 +9,7 @@ torch.nn.functional.softmax(input, dim=None, _stacklevel=3, dtype=None)
 ### [paddle.nn.functional.softmax](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/functional/softmax_cn.html#softmax)
 
 ```python
-paddle.nn.functional.softmax(x, axis=- 1, dtype=None, name=None)
+paddle.nn.functional.softmax(x, axis=-1, dtype=None, name=None)
 ```
 
 PyTorch 相比 Paddle 支持更多其他参数，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.alpha_dropout.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.alpha_dropout.md
@@ -1,0 +1,23 @@
+## [ 仅参数名不一致 ]torch.alpha_dropout
+
+### [torch.alpha\_dropout](https://pytorch.org/docs/master/generated/torch.nn.functional.alpha_dropout.html)
+
+```python
+torch.alpha_dropout(input, p=0.5, train=False)
+```
+
+### [paddle.nn.functional.alpha\_dropout](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/functional/alpha_dropout_cn.html#alpha-dropout)
+
+```python
+paddle.nn.functional.alpha_dropout(x, p=0.5, training=True, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | 输入的多维 Tensor，数据类型为：float16、float32 或 float64。 |
+| p       | p            | 将输入节点置 0 的概率，即丢弃概率。默认：0.5。 |
+| train   | training     | 标记是否为训练阶段。默认：True。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.alpha_dropout.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.alpha_dropout.md
@@ -1,4 +1,4 @@
-## [ 仅参数名不一致 ]torch.alpha_dropout
+## [ 仅参数默认值不一致 ]torch.alpha_dropout
 
 ### [torch.alpha\_dropout](https://pytorch.org/docs/master/generated/torch.nn.functional.alpha_dropout.html)
 
@@ -12,12 +12,12 @@ torch.alpha_dropout(input, p=0.5, train=False)
 paddle.nn.functional.alpha_dropout(x, p=0.5, training=True, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+其中 PyTorch 和 Paddle 功能一致，仅参数默认值不一致，具体如下：
 
 ### 参数映射
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| input   | x            | 输入的多维 Tensor，数据类型为：float16、float32 或 float64。 |
-| p       | p            | 将输入节点置 0 的概率，即丢弃概率。默认：0.5。 |
-| train   | training     | 标记是否为训练阶段。默认：True。 |
+| input   | x            | 输入的多维 Tensor，仅参数名不一致。 |
+| p       | p            | 将输入节点置 0 的概率，即丢弃概率。 |
+| train   | training     | 标记是否为训练阶段。PyTorch 默认值为 False，Paddle 默认值为 True。Paddle 需设置为与 PyTorch 一致。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amax.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.amax
+## [ torch 参数更多 ]torch.amax
 
 ### [torch.amax](https://pytorch.org/docs/stable/generated/torch.amax.html)
 
@@ -18,10 +18,10 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| input   | x            | Tensor，支持数据类型为 float32、float64、int32、int64，维度不超过 4 维。 |
-| dim     | axis         | 求最大值运算的维度。 |
+| input   | x            | 输入 Tensor，仅参数名不一致。 |
+| dim     | axis         | 求最大值运算的维度，仅参数名不一致。 |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
-| out     | -            | 表示输出的 Tensor,可选项，Paddle 无此参数，需要转写。 |
+| out     | -            | 输出 Tensor，Paddle 无此参数，需要转写。 |
 
 ### 转写示例
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amax.md
@@ -1,0 +1,36 @@
+## [ 参数不一致 ]torch.amax
+
+### [torch.amax](https://pytorch.org/docs/stable/generated/torch.amax.html)
+
+```python
+torch.amax(input, dim, keepdim=False, *, out=None)
+```
+
+### [paddle.amax](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/amax_cn.html#amax)
+
+```python
+paddle.amax(x, axis=None, keepdim=False, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | Tensor，支持数据类型为 float32、float64、int32、int64，维度不超过 4 维。 |
+| dim     | axis         | 求最大值运算的维度。 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
+| out     | -            | 表示输出的 Tensor,可选项，Paddle 无此参数，需要转写。 |
+
+### 转写示例
+
+#### out： 指定输出
+
+```python
+# PyTorch 写法
+torch.amax(a, dim=0，out=y)
+
+# Paddle 写法
+paddle.assign(paddle.amax(a, dim=0), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amin.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.amin
+## [ torch 参数更多 ]torch.amin
 
 ### [torch.amin](https://pytorch.org/docs/stable/generated/torch.amin.html)
 
@@ -18,10 +18,10 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| input   | x            | Tensor，支持数据类型为 float32、float64、int32、int64，维度不超过 4 维。 |
-| dim     | axis         | 求最小值运算的维度。 |
+| input   | x            | 输入 Tensor，仅参数名不一致。 |
+| dim     | axis         | 求最小值运算的维度，仅参数名不一致。 |
 | keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
-| out     | -            | 表示输出的 Tensor,可选项，Paddle 无此参数，需要转写。 |
+| out     | -            | 输出 Tensor，Paddle 无此参数，需要转写。 |
 
 ### 转写示例
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.amin.md
@@ -1,0 +1,36 @@
+## [ 参数不一致 ]torch.amin
+
+### [torch.amin](https://pytorch.org/docs/stable/generated/torch.amin.html)
+
+```python
+torch.amin(input, dim, keepdim=False, *, out=None)
+```
+
+### [paddle.amin](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/amin_cn.html#amin)
+
+```python
+paddle.amin(x, axis=None, keepdim=False, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | Tensor，支持数据类型为 float32、float64、int32、int64，维度不超过 4 维。 |
+| dim     | axis         | 求最小值运算的维度。 |
+| keepdim | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
+| out     | -            | 表示输出的 Tensor,可选项，Paddle 无此参数，需要转写。 |
+
+### 转写示例
+
+#### out： 指定输出
+
+```python
+# PyTorch 写法
+torch.amin(a, dim=0，out=y)
+
+# Paddle 写法
+paddle.assign(paddle.amin(a, dim=0), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.angle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.angle.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.angle
+## [ torch 参数更多 ]torch.angle
 
 ### [torch.angle](https://pytorch.org/docs/stable/generated/torch.angle.html)
 
@@ -18,8 +18,8 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
-| input   | x            | 输入的 Tensor。 |
-| out     | -            | 表示输出的 Tensor,可选项，Paddle 无此参数，需要转写。 |
+| input   | x            | 输入 Tensor，仅参数名不一致。 |
+| out     | -            | 输出 Tensor，Paddle 无此参数，需要转写。 |
 
 ### 转写示例
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.angle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.angle.md
@@ -1,0 +1,34 @@
+## [ 参数不一致 ]torch.angle
+
+### [torch.angle](https://pytorch.org/docs/stable/generated/torch.angle.html)
+
+```python
+torch.angle(input, *, out=None)
+```
+
+### [paddle.angle](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/angle_cn.html#angle)
+
+```python
+paddle.angle(x, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | 输入的 Tensor。 |
+| out     | -            | 表示输出的 Tensor,可选项，Paddle 无此参数，需要转写。 |
+
+### 转写示例
+
+#### out： 指定输出
+
+```python
+# PyTorch 写法
+torch.angle(x, out=y)
+
+# Paddle 写法
+paddle.assign(paddle.angle(x), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.autograd.function.FunctionCtx.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.autograd.function.FunctionCtx.md
@@ -1,0 +1,15 @@
+## [ 无参数 ]torch.autograd.function.FunctionCtx
+
+### [torch.autograd.function.FunctionCtx]()
+
+```python
+torch.autograd.function.FunctionCtx
+```
+
+### [paddle.autograd.PyLayerContext](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/autograd/PyLayerContext_cn.html#pylayercontext)
+
+```python
+paddle.autograd.PyLayerContext
+```
+
+两者功能一致，无参数。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/optimizer/torch.optim.Optimizer.load_state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/optimizer/torch.optim.Optimizer.load_state_dict.md
@@ -9,7 +9,7 @@ torch.optim.Optimizer.load_state_dict(state_dict)
 ### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html)
 
 ```python
-paddle.optimizer.Optimizer.load_state_ dict(state_dict)
+paddle.optimizer.Optimizer.load_state_dict(state_dict)
 ```
 
 两者功能一致，参数完全一致。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.distributed.DistributedSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.distributed.DistributedSampler.md
@@ -31,7 +31,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | dataset       | dataset      | 所用的数据集。 |
 | num_replicas  | num_replicas | 进程数量。    |
 | rank          | rank         | num_replicas 个进程中的进程序号。 |
-| shuffle       | shuffle      | 是否打乱。PyTorch 默认值为 True， 默认值为 False。Paddle 需设置为与 PyTorch 一致。 |
+| shuffle       | shuffle      | 是否打乱。PyTorch 默认值为 True，Paddle 默认值为 False。Paddle 需设置为与 PyTorch 一致。 |
 | seed          | -            | 如果 shuffle=True，则使用随机种子对采样器进行随机排序,此数字在分布式组中的所有进程中应相同，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。  |
 | drop_last     | drop_last    | 是否需要丢弃最后无法凑整一个 mini-batch 的样本。 |
 | -             | batch_size   | 每 mini-batch 中包含的样本数，PyTorch 无此参数，Paddle 需设置为 1。                   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.distributed.DistributedSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.distributed.DistributedSampler.md
@@ -1,4 +1,5 @@
-## [ 参数不一致 ]torch.utils.data.distributed.DistributedSampler
+## [ torch 参数更多 ]torch.utils.data.distributed.DistributedSampler
+
 ### [torch.utils.data.distributed.DistributedSampler](https://pytorch.org/docs/stable/data.html?highlight=distributedsampler#torch.utils.data.distributed.DistributedSampler)
 
 ```python
@@ -21,9 +22,16 @@ paddle.io.DistributedBatchSampler(dataset=None,
                                   drop_last=False)
 ```
 
-两者功能一致但参数不一致，具体如下：
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
 ### 参数差异
-| PyTorch       | PaddlePaddle | 备注                                                   |
-| ----- | ---------- | ---------- |
+
+| PyTorch       | PaddlePaddle | 备注       |
+| ------------- | ------------ | ---------- |
+| dataset       | dataset      | 所用的数据集。 |
+| num_replicas  | num_replicas | 进程数量。    |
+| rank          | rank         | num_replicas 个进程中的进程序号。 |
+| shuffle       | shuffle      | 是否打乱。PyTorch 默认值为 True， 默认值为 False。Paddle 需设置为与 PyTorch 一致。 |
 | seed          | -            | 如果 shuffle=True，则使用随机种子对采样器进行随机排序,此数字在分布式组中的所有进程中应相同，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。  |
+| drop_last     | drop_last    | 是否需要丢弃最后无法凑整一个 mini-batch 的样本。 |
 | -             | batch_size   | 每 mini-batch 中包含的样本数，PyTorch 无此参数，Paddle 需设置为 1。                   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.distributed.DistributedSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.distributed.DistributedSampler.md
@@ -2,23 +2,23 @@
 ### [torch.utils.data.distributed.DistributedSampler](https://pytorch.org/docs/stable/data.html?highlight=distributedsampler#torch.utils.data.distributed.DistributedSampler)
 
 ```python
-class torch.utils.data.distributed.DistributedSampler(dataset,
-                                                      num_replicas=None,
-                                                      rank=None,
-                                                      shuffle=True,
-                                                      seed=0,
-                                                      drop_last=False)
+torch.utils.data.distributed.DistributedSampler(dataset,
+                                                num_replicas=None,
+                                                rank=None,
+                                                shuffle=True,
+                                                seed=0,
+                                                drop_last=False)
 ```
 
 ### [paddle.io.DistributedBatchSampler](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/io/DistributedBatchSampler_cn.html#distributedbatchsampler)
 
 ```python
-class paddle.io.DistributedBatchSampler(dataset=None,
-                                        batch_size,
-                                        num_replicas=None,
-                                        rank=None,
-                                        shuffle=False,
-                                        drop_last=False)
+paddle.io.DistributedBatchSampler(dataset=None,
+                                  batch_size,
+                                  num_replicas=None,
+                                  rank=None,
+                                  shuffle=False,
+                                  drop_last=False)
 ```
 
 两者功能一致但参数不一致，具体如下：

--- a/docs/guides/model_convert/convert_from_pytorch/apply_reference_from_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/apply_reference_from_api_difference.py
@@ -13,6 +13,10 @@ class DiffMeta(typing.TypedDict):
     source_file: str
 
 
+def unescape_api(api):
+    return api.replace(r"\_", "_")
+
+
 def get_meta_from_diff_file(filepath):
     meta_data: DiffMeta = {"source_file": filepath}
     state = 0
@@ -39,7 +43,7 @@ def get_meta_from_diff_file(filepath):
                     mapping_type = title_match["type"].strip()
                     torch_api = title_match["torch_api"].strip()
 
-                    meta_data["torch_api"] = torch_api
+                    meta_data["torch_api"] = unescape_api(torch_api)
                     meta_data["mapping_type"] = mapping_type
                     state = 1
                 else:
@@ -51,7 +55,7 @@ def get_meta_from_diff_file(filepath):
                     torch_api = torch_match["torch_api"].strip()
                     torch_url = torch_match["url"] if torch_match["url"] else ""
                     real_url = torch_url.lstrip("(").rstrip(")")
-                    if meta_data["torch_api"] != torch_api:
+                    if meta_data["torch_api"] != unescape_api(torch_api):
                         raise Exception(
                             f"torch api not match: {line} != {meta_data['torch_api']} in {filepath}"
                         )


### PR DESCRIPTION
- 修复了此前类构造方法签名不一致的问题：均不使用 class
- 新增了部分映射文档，基于 PaConvert 已实现的 api 映射

剩余已实现的 api 文档正在整理中

> 思考：
  考虑维护问题的话，或许可以考虑给所有的映射文档一个更统一规范的模板？
  包括但不限于：
      - 映射文档中函数签名不同行的缩进与空格使用等
      - 网址格式是否使用锚点
      - 参数对比表格格式中字体强调色、表格空格使用数量、表格分割线格式等
      - 同级别的映射类型同时存在时，映射类型选择与映射类型描述的规范等（如，参数名不一致 + paddle 参数更多）
