### PR TITLE
Fix paddle url pattern in api mapping

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
@@ -110,7 +110,7 @@ def get_meta_from_diff_file(filepath):
         r"^### +\[ *(?P<torch_api>torch.[^\]]+)\](?P<url>\([^\)]*\))?$"
     )
     paddle_pattern = re.compile(
-        r"^### +\[ *(?P<paddle_api>paddle.[^\]]+)\](?P<url>\([^\)]*\))?$"
+        r"^### +\[ *(?P<paddle_api>paddle.[^\]]+)\](\((?P<url>[^\)]*)\))?$"
     )
     code_begin_pattern = re.compile(r"^```(python)?$")
     code_pattern = re.compile(r"^(?P<api_name>(paddle|torch)[^\( ]+)(.*?)$")


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/docs/pull/6494#discussion_r1526653613

提取到的 url 不应该包含左右两侧的 `()`

- 当前 develop：https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.html#torch-xx-api
- 本 PR：http://preview-pr-6522.paddle-docs-preview.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.html#torch-xx-api