### PR TITLE
fix: shimo MODOC 5 7 8 10

### DIFF
--- a/docs/api/paddle/Model_cn.rst
+++ b/docs/api/paddle/Model_cn.rst
@@ -219,7 +219,7 @@ evaluate(eval_data, batch_size=1, log_freq=10, verbose=2, num_workers=0, callbac
     - **batch_size** (int，可选) - 训练数据或评估数据的批大小，当 ``eval_data`` 为 ``DataLoader`` 的实例时，该参数会被忽略。默认值：1。
     - **log_freq** (int，可选) - 日志打印的频率，多少个 ``step`` 打印一次日志。默认值：10。
     - **verbose** (int，可选) - 可视化的模型，必须为 0，1，2。当设定为 0 时，不打印日志，设定为 1 时，使用进度条的方式打印日志，设定为 2 时，一行一行地打印日志。默认值：2。
-    - **num_workers** (int，可选) - 启动子进程用于读取数据的数量。当 ``eval_data`` 为 ``DataLoader`` 的实例时，该参数会被忽略。默认值：True。
+    - **num_workers** (int，可选) - 启动子进程用于读取数据的数量。当 ``eval_data`` 为 ``DataLoader`` 的实例时，该参数会被忽略。默认值：0。
     - **callbacks** (Callback|list[Callback]|None，可选) -  ``Callback`` 的一个实例或实例列表。该参数不给定时，默认会插入 ``ProgBarLogger`` 和 ``ModelCheckpoint`` 这两个实例。默认值：None。
     - **num_iters** (int，可选) -  训练模型过程中的迭代次数。如果设置为 None，则根据参数 ``epochs`` 来训练模型，否则训练模型 ``num_iters`` 次。默认值：None。
 
@@ -241,7 +241,7 @@ predict(test_data, batch_size=1, num_workers=0, stack_outputs=False, verbose=1, 
 
     - **test_data** (Dataset|DataLoader) - 一个可迭代的数据源，推荐给定一个 ``paddle.io.Dataset`` 或 ``paddle.io.Dataloader`` 的实例。默认值：None。
     - **batch_size** (int，可选) - 训练数据或评估数据的批大小，当 ``test_data`` 为 ``DataLoader`` 的实例时，该参数会被忽略。默认值：1。
-    - **num_workers** (int，可选) - 启动子进程用于读取数据的数量。当 ``test_data`` 为 ``DataLoader`` 的实例时，该参数会被忽略。默认值：True。
+    - **num_workers** (int，可选) - 启动子进程用于读取数据的数量。当 ``test_data`` 为 ``DataLoader`` 的实例时，该参数会被忽略。默认值：0。
     - **stack_outputs** (bool，可选) - 是否将输出进行堆叠。比如对于单个样本输出形状为 ``[X, Y]``，``test_data`` 包含 N 个样本的情况，如果 ``stack_outputs`` 设置为 True，那么输出的形状将会是 ``[N, X, Y]``，如果 ``stack_outputs`` 设置为 False，那么输出的形状将会是 ``[[X, Y], [X, Y], ..., [X, Y]]``。将 ``stack_outputs`` 设置为 False 适用于输出为 LoDTensor 的情况，如果输出不包含 LoDTensor，建议将其设置为 True。默认值：False。
     - **verbose** (int，可选) - 可视化的模型，必须为 0，1，2。当设定为 0 时，不打印日志，设定为 1 时，使用进度条的方式打印日志，设定为 2 时，一行一行地打印日志。默认值：1。
     - **callbacks** (Callback|list[Callback]|None，可选) -  ``Callback`` 的一个实例或实例列表。默认值：None。

--- a/docs/api/paddle/Tensor_cn.rst
+++ b/docs/api/paddle/Tensor_cn.rst
@@ -1708,7 +1708,7 @@ median(axis=None, keepdim=False, name=None)
 
 请参考 :ref:`cn_api_paddle_median`
 
-nanmedian(axis=None, keepdim=True, name=None)
+nanmedian(axis=None, keepdim=False, name=None)
 :::::::::
 
 返回：沿着 ``axis`` 忽略 NAN 元素进行中位数计算的结果

--- a/docs/api/paddle/nn/Conv3DTranspose_cn.rst
+++ b/docs/api/paddle/nn/Conv3DTranspose_cn.rst
@@ -47,7 +47,7 @@ Conv3DTranspose
   - **dilation** (int|tuple，可选) - 空洞大小。可以为单个整数或包含三个整数的元组或列表，分别表示卷积核中的元素沿着深度，高和宽的空洞。如果为单个整数，表示深度，高和宽的空洞都等于该整数。默认值为 1。
   - **weight_attr** (ParamAttr，可选) - 指定权重参数属性的对象。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_paddle_ParamAttr` 。
   - **bias_attr** (ParamAttr|bool，可选) - 指定偏置参数属性的对象。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_paddle_ParamAttr` 。
-  - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是 "NCHW" 和 "NHWC"。N 是批尺寸，C 是通道数，H 是特征高度，W 是特征宽度。默认值为 "NCDHW"。
+  - **data_format** (str，可选) - 指定输入的数据格式，输出的数据格式将与输入保持一致，可以是 "NCDHW" 和 "NDHWC"。N 是批尺寸，C 是通道数，D 为特征深度，H 是特征高度，W 是特征宽度。默认值为 "NCDHW"。
 
 形状
 ::::::::::::

--- a/docs/api/paddle/nn/Overview_cn.rst
+++ b/docs/api/paddle/nn/Overview_cn.rst
@@ -361,7 +361,7 @@ Pooling 相关函数
     " :ref:`paddle.nn.functional.max_pool2d <cn_api_paddle_nn_functional_max_pool2d>` ", "二维最大池化"
     " :ref:`paddle.nn.functional.max_pool3d <cn_api_paddle_nn_functional_max_pool3d>` ", "三维最大池化"
     " :ref:`paddle.nn.functional.max_unpool1d <cn_api_paddle_nn_functional_max_unpool1d>` ", "一维最大反池化层"
-    " :ref:`paddle.nn.functional.max_unpool1d <cn_api_paddle_nn_functional_max_unpool2d>` ", "二维最大反池化层"
+    " :ref:`paddle.nn.functional.max_unpool2d <cn_api_paddle_nn_functional_max_unpool2d>` ", "二维最大反池化层"
     " :ref:`paddle.nn.functional.max_unpool3d <cn_api_paddle_nn_functional_max_unpool3d>` ", "三维最大反池化层"
     " :ref:`paddle.nn.functional.fractional_max_pool2d <cn_api_paddle_nn_functional_fractional_max_pool2d>` ", "二维分数阶最大值池化"
     " :ref:`paddle.nn.functional.fractional_max_pool3d <cn_api_paddle_nn_functional_fractional_max_pool3d>` ", "三维分数阶最大值池化"


### PR DESCRIPTION
来源： [文档修复（文档团）](https://shimo.im/sheets/1d3aMbB67WSLEb3g/MODOC)

本次修改：
-  `keepdim=True` --> `keepdim=False`
- `num_workers ` 默认值： True --> 0
- `data_format ` 的  "NCHW" 和 "NHWC" --> "NCDHW" 和 "NDHWC"
- `paddle.nn.functional.max_unpool1d` --> `paddle.nn.functional.max_unpool2d`