### PR TITLE
【映射文档】补全缺失的映射文档 part.2

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.allclose.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.allclose.md
@@ -1,0 +1,37 @@
+## [ 参数不一致 ]torch.Tensor.allclose
+
+### [torch.Tensor.allclose](https://pytorch.org/docs/stable/generated/torch.Tensor.allclose.html)
+
+```python
+torch.Tensor.allclose(other, rtol=1e-05, atol=1e-08, equal_nan=False)
+```
+
+### [paddle.Tensor.allclose](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/Tensor_cn.html#allclose-y-rtol-1e-05-atol-1e-08-equal-nan-false-name-none)
+
+```python
+paddle.Tensor.allclose(y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None)
+```
+
+其中 PyTorch 和 Paddle 功能一致，返回类型不一致，具体如下：
+
+### 参数映射
+
+| PyTorch   | PaddlePaddle | 备注 |
+| --------- | ------------ | -- |
+| other     | y            | 输入 Tensor，仅参数名不一致。 |
+| rtol      | rtol         | 相对容差。 |
+| atol      | atol         | 绝对容差。 |
+| equal_nan | equal_nan    | 如果设置为 True，则两个 NaN 数值将被视为相等。 |
+| 返回值    | 返回值        | PyTorch 返回值为标量， Paddle 返回值 0D Tensor。|
+
+### 转写示例
+
+#### 返回值
+
+```python
+# PyTorch 写法
+x.allclose(y)
+
+# Paddle 写法
+x.allclose(y).item()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.erfc.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.erfc.md
@@ -1,0 +1,19 @@
+## [ 组合替代实现 ]torch.Tensor.erfc
+
+### [torch.Tensor.erfc](https://pytorch.org/docs/stable/generated/torch.Tensor.erfc.html)
+
+```python
+torch.Tensor.erfc()
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+y = x.erfc()
+
+# Paddle 写法
+y = 1 - x.erf()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_copy_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.index_copy_.md
@@ -1,0 +1,29 @@
+## [ 组合替代实现 ]torch.Tensor.index_copy_
+
+### [torch.Tensor.index_copy_](https://pytorch.org/docs/stable/generated/torch.Tensor.index_copy_.html)
+
+```python
+torch.Tensor.index_copy_(dim, index, source)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法，dim=0
+y = x.index_copy_(0, index, source)
+
+# Paddle 写法
+y = x.scatter_(index, source)
+
+# PyTorch 写法，dim>0
+y = x.index_copy_(dim, index, source)
+
+# Paddle 写法
+times, temp_shape, temp_index = paddle.prod(paddle.to_tensor(x.shape[:dim])), x.shape, index
+x, new_t = x.reshape([-1] + temp_shape[dim+1:]), source.reshape([-1] + temp_shape[dim+1:])
+for i in range(1, times):
+    temp_index= paddle.concat([temp_index, index+len(index)*i])
+y = x.scatter_(temp_index, new_t).reshape_(temp_shape)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_empty.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_empty.md
@@ -21,7 +21,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
 | *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
-| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| dtype         | dtype        | 表示输出 Tensor 类型，如果没有指定，默认使用当前对象的 dtype，需要转写。    |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
 | layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
@@ -39,6 +39,15 @@ x.new_empty(3, 5)
 paddle.empty([3, 5])
 ```
 
+#### dtype：数据类型
+
+```python
+# PyTorch 写法
+x.new_empty(3, 5)
+
+# Paddle 写法
+paddle.empty([3, 5], dtype=x.dtype)
+```
 
 #### device: Tensor torch 的设备
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_empty.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_empty.md
@@ -20,7 +20,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
-| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
 | dtype         | dtype        | 表示输出 Tensor 类型。                                       |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_empty.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_empty.md
@@ -1,0 +1,73 @@
+## [torch 参数更多]torch.Tensor.new_empty
+
+### [torch.Tensor.new_empty](https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html#torch-tensor-new-empty)
+
+```python
+torch.Tensor.new_empty(*size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, pin_memory=False)
+```
+
+### [paddle.empty](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/empty_cn.html)
+
+```python
+paddle.empty(shape,
+             dtype=None,
+             name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                         |
+| ------------- | ------------ | ------------------------------------------------------------ |
+| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
+| requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
+| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
+
+### 转写示例
+
+#### size：输出形状大小
+
+```python
+# PyTorch 写法
+x.new_empty(3, 5)
+
+# Paddle 写法
+paddle.empty([3, 5])
+```
+
+
+#### device: Tensor torch 的设备
+
+```python
+# PyTorch 写法
+y = x.new_empty((3, 5), device=torch.device('cpu'))
+
+# Paddle 写法
+y = paddle.empty([3, 5])
+y.cpu()
+```
+
+#### requires_grad：是否求梯度
+
+```python
+# PyTorch 写法
+y = x.new_empty((3, 5), requires_grad=True)
+
+# Paddle 写法
+y = paddle.empty([3, 5])
+y.stop_gradient = False
+```
+
+#### pin_memory：是否分配到固定内存上
+
+```python
+# PyTorch 写法
+y = x.new_empty((3, 5), pin_memory=True)
+
+# Paddle 写法
+y = paddle.empty([3, 5]).pin_memory()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
@@ -23,13 +23,23 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | ------------ | ----------- | ----------------------------------------------------------- |
 | size          | shape        | 表示创建 Tensor 的形状，仅参数名不一致。                     |
 | fill_value    | fill_value   | 表示初始化输出 Tensor 的常量数据的值                         |
-| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| dtype         | dtype        | 表示输出 Tensor 类型，如果没有指定，默认使用当前对象的 dtype，需要转写。    |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
 | layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
 | pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
 
 ### 转写示例
+
+#### dtype：数据类型
+
+```python
+# PyTorch 写法
+x.new_full(3, 5, 1.)
+
+# Paddle 写法
+paddle.full([3, 5], 1., dtype=x.dtype)
+```
 
 #### device: Tensor 的设备
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
@@ -1,0 +1,64 @@
+## [torch 参数更多]torch.Tensor.new_full
+
+###  [torch.Tensor.new_full](https://pytorch.org/docs/stable/generated/torch.Tensor.new_full.html#torch-tensor-new-full)
+
+```python
+torch.Tensor.new_full(size, fill_value, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, pin_memory=False)
+```
+
+###  [paddle.full](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/full_cn.html)
+
+```python
+paddle.full(shape,
+            fill_value,
+            dtype=None,
+            name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                         |
+| ------------ | ----------- | ----------------------------------------------------------- |
+| size          | shape        | 表示创建 Tensor 的形状，仅参数名不一致。                     |
+| fill_value    | fill_value   | 表示初始化输出 Tensor 的常量数据的值                         |
+| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
+| requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
+| pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
+
+### 转写示例
+
+#### out：指定输出
+
+```python
+# PyTorch 写法
+torch.full([3, 5], 1., out=y)
+
+# Paddle 写法
+paddle.assign(paddle.full([3, 5], 1.), y)
+```
+
+#### device: Tensor 的设备
+
+```python
+# PyTorch 写法
+y = torch.full([3, 5], 1., device=torch.device('cpu'))
+
+# Paddle 写法
+y = paddle.full([3, 5], 1.)
+y.cpu()
+```
+
+#### requires_grad：是否求梯度
+
+```python
+# PyTorch 写法
+y = torch.full([3, 5], 1., requires_grad=True)
+
+# Paddle 写法
+y = paddle.full([3, 5], 1.)
+y.stop_gradient = False
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
@@ -24,9 +24,9 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | size          | shape        | 表示创建 Tensor 的形状，仅参数名不一致。                     |
 | fill_value    | fill_value   | 表示初始化输出 Tensor 的常量数据的值                         |
 | dtype         | dtype        | 表示输出 Tensor 类型。                                       |
-| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
+| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
 | pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_full.md
@@ -31,21 +31,11 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 ### 转写示例
 
-#### out：指定输出
-
-```python
-# PyTorch 写法
-torch.full([3, 5], 1., out=y)
-
-# Paddle 写法
-paddle.assign(paddle.full([3, 5], 1.), y)
-```
-
 #### device: Tensor 的设备
 
 ```python
 # PyTorch 写法
-y = torch.full([3, 5], 1., device=torch.device('cpu'))
+y = x.new_full([3, 5], 1., device=torch.device('cpu'))
 
 # Paddle 写法
 y = paddle.full([3, 5], 1.)
@@ -56,9 +46,19 @@ y.cpu()
 
 ```python
 # PyTorch 写法
-y = torch.full([3, 5], 1., requires_grad=True)
+y = x.new_full([3, 5], 1., requires_grad=True)
 
 # Paddle 写法
 y = paddle.full([3, 5], 1.)
 y.stop_gradient = False
+```
+
+#### pin_memory：是否分配到固定内存上
+
+```python
+# PyTorch 写法
+y = x.new_full((3, 5), 1., pin_memory=True)
+
+# Paddle 写法
+y = paddle.full([3, 5], 1.).pin_memory()
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_ones.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_ones.md
@@ -1,0 +1,73 @@
+## [torch 参数更多]torch.Tensor.new_ones
+
+### [torch.Tensor.new_ones](https://pytorch.org/docs/stable/generated/torch.Tensor.new_ones.html#torch-tensor-new-ones)
+
+```python
+torch.Tensor.new_ones(*size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, pin_memory=False)
+```
+
+### [paddle.ones](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/ones_cn.html)
+
+```python
+paddle.ones(shape,
+             dtype=None,
+             name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                         |
+| ------------- | ------------ | ------------------------------------------------------------ |
+| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
+| requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
+| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
+
+### 转写示例
+
+#### size：输出形状大小
+
+```python
+# PyTorch 写法
+x.new_ones(3, 5)
+
+# Paddle 写法
+paddle.ones([3, 5])
+```
+
+
+#### device: Tensor torch 的设备
+
+```python
+# PyTorch 写法
+y = x.new_ones((3, 5), device=torch.device('cpu'))
+
+# Paddle 写法
+y = paddle.ones([3, 5])
+y.cpu()
+```
+
+#### requires_grad：是否求梯度
+
+```python
+# PyTorch 写法
+y = x.new_ones((3, 5), requires_grad=True)
+
+# Paddle 写法
+y = paddle.ones([3, 5])
+y.stop_gradient = False
+```
+
+#### pin_memory：是否分配到固定内存上
+
+```python
+# PyTorch 写法
+y = x.new_ones((3, 5), pin_memory=True)
+
+# Paddle 写法
+y = paddle.ones([3, 5]).pin_memory()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_ones.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_ones.md
@@ -20,7 +20,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
-| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
 | dtype         | dtype        | 表示输出 Tensor 类型。                                       |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_ones.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_ones.md
@@ -21,7 +21,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
 | *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
-| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| dtype         | dtype        | 表示输出 Tensor 类型，如果没有指定，默认使用当前对象的 dtype，需要转写。    |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
 | layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
@@ -37,6 +37,16 @@ x.new_ones(3, 5)
 
 # Paddle 写法
 paddle.ones([3, 5])
+```
+
+#### dtype：数据类型
+
+```python
+# PyTorch 写法
+x.new_ones(3, 5)
+
+# Paddle 写法
+paddle.ones([3, 5], dtype=x.dtype)
 ```
 
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_tensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_tensor.md
@@ -1,0 +1,48 @@
+## [torch 参数更多]torch.Tensor.new_tensor
+
+### [torch.Tensor.new_tensor](https://pytorch.org/docs/stable/generated/torch.Tensor.new_tensor.html#torch-tensor-new-tensor)
+
+```python
+torch.Tensor.new_tensor(data, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, pin_memory=False)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html)
+
+```python
+paddle.to_tensor(data, dtype=None, place=None, stop_gradient=True)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                         |
+| ------------- | ------------ | ------------------------------------------------------------ |
+| data          | data         | 数据内容。 |
+| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| device        | place         | 创建 tensor 的设备位置，仅参数名不一致。                       |
+| requires_grad | stop_gradient | 表示是否计算梯度，两者参数功能相反，需要转写。      |
+| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
+
+### 转写示例
+
+#### requires_grad：是否求梯度
+
+```python
+# PyTorch 写法
+y = x.new_tensor(data, requires_grad=True)
+
+# Paddle 写法
+y = paddle.to_tensor(data，stop_gradient=False)
+```
+
+#### pin_memory：是否分配到固定内存上
+
+```python
+# PyTorch 写法
+y = x.new_tensor(data, pin_memory=True)
+
+# Paddle 写法
+y = paddle.to_tensor(data).pin_memory()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_tensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_tensor.md
@@ -19,13 +19,23 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
 | data          | data         | 数据内容。 |
-| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| dtype         | dtype        | 表示输出 Tensor 类型，如果没有指定，默认使用当前对象的 dtype，需要转写。    |
 | device        | place         | 创建 tensor 的设备位置，仅参数名不一致。                       |
 | requires_grad | stop_gradient | 表示是否计算梯度，两者参数功能相反，需要转写。      |
 | layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
 | pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
 
 ### 转写示例
+
+#### dtype：数据类型
+
+```python
+# PyTorch 写法
+y = x.new_tensor(data)
+
+# Paddle 写法
+y = paddle.to_tensor(data, dtype=x.dtype)
+```
 
 #### requires_grad：是否求梯度
 
@@ -34,7 +44,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 y = x.new_tensor(data, requires_grad=True)
 
 # Paddle 写法
-y = paddle.to_tensor(data，stop_gradient=False)
+y = paddle.to_tensor(data, stop_gradient=False)
 ```
 
 #### pin_memory：是否分配到固定内存上

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_zeros.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_zeros.md
@@ -1,0 +1,73 @@
+## [torch 参数更多]torch.Tensor.new_zeros
+
+### [torch.Tensor.new_zeros](https://pytorch.org/docs/stable/generated/torch.Tensor.new_zeros.html#torch-tensor-new-zeros)
+
+```python
+torch.Tensor.new_zeros(*size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, pin_memory=False)
+```
+
+### [paddle.zeros](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/zeros_cn.html)
+
+```python
+paddle.zeros(shape,
+             dtype=None,
+             name=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch       | PaddlePaddle | 备注                                                         |
+| ------------- | ------------ | ------------------------------------------------------------ |
+| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
+| requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
+| layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
+| pin_memory    | -            | 表示是否使用锁页内存， Paddle 无此参数，需要转写。       |
+
+### 转写示例
+
+#### size：输出形状大小
+
+```python
+# PyTorch 写法
+x.new_zeros(3, 5)
+
+# Paddle 写法
+paddle.zeros([3, 5])
+```
+
+
+#### device: Tensor torch 的设备
+
+```python
+# PyTorch 写法
+y = x.new_zeros((3, 5), device=torch.device('cpu'))
+
+# Paddle 写法
+y = paddle.zeros([3, 5])
+y.cpu()
+```
+
+#### requires_grad：是否求梯度
+
+```python
+# PyTorch 写法
+y = x.new_zeros((3, 5), requires_grad=True)
+
+# Paddle 写法
+y = paddle.zeros([3, 5])
+y.stop_gradient = False
+```
+
+#### pin_memory：是否分配到固定内存上
+
+```python
+# PyTorch 写法
+y = x.new_zeros((3, 5), pin_memory=True)
+
+# Paddle 写法
+y = paddle.zeros([3, 5]).pin_memory()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_zeros.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_zeros.md
@@ -21,7 +21,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
 | *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
-| dtype         | dtype        | 表示输出 Tensor 类型。                                       |
+| dtype         | dtype        | 表示输出 Tensor 类型，如果没有指定，默认使用当前对象的 dtype，需要转写。    |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |
 | layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |
@@ -39,6 +39,15 @@ x.new_zeros(3, 5)
 paddle.zeros([3, 5])
 ```
 
+#### dtype: 数据类型
+
+```python
+# PyTorch 写法
+x.new_zeros(3, 5)
+
+# Paddle 写法
+paddle.zeros([3, 5], dtype=x.dtype)
+```
 
 #### device: Tensor torch 的设备
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_zeros.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.new_zeros.md
@@ -20,7 +20,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | ------------- | ------------ | ------------------------------------------------------------ |
-| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
 | dtype         | dtype        | 表示输出 Tensor 类型。                                       |
 | device        | -            | 表示 Tensor 存放设备位置，Paddle 无此参数，需要转写。    |
 | requires_grad | -            | 表示是否计算梯度，Paddle 无此参数，需要转写。            |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.BoolTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.BoolTensor.md
@@ -1,0 +1,24 @@
+## [ 仅 paddle 参数更多 ] torch.cuda.BoolTensor
+
+### [torch.cuda.BoolTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.cuda.BoolTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='bool', place='gpu', stop_gradient=True)
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'bool'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.BoolTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.BoolTensor.md
@@ -20,5 +20,5 @@ Paddle 比 PyTorch 支持更多参数，具体如下：
 | ------- | ------------ | ----------------------------------------------------------- |
 | data    | data         | 要转换的数据。 |
 | -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'bool'。   |
-| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'gpu' 。         |
 | -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ByteTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ByteTensor.md
@@ -1,0 +1,24 @@
+## [ 仅 paddle 参数更多 ] torch.cuda.ByteTensor
+
+### [torch.cuda.ByteTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.cuda.ByteTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='uint8', place='gpu', stop_gradient=True)
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'uint8'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ByteTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ByteTensor.md
@@ -20,5 +20,5 @@ Paddle 比 PyTorch 支持更多参数，具体如下：
 | ------- | ------------ | ----------------------------------------------------------- |
 | data    | data         | 要转换的数据。 |
 | -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'uint8'。   |
-| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'gpu' 。         |
 | -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.FloatTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.FloatTensor.md
@@ -1,0 +1,24 @@
+## [ 仅 paddle 参数更多 ] torch.cuda.FloatTensor
+
+### [torch.cuda.FloatTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.cuda.FloatTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='float32', place='gpu', stop_gradient=True)
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'float32'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.FloatTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.FloatTensor.md
@@ -20,5 +20,5 @@ Paddle 比 PyTorch 支持更多参数，具体如下：
 | ------- | ------------ | ----------------------------------------------------------- |
 | data    | data         | 要转换的数据。 |
 | -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'float32'。   |
-| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'gpu' 。         |
 | -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.IntTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.IntTensor.md
@@ -1,0 +1,24 @@
+## [ 仅 paddle 参数更多 ] torch.cuda.IntTensor
+
+### [torch.cuda.IntTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.cuda.IntTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='int32', place='gpu', stop_gradient=True)
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'int32'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.IntTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.IntTensor.md
@@ -20,5 +20,5 @@ Paddle 比 PyTorch 支持更多参数，具体如下：
 | ------- | ------------ | ----------------------------------------------------------- |
 | data    | data         | 要转换的数据。 |
 | -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'int32'。   |
-| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'gpu' 。         |
 | -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.LongTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.LongTensor.md
@@ -20,5 +20,5 @@ Paddle 比 PyTorch 支持更多参数，具体如下：
 | ------- | ------------ | ----------------------------------------------------------- |
 | data    | data         | 要转换的数据。 |
 | -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'int64'。   |
-| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'gpu' 。         |
 | -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.LongTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.LongTensor.md
@@ -1,0 +1,24 @@
+## [ 仅 paddle 参数更多 ] torch.cuda.LongTensor
+
+### [torch.cuda.LongTensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.cuda.LongTensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype='int64', place='gpu', stop_gradient=True)
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 需设置为 'int64'。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cuda' 。         |
+| -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.rpc.init_rpc.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.rpc.init_rpc.md
@@ -23,4 +23,4 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | rank                | rank                | worker 的 ID，仅参数默认值不同。 |
 | world_size          | world_size          | workers 的数量。 |
 | rpc_backend_options | -                   | 传递给 worker 创建时的配置项，Paddle 无此参数，暂无转写方式。 |
-| -                   | master_endpoint     | master 的 IP 地址。 |
+| -                   | master_endpoint     | master 的 IP 地址，PyTorch 无此参数，Paddle 保持默认即可。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.rpc.init_rpc.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.rpc.init_rpc.md
@@ -1,0 +1,26 @@
+## [ torch 参数更多 ]torch.distributed.rpc.init_rpc
+
+### [torch.distributed.rpc.init\_rpc](https://pytorch.org/docs/stable/rpc.html#torch.distributed.rpc.init_rpc)
+
+```python
+torch.distributed.rpc.init_rpc(name, backend=None, rank=-1, world_size=None, rpc_backend_options=None)
+```
+
+### [paddle.distributed.rpc.init\_rpc](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/distributed/rpc/init_rpc_cn.html#init-rpc)
+
+```python
+paddle.distributed.rpc.init_rpc(name, rank=None, world_size=None, master_endpoint=None)
+```
+
+PyTorch 相比 Paddle 支持更多其他参数，具体如下：
+
+### 参数映射
+
+| PyTorch             | PaddlePaddle        | 备注 |
+| ------------------- | ------------------- | -- |
+| name                | name                | worker 名字。 |
+| backend             | -                   | RPC 后台实现类型，Paddle 无此参数，暂无转写方式。 |
+| rank                | rank                | worker 的 ID，仅参数默认值不同。 |
+| world_size          | world_size          | workers 的数量。 |
+| rpc_backend_options | -                   | 传递给 worker 创建时的配置项，Paddle 无此参数，暂无转写方式。 |
+| -                   | master_endpoint     | master 的 IP 地址。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.modules.utils._ntuple.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.modules.utils._ntuple.md
@@ -1,0 +1,28 @@
+## [ 组合替代实现 ]torch.nn.modules.utils._ntuple
+
+### [torch.nn.modules.utils._ntuple](https://github.com/pytorch/pytorch/blob/1f4d4d3b7836d38d936a21665e6b2ab0b39d7092/torch/nn/modules/utils.py#L8)
+
+```python
+torch.nn.modules.utils._ntuple(n, name="parse")
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+torch.nn.modules.utils._ntuple(2, name="parse")
+
+# Paddle 写法
+def _ntuple(n, name="parse"):
+    def parse(x):
+        if isinstance(x, collections.abc.Iterable):
+            return tuple(x)
+        return tuple(repeat(x, n))
+
+    parse.__name__ = name
+    return parse
+
+_ntuple(2, name="parse")
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.modules.utils._pair.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.modules.utils._pair.md
@@ -1,0 +1,28 @@
+## [ 组合替代实现 ]torch.nn.modules.utils._pair
+
+### [torch.nn.modules.utils._pair](https://github.com/pytorch/pytorch/blob/1f4d4d3b7836d38d936a21665e6b2ab0b39d7092/torch/nn/modules/utils.py#L198)
+
+```python
+torch.nn.modules.utils._pair(x)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+torch.nn.modules.utils._pair(x)
+
+# Paddle 写法
+def _ntuple(n, name="parse"):
+    def parse(x):
+        if isinstance(x, collections.abc.Iterable):
+            return tuple(x)
+        return tuple(repeat(x, n))
+
+    parse.__name__ = name
+    return parse
+
+_ntuple(n=2, name="parse")(x)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Generator.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Generator.md
@@ -1,0 +1,28 @@
+## [组合替代实现]torch.Generator
+
+### [torch.Generator](https://pytorch.org/docs/stable/generated/torch.Generator.html#generator)
+
+```python
+torch.Generator(device='cpu')
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+torch.Generator()
+
+# Paddle 写法
+paddle.framework.core.default_cpu_generator()
+```
+
+```python
+# PyTorch 写法
+torch.Generator(device="cuda")
+
+# Paddle 写法
+device = paddle.device.get_device()
+paddle.framework.core.default_cuda_generator(int(device[-1]))
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Size.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Size.md
@@ -1,0 +1,27 @@
+## [组合替代实现]torch.Size
+
+### [torch.Size](https://pytorch.org/docs/stable/jit_builtin_functions.html#supported-pytorch-functions)
+
+```python
+torch.Size(sizes)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+torch.Size([1])
+
+# Paddle 写法
+tuple([1])
+```
+
+```python
+# PyTorch 写法
+torch.Size([2, 3])
+
+# Paddle 写法
+tuple([2, 3])
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Size.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Size.md
@@ -15,7 +15,7 @@ Paddle 无此 API，需要组合实现。
 torch.Size([1])
 
 # Paddle 写法
-tuple([1])
+(1,)
 ```
 
 ```python
@@ -23,5 +23,5 @@ tuple([1])
 torch.Size([2, 3])
 
 # Paddle 写法
-tuple([2, 3])
+(2, 3)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Tensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Tensor.md
@@ -1,0 +1,24 @@
+## [ 仅 paddle 参数更多 ] torch.Tensor
+
+### [torch.Tensor](https://pytorch.org/docs/stable/tensors.html)
+
+```python
+torch.Tensor(data)
+```
+
+### [paddle.to_tensor](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/to_tensor_cn.html#to-tensor)
+
+```python
+paddle.to_tensor(data, dtype=None, place=None, stop_gradient=True)
+```
+
+Paddle 比 PyTorch 支持更多参数，具体如下：
+
+### 参数映射
+
+| PyTorch | PaddlePaddle | 备注                                                        |
+| ------- | ------------ | ----------------------------------------------------------- |
+| data    | data         | 要转换的数据。 |
+| -       | dtype        | Tensor 的数据类型，PyTorch 无此参数，Paddle 保持默认即可。   |
+| -       | place        | Tensor 的设备，PyTorch 无此参数，Paddle 需设置为 'cpu' 。         |
+| -       | stop_gradient | 是否阻断 Autograd 的梯度传导。PyTorch 无此参数，Paddle 保持默认即可。     |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.device.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.device.md
@@ -1,0 +1,27 @@
+## [ 组合替代实现 ]torch.device
+
+### [torch.device](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device)
+
+```python
+torch.device(type, index)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+torch.device('cuda', 0)
+
+# Paddle 写法
+str('gpu:0')
+
+
+# PyTorch 写法
+torch.device('cpu')
+
+# Paddle 写法
+str('cpu')
+
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.device.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.device.md
@@ -15,13 +15,12 @@ Paddle 无此 API，需要组合实现。
 torch.device('cuda', 0)
 
 # Paddle 写法
-str('gpu:0')
+'gpu:0'
 
 
 # PyTorch 写法
 torch.device('cpu')
 
 # Paddle 写法
-str('cpu')
-
+'cpu'
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.empty.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.empty.md
@@ -28,7 +28,7 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 
 | PyTorch       | PaddlePaddle | 备注                                                         |
 | :------------ | :----------- | :----------------------------------------------------------- |
-| *size         | shape        | 表示输出形状大小， PyTorch 是多个元素， Paddle 是列表或元组，需要转写。 |
+| *size         | shape        | 表示输出形状大小， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写。 |
 | out           | -            | 表示输出的 Tensor，Paddle 无此参数，需要转写。           |
 | dtype         | dtype        | 表示输出 Tensor 类型。                                       |
 | layout        | -            | 表示布局方式，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。 |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
@@ -16,8 +16,6 @@ Paddle 无此 API，需要组合实现。
 
 # Paddle 写法
 # 当 mode 为 False 时，可以直接删去
-# 使用空装饰器以便保持原有结构
-@empty_decorator()
 
 
 # PyTorch 写法

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
@@ -1,0 +1,26 @@
+## [ 组合替代实现 ]torch.inference_mode
+
+### [torch.inference_mode](https://pytorch.org/docs/stable/generated/torch.inference_mode.html#torch.inference_mode)
+
+```python
+torch.inference_mode(mode=True)
+```
+
+Paddle 无此 API，需要组合实现。
+
+### 转写示例
+
+```python
+# PyTorch 写法
+@torch.inference_mode(False)
+
+# Paddle 写法
+@empty_decorator()
+
+
+# PyTorch 写法
+@torch.inference_mode(True)
+
+# Paddle 写法
+@paddle.no_grad()
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
@@ -15,6 +15,8 @@ Paddle 无此 API，需要组合实现。
 @torch.inference_mode(False)
 
 # Paddle 写法
+# 当 mode 为 False 时，可以直接删去方法
+# 使用空装饰器保持原有结构
 @empty_decorator()
 
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.inference_mode.md
@@ -15,8 +15,8 @@ Paddle 无此 API，需要组合实现。
 @torch.inference_mode(False)
 
 # Paddle 写法
-# 当 mode 为 False 时，可以直接删去方法
-# 使用空装饰器保持原有结构
+# 当 mode 为 False 时，可以直接删去
+# 使用空装饰器以便保持原有结构
 @empty_decorator()
 
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.TensorDataset.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.TensorDataset.md
@@ -18,7 +18,7 @@ paddle 参数和 torch 参数用法不一致，具体如下：
 
 | PyTorch  | PaddlePaddle | 备注                                             |
 |----------|--------------|------------------------------------------------|
-| *tensors | tensors      | 输入的 Tensor， PyTorch 是多个元素， Paddle 是列表或元组，需要转写 |
+| *tensors | tensors      | 输入的 Tensor， PyTorch 是可变参数用法， Paddle 是列表或元组，需要转写 |
 
 ### 转写示例
 


### PR DESCRIPTION
- 添加 21 篇映射文档
- 仍然缺失的映射文档有 

    > torch.Tensor.max
torch.Tensor.min
torch.Tensor.rename

    其中 `torch.Tensor.min` 和 `torch.Tensor.max` 逻辑仍在检查，`torch.Tensor.rename` 疑似不支持。