### PR TITLE
【映射文档】补全缺失的映射文档

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.BoolTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.BoolTensor.md
@@ -1,0 +1,23 @@
+## [ 仅 paddle 参数更多 ] torch.BoolTensor
+
+### [torch.BoolTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.BoolTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='bool', place='cpu')
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'bool'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cpu' 。         |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.FloatTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.FloatTensor.md
@@ -1,0 +1,23 @@
+## [ 仅 paddle 参数更多 ] torch.FloatTensor
+
+### [torch.FloatTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.FloatTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='float32', place='cpu')
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'float32'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cpu' 。         |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.IntTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.IntTensor.md
@@ -1,0 +1,23 @@
+## [ 仅 paddle 参数更多 ] torch.IntTensor
+
+### [torch.IntTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.IntTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='int32', place='cpu')
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'int32'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cpu' 。         |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.LongTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.LongTensor.md
@@ -1,0 +1,23 @@
+## [ 仅 paddle 参数更多 ] torch.LongTensor
+
+### [torch.LongTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.LongTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='int64', place='cpu')
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'int64'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cpu' 。         |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.embedding.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.embedding.md
@@ -1,4 +1,4 @@
-## [torch 参数]torch.nn.functional.embedding
+## [torch 参数更多]torch.nn.functional.embedding
 
 ### [torch.nn.functional.embedding](https://pytorch.org/docs/stable/generated/torch.nn.functional.embedding.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_norm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.matrix_norm.md
@@ -6,10 +6,10 @@
 torch.linalg.matrix_norm(input, ord='fro', dim=(-2, -1), keepdim=False, *, dtype=None, out=None)
 ```
 
-### [paddle.linalg.norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/linalg/norm_cn.html)
+### [paddle.linalg.matrix_norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/linalg/matrix_norm_cn.html)
 
 ```python
-paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
+paddle.linalg.matrix_norm(x, p='fro', axis=[-2,-1], keepdim=False, name=None)
 ```
 
 其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -19,7 +19,7 @@ paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
 | PyTorch | PaddlePaddle | 备注                                                                            |
 | ------- | ------------ | ------------------------------------------------------------------------------- |
 | input   | x            | 输入 Tensor，仅参数名不一致。                                                   |
-| ord     | p            | 范数的种类。参数不一致。PyTorch 支持负实数的范数，Paddle 不支持，暂无转写方式。 |
+| ord     | p            | 范数的种类，仅参数名不一致。 |
 | dim     | axis         | 使用范数计算的轴 ，仅参数名不一致。                                             |
 | keepdim | keepdim      | 是否在输出的 Tensor 中保留和输入一样的维度。                                    |
 | dtype   | -            | 表示输出 Tensor 的数据类型， Paddle 无此参数，需要转写。                        |
@@ -34,7 +34,7 @@ paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
 torch.linalg.matrix_norm(x, out=y)
 
 # Paddle 写法
-paddle.assign(paddle.linalg.norm(x), y)
+paddle.assign(paddle.linalg.matrix_norm(x), y)
 ```
 
 #### dtype：表示输出 Tensor 的数据类型
@@ -44,5 +44,5 @@ paddle.assign(paddle.linalg.norm(x), y)
 torch.linalg.matrix_norm(x, dtype=torch.float64)
 
 # Paddle 写法
-paddle.linalg.norm(x.astype(paddle.float64))
+paddle.linalg.matrix_norm(x.astype(paddle.float64))
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.vector_norm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.vector_norm.md
@@ -6,10 +6,10 @@
 torch.linalg.vector_norm(x, ord=2, dim=None, keepdim=False, *, dtype=None, out=None)
 ```
 
-### [paddle.linalg.norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/linalg/norm_cn.html)
+### [paddle.linalg.vector_norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/linalg/vector_norm_cn.html)
 
 ```python
-paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
+paddle.linalg.vector_norm(x, p=2.0, axis=None, keepdim=False, name=None)
 ```
 
 其中 PyTorch 相比 Paddle 支持更多其他参数，具体如下：
@@ -19,7 +19,7 @@ paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
 | PyTorch | PaddlePaddle | 备注                                                                            |
 | ------- | ------------ | ------------------------------------------------------------------------------- |
 | x       | x            | 输入 Tensor。                                                                   |
-| ord     | p            | 范数的种类。参数不一致。PyTorch 支持负实数的范数，Paddle 不支持，暂无转写方式。 |
+| ord     | p            | 范数的种类，仅参数名不一致。 |
 | dim     | axis         | 使用范数计算的轴 ，仅参数名不一致。                                             |
 | keepdim | keepdim      | 是否在输出的 Tensor 中保留和输入一样的维度。                                    |
 | dtype   | -            | 表示输出 Tensor 的数据类型， Paddle 无此参数，需要转写。                        |
@@ -34,7 +34,7 @@ paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
 torch.linalg.vector_norm(x, out=y)
 
 # Paddle 写法
-paddle.assign(paddle.linalg.norm(x), y)
+paddle.assign(paddle.linalg.vector_norm(x), y)
 ```
 
 #### dtype：表示输出 Tensor 的数据类型
@@ -44,5 +44,5 @@ paddle.assign(paddle.linalg.norm(x), y)
 torch.linalg.vector_norm(x, dtype=torch.float64)
 
 # Paddle 写法
-paddle.linalg.norm(x.astype(paddle.float64))
+paddle.linalg.vector_norm(x.astype(paddle.float64))
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.mean.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.mean.md
@@ -6,7 +6,7 @@
 torch.mean(input, dim, keepdim=False, *, dtype=None, out=None)
 ```
 
-### [paddle.mean]((url_placeholder))
+### [paddle.mean](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/mean_cn.html#mean)
 
 ```python
 paddle.mean(x, axis=None, keepdim=False, name=None)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.norm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.norm.md
@@ -1,4 +1,4 @@
-## [ 参数不一致 ]torch.norm
+## [ torch 参数更多 ]torch.norm
 
 ### [torch.norm](https://pytorch.org/docs/stable/generated/torch.norm.html)
 
@@ -12,14 +12,14 @@ torch.norm(input, p='fro', dim=None, keepdim=False, out=None, dtype=None)
 paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
 ```
 
-其中 PyTorch 和 Paddle 的 `p` 参数用法不一致，PyTorch 还支持更多其他参数，具体如下：
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 ### 参数映射
 
 | PyTorch | PaddlePaddle | 备注 |
 | ------- | ------------ | -- |
 | input   | x            | 输入 Tensor，仅参数名不一致。 |
-| p       | p            | 范数(ord)的种类。PyTorch 支持 "nuc", "fro" 与任意数值（包括 inf 和 -inf），Paddle 暂不支持 "nuc"。 |
+| p       | p            | 范数(ord)的种类。 |
 | dim     | axis         | 使用范数计算的轴，仅参数名不一致。 |
 | keepdim | keepdim      | 是否在输出的 Tensor 中保留和输入一样的维度。 |
 | out     | -            | 表示输出的 Tensor，Paddle 无此参数，需要转写。          |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.norm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.norm.md
@@ -1,0 +1,47 @@
+## [ 参数不一致 ]torch.norm
+
+### [torch.norm](https://pytorch.org/docs/stable/generated/torch.norm.html)
+
+```python
+torch.norm(input, p='fro', dim=None, keepdim=False, out=None, dtype=None)
+```
+
+### [paddle.linalg.norm](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/linalg/norm_cn.html#norm)
+
+```python
+paddle.linalg.norm(x, p='fro', axis=None, keepdim=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 的 `p` 参数用法不一致，PyTorch 还支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | 输入 Tensor，仅参数名不一致。 |
+| p       | p            | 范数(ord)的种类。PyTorch 支持 "nuc", "fro" 与任意数值（包括 inf 和 -inf），Paddle 暂不支持 "nuc"。 |
+| dim     | axis         | 使用范数计算的轴，仅参数名不一致。 |
+| keepdim | keepdim      | 是否在输出的 Tensor 中保留和输入一样的维度。 |
+| out     | -            | 表示输出的 Tensor，Paddle 无此参数，需要转写。          |
+| dtype   | -            | 表示输出 Tensor 的数据类型， Paddle 无此参数，需要转写。                        |
+
+### 转写示例
+
+#### out 参数：指定输出
+``` python
+# PyTorch 写法:
+torch.norm(x, out=y)
+
+# Paddle 写法:
+paddle.assign(paddle.linalg.norm(x) , y)
+```
+
+#### dtype：表示输出 Tensor 的数据类型
+
+```python
+# PyTorch 写法
+torch.norm(x, dtype=torch.float64)
+
+# Paddle 写法
+paddle.linalg.norm(x.astype(paddle.float64))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rrelu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rrelu.md
@@ -1,0 +1,24 @@
+## [ 仅参数名不一致 ]torch.rrelu
+
+### [torch.rrelu](https://pytorch.org/docs/stable/generated/torch.nn.functional.rrelu.html#torch.nn.functional.rrelu)
+
+```python
+torch.rrelu(input, lower=1./8, upper=1./3, training=False)
+```
+
+### [paddle.nn.functional.rrelu](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/functional/rrelu_cn.html)
+
+```python
+paddle.nn.functional.rrelu(x, lower=1./8, upper=1./3, training=True, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch  | PaddlePaddle | 备注                                                                                                            |
+| -------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
+| input    | x            | 输入的 Tensor，仅参数名不一致。                                                                                 |
+| lower    | lower        | 负值斜率的随机值范围下限。                                                                                      |
+| upper    | upper        | 负值斜率的随机值范围上限。                                                                                      |
+| training | training     | 标记是否为训练阶段。                                                                                            |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rrelu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rrelu.md
@@ -1,4 +1,4 @@
-## [ 仅参数名不一致 ]torch.rrelu
+## [ 仅参数默认值不一致 ]torch.rrelu
 
 ### [torch.rrelu](https://pytorch.org/docs/stable/generated/torch.nn.functional.rrelu.html#torch.nn.functional.rrelu)
 
@@ -12,7 +12,7 @@ torch.rrelu(input, lower=1./8, upper=1./3, training=False)
 paddle.nn.functional.rrelu(x, lower=1./8, upper=1./3, training=True, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅参数名不一致，具体如下：
+其中 PyTorch 和 Paddle 功能一致，仅参数名与参数默认值不一致，具体如下：
 
 ### 参数映射
 
@@ -21,4 +21,4 @@ paddle.nn.functional.rrelu(x, lower=1./8, upper=1./3, training=True, name=None)
 | input    | x            | 输入的 Tensor，仅参数名不一致。                                                                                 |
 | lower    | lower        | 负值斜率的随机值范围下限。                                                                                      |
 | upper    | upper        | 负值斜率的随机值范围上限。                                                                                      |
-| training | training     | 标记是否为训练阶段。                                                                                            |
+| training | training     | 标记是否为训练阶段，仅参数默认值不一致。                                                                                            |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.selu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.selu.md
@@ -1,0 +1,21 @@
+## [仅参数名不一致]torch.selu
+
+### [torch.selu](https://pytorch.org/docs/stable/generated/torch.nn.functional.selu.html#torch.nn.functional.selu)
+
+```python
+torch.selu(input)
+```
+
+### [paddle.nn.functional.selu](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/functional/selu_cn.html)
+
+```python
+paddle.nn.functional.selu(x, scale=1.0507009873554804934193349852946, alpha=1.6732632423543772848170429916717, name=None)
+```
+
+两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                                                                            |
+| ------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
+| input   | x            | 输入的 Tensor，仅参数名不一致。                                                                                 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.selu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.selu.md
@@ -1,4 +1,4 @@
-## [仅参数名不一致]torch.selu
+## [仅 paddle 参数更多]torch.selu
 
 ### [torch.selu](https://pytorch.org/docs/stable/generated/torch.nn.functional.selu.html#torch.nn.functional.selu)
 
@@ -12,10 +12,12 @@ torch.selu(input)
 paddle.nn.functional.selu(x, scale=1.0507009873554804934193349852946, alpha=1.6732632423543772848170429916717, name=None)
 ```
 
-两者功能一致且参数用法一致，仅参数名不一致，具体如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 
 ### 参数映射
 
 | PyTorch | PaddlePaddle | 备注                                                                                                            |
 | ------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | input   | x            | 输入的 Tensor，仅参数名不一致。                                                                                 |
+| -       | scale        | selu 激活计算公式中的 scale 值，PyTorch 无此参数，Paddle 保持默认即可。 |
+| -       | alpha        | selu 激活计算公式中的 alpha 值，PyTorch 无此参数，Paddle 保持默认即可。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.set_default_tensor_type.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.set_default_tensor_type.md
@@ -1,0 +1,33 @@
+## [ 参数不一致 ]torch.set_default_tensor_type
+
+### [torch.set\_default\_tensor\_type](https://pytorch.org/docs/stable/generated/torch.set_default_tensor_type.html)
+
+```python
+torch.set_default_tensor_type(t)
+```
+
+### [paddle.set\_default\_dtype](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/set_default_dtype_cn.html#set-default-dtype)
+
+```python
+paddle.set_default_dtype(d)
+```
+
+其中 PyTorch 与 Paddle 的参数类型不一致，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| t       | d            | 指定的默认张量类型，参数类型不一致。PyTorch 支持张量类型或其名称字符串（如 `torch.FloatTensor`，Paddle 支持直接指定 `dtype`（如 `paddle.float32`），需要转写。 |
+
+### 转写示例
+
+#### t 张量类型
+
+```python
+# PyTorch
+torch.set_default_tensor_type(torch.FloatTensor)
+
+# Paddle
+paddle.set_default_dtype(paddle.float32)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.softmax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.softmax.md
@@ -1,0 +1,36 @@
+## [ torch 参数更多 ]torch.softmax
+
+### [torch.softmax](https://pytorch.org/docs/stable/generated/torch.softmax.html)
+
+```python
+torch.softmax(input, dim, *, dtype=None, out=None)
+```
+
+### [paddle.nn.functional.softmax](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/functional/softmax_cn.html#softmax)
+
+```python
+paddle.nn.functional.softmax(x, axis=-1, dtype=None, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            |  表示输入张量，仅参数名不一致。           |
+| dim     | axis         |  表示对输入 Tensor 进行运算的轴，仅参数名不一致。            |
+| dtype   | dtype        |  表示返回张量所需的数据类型。  |
+| out     | -            | 表示输出的 Tensor ，Paddle 无此参数，需要转写。          |
+
+### 转写示例
+
+#### out
+
+```python
+# PyTorch
+torch.softmax(x, dim, out=y)
+
+# Paddle
+paddle.assign(paddle.nn.functional.softmax(x, dim), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.std.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.std.md
@@ -1,0 +1,55 @@
+## [ torch 参数更多 ]torch.std
+
+### [torch.std](https://pytorch.org/docs/stable/generated/torch.std.html)
+
+```python
+torch.std(input, dim=None, unbiased=True, keepdim=False, *, correction=1, out=None)
+```
+
+### [paddle.std](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/std_cn.html#std)
+
+```python
+paddle.std(x, axis=None, unbiased=True, keepdim=False, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch    | PaddlePaddle | 备注 |
+| ---------- | ------------ | -- |
+| input      | x            | 输入张量，仅参数名不一致。   |
+| dim        | axis         | 指定对 x 进行计算的轴，仅参数名不一致。 |
+| unbiased   | unbiased     | 是否使用无偏估计来计算标准差。 |
+| keepdim    | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
+| correction | -            | 样本尺寸与其自由度的差异，Paddle 无此参数，需要转写。   |
+| out        | -            | 表示输出的 Tensor ，Paddle 无此参数，需要转写。          |
+
+### 转写示例
+
+#### correction
+
+```python
+# PyTorch
+torch.std(x, dim, correction=0)
+
+# Paddle
+paddle.std(x, dim, unbiased=False)
+
+
+# PyTorch
+torch.std(x, dim, correction=1)
+
+# Paddle
+paddle.std(x, dim, unbiased=True)
+```
+
+#### out
+
+```python
+# PyTorch
+torch.std(x, out=y)
+
+# Paddle
+paddle.assign(paddle.std(x), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.tan.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.tan.md
@@ -1,0 +1,34 @@
+## [ 仅参数名不一致 ]torch.tan
+
+### [torch.tan](https://pytorch.org/docs/stable/generated/torch.tan.html)
+
+```python
+torch.tan(input, *, out=None)
+```
+
+### [paddle.tan](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/tan_cn.html#tan)
+
+```python
+paddle.tan(x, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | 输入 Tensor，仅参数名不一致。 |
+| out     | -            | 表示输出的 Tensor ，Paddle 无此参数，需要转写。          |
+
+### 转写示例
+
+#### out
+
+```python
+# PyTorch
+torch.tan(x, out=y)
+
+# Paddle
+paddle.assign(paddle.tan(x), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.true_divide.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.true_divide.md
@@ -1,0 +1,35 @@
+## [ torch 参数更多 ]torch.true_divide
+
+### [torch.true\_divide](https://pytorch.org/docs/stable/generated/torch.true_divide.html)
+
+```python
+torch.true_divide(input, other, *, out)
+```
+
+### [paddle.divide](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/divide_cn.html#divide)
+
+```python
+paddle.divide(x, y, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注 |
+| ------- | ------------ | -- |
+| input   | x            | 输入 Tensor，仅参数名不一致。 |
+| other   | y            | 输入 Tensor，仅参数名不一致。 |
+| out     | -            | 表示输出的 Tensor ，Paddle 无此参数，需要转写。          |
+
+### 转写示例
+
+#### out
+
+```python
+# PyTorch
+torch.true_divide(x, y, out=z)
+
+# Paddle
+paddle.assign(paddle.div(x, y), z)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.utils.data.SequentialSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.utils.data.SequentialSampler.md
@@ -1,0 +1,21 @@
+## [ 参数完全一致 ]torch.utils.data.SequentialSampler
+
+### [torch.utils.data.SequentialSampler](https://pytorch.org/docs/stable/generated/torch.utils.data.SequentialSampler.html)
+
+```python
+torch.utils.data.SequentialSampler(data_source)
+```
+
+### [paddle.io.SequenceSampler](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/io/SequenceSampler_cn.html#sequencesampler)
+
+```python
+paddle.io.SequenceSampler(data_source)
+```
+
+功能一致，参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch     | PaddlePaddle | 备注 |
+| ----------- | ------------ | -- |
+| data_source | data_source  | Dataset 或 IterableDataset 的一个子类实例或实现了 `__len__` 的 Python 对象。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.var.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.var.md
@@ -1,0 +1,55 @@
+## [ torch 参数更多 ]torch.var
+
+### [torch.var](https://pytorch.org/docs/stable/generated/torch.var.html)
+
+```python
+torch.var(input, dim=None, unbiased=True, keepdim=False, *, correction=1, out=None)
+```
+
+### [paddle.var](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/var_cn.html#var)
+
+```python
+paddle.var(x, axis=None, unbiased=True, keepdim=False, name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch    | PaddlePaddle | 备注 |
+| ---------- | ------------ | -- |
+| input      | x            | 输入张量，仅参数名不一致。   |
+| dim        | axis         | 指定对 x 进行计算的轴，仅参数名不一致。 |
+| unbiased   | unbiased     | 是否使用无偏估计来计算标准差。 |
+| keepdim    | keepdim      | 是否在输出 Tensor 中保留减小的维度。 |
+| correction | -            | 样本尺寸与其自由度的差异，Paddle 无此参数，需要转写。   |
+| out        | -            | 表示输出的 Tensor ，Paddle 无此参数，需要转写。          |
+
+### 转写示例
+
+#### correction
+
+```python
+# PyTorch
+torch.var(x, dim, correction=0)
+
+# Paddle
+paddle.var(x, dim, unbiased=False)
+
+
+# PyTorch
+torch.var(x, dim, correction=1)
+
+# Paddle
+paddle.var(x, dim, unbiased=True)
+```
+
+#### out
+
+```python
+# PyTorch
+torch.var(x, out=y)
+
+# Paddle
+paddle.assign(paddle.var(x), y)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.RandomSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.RandomSampler.md
@@ -2,13 +2,13 @@
 
 ### [torch.utils.data.RandomSampler](https://pytorch.org/docs/stable/data.html#torch.utils.data.RandomSampler)
 
-```
+```python
 torch.utils.data.RandomSampler(data_source, replacement=False, num_samples=None, generator=None)
 ```
 
 ### [paddle.io.RandomSampler](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/io/RandomSampler_cn.html#paddle.io.RandomSampler)
 
-```
+```python
 paddle.io.RandomSampler(data_source, replacement=False, num_samples=None, generator=None)
 ```
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.RandomSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.RandomSampler.md
@@ -1,0 +1,24 @@
+## [ 参数完全一致 ] torch.utils.data.RandomSampler
+
+### [torch.utils.data.RandomSampler](https://pytorch.org/docs/stable/data.html#torch.utils.data.RandomSampler)
+
+```
+torch.utils.data.RandomSampler(data_source, replacement=False, num_samples=None, generator=None)
+```
+
+### [paddle.io.RandomSampler](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/io/RandomSampler_cn.html#paddle.io.RandomSampler)
+
+```
+paddle.io.RandomSampler(data_source, replacement=False, num_samples=None, generator=None)
+```
+
+两者参数完全一致，具体如下：
+
+### 参数映射
+
+| PyTorch     | PaddlePaddle | 备注                                                                 |
+| ----------- | ------------ | -------------------------------------------------------------------- |
+| data_source | data_source  | Dataset 或 IterableDataset 的一个子类实例或实现了 `__len__` 的 Python 对象。            |
+| replacement | replacement  | 如果为 False 则会采样整个数据集。    |
+| num_samples | num_samples  | 如果 replacement 设置为 True 则按此参数采集对应的样本数。    |
+| generator   | generator    | 指定采样 data_source 的采样器。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.SubsetRandomSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.SubsetRandomSampler.md
@@ -2,13 +2,13 @@
 
 ### [torch.utils.data.SubsetRandomSampler](https://pytorch.org/docs/stable/data.html#torch.utils.data.SubsetRandomSampler)
 
-```
+```python
 torch.utils.data.SubsetRandomSampler(indices, generator=None)
 ```
 
 ### [paddle.io.SubsetRandomSampler](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/io/SubsetRandomSampler_cn.html#paddle.io.SubsetRandomSampler)
 
-```
+```python
 paddle.io.SubsetRandomSampler(indices)
 ```
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.SubsetRandomSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.SubsetRandomSampler.md
@@ -12,7 +12,7 @@ torch.utils.data.SubsetRandomSampler(indices, generator=None)
 paddle.io.SubsetRandomSampler(indices)
 ```
 
-两者参数完全一致，具体如下：
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 ### 参数映射
 


### PR DESCRIPTION
- 修复 4 个此前存在问题的映射文档
- 添加 16 个映射文档

当前存量的缺失映射文档仍有 33 条，列表如下：
```
# fairscale 7 条
fairscale.nn.model_parallel.initialize.get_model_parallel_rank
fairscale.nn.model_parallel.initialize.get_model_parallel_world_size
fairscale.nn.model_parallel.initialize.initialize_model_parallel
fairscale.nn.model_parallel.initialize.model_parallel_is_initialized
fairscale.nn.model_parallel.layers.ColumnParallelLinear
fairscale.nn.model_parallel.layers.ParallelEmbedding
fairscale.nn.model_parallel.layers.RowParallelLinear
# os 1 条
os.environ.get
# setuptools 1 条
setuptools.setup
# torch 24 条
torch.Generator
torch.Size
torch.Tensor
torch.Tensor.allclose
torch.Tensor.erfc
torch.Tensor.index_copy_
torch.Tensor.max
torch.Tensor.min
torch.Tensor.new_empty
torch.Tensor.new_full
torch.Tensor.new_ones
torch.Tensor.new_tensor
torch.Tensor.new_zeros
torch.Tensor.rename
torch.cuda.BoolTensor
torch.cuda.ByteTensor
torch.cuda.FloatTensor
torch.cuda.IntTensor
torch.cuda.LongTensor
torch.device
torch.distributed.rpc.init_rpc
torch.inference_mode
torch.nn.modules.utils._ntuple
torch.nn.modules.utils._pair
```