### PR TITLE
fix: shimo MODOC 34 37 39 40 42

### DIFF
--- a/docs/faq/save_cn.md
+++ b/docs/faq/save_cn.md
@@ -13,7 +13,7 @@
 
       该接口用于保存推理模型和参数，2.0 的`paddle.static.save_inference_model`保存结果为`*.pdmodel`和`*.pdiparams`两个文件，其中`*.pdmodel`为推理使用的模型 program 描述，`*.pdiparams`为推理用的参数，这里存储格式与`*.pdparams`不同（注意两者后缀差个`i`），`*.pdiparams`为二进制 Tensor 存储格式，不含变量名。1.8 的`fluid.io.save_inference_model`默认保存结果为`__model__`文件，和以参数名为文件名的多个分散参数文件，格式与 2.0 一致。
 
-  3. 关于更多 2.0 动态图模型保存和加载的介绍可以参考教程：[模型存储与载入](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/02_paddle2.0_develop/08_model_save_load_cn.html)
+  3. 关于更多 2.0 动态图模型保存和加载的介绍可以参考教程：[模型保存与加载](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/model_save_load_cn.html)
 
 ----------
 
@@ -88,10 +88,10 @@ adam.set_state_dict(opti_state_dict)
 + 答复：
 
     1. 在 paddle2.x 可使用``paddle.jit.save``接口以及``paddle.static.save_inference_model``,通过指定``path``来保存成为``path.pdmodel``和``path.pdiparams``,可对应 paddle1.x 中使用``save_inference_model``指定 dirname 和 params_filename 生成``dirname/__model__``和``dirname/params 文件``。paddle2.x 保存模型文件详情可参考:
-    - [paddle.jit.save/load](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/02_paddle2.0_develop/08_model_save_load_cn.html#dongtaitumoxing-canshubaocunzairu-xunliantuili)
-    - [paddle.static.save/load_inference_model](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/02_paddle2.0_develop/08_model_save_load_cn.html#jingtaitumoxing-canshubaocunzairu-tuilibushu)
+    - [paddle.jit.save/load](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/model_save_load_cn.html#sanyongyutuilibushuchangjing)
+    - [paddle.static.save/load_inference_model](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/model_save_load_cn.html#jingtaitumoxingdebaocunyujiazai)
     2. 如果想要在 paddle2.x 中读取 paddle 1.x 中的 model 文件，可参考:
-    - [兼容载入旧格式模型](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.2rc/guides/01_paddle2.0_introduction/load_old_format_model.html#cn-guides-load-old-format-model)
+    - [兼容载入旧格式模型](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/model_convert/load_old_format_model_cn.html)
 
 
 ##### 问题：paddle 如何单独 load 存下来所有模型变量中某一个变量，然后修改变量中的值？

--- a/docs/guides/06_distributed_training/pipeline_parallel_cn.rst
+++ b/docs/guides/06_distributed_training/pipeline_parallel_cn.rst
@@ -57,9 +57,8 @@
   import os
   import paddle
   from paddle.distributed import fleet
-  from paddle.fluid.dygraph.container import Sequential
+  from paddle.nn import Sequential, Layer
   import paddle.nn as nn
-  from paddle.fluid.dygraph.layers import Layer
   from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
   import paddle.nn.functional as F
   import paddle.distributed as dist

--- a/docs/guides/beginner/model_save_load_cn.ipynb
+++ b/docs/guides/beginner/model_save_load_cn.ipynb
@@ -196,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> 注：`paddle.save` 的文件名称是自定义的，以输入参数 `path` （如 \"linear_net.pdparams\"）直接作为存储结果的文件名。为了便于辩识，我们推荐使用统一的标椎文件后缀： \n",
+    "> 注：`paddle.save` 的文件名称是自定义的，以输入参数 `path` （如 \"linear_net.pdparams\"）直接作为存储结果的文件名。为了便于辩识，我们推荐使用统一的标准文件后缀： \n",
     "> 1. 对于 `Layer.state_dict()` （模型参数），推荐使用后缀 `.pdparams` ； \n",
     "> 2. 对于 `Optimizer.state_dict()` （优化器参数），推荐使用后缀 `.pdopt` 。\n",
     "#### 2.2.2 加载动态图模型\n",

--- a/docs/guides/performance_improving/amp_cn.md
+++ b/docs/guides/performance_improving/amp_cn.md
@@ -721,7 +721,7 @@ print("使用 AMP-O2 模式耗时:{:.3f} sec".format(train_time/(epochs*nums_bat
 
     可能原因 1：所用显卡并不支持 AMP 加速，可在训练日志中查看如下 warning 信息：`UserWarning: AMP only support NVIDIA GPU with Compute Capability 7.0 or higher, current GPU is: Tesla K40m, with Compute Capability: 3.5.`；
 
-    可能原因 2：模型是轻计算、重调度的类型，计算负载较大的 matmul、conv 等操作占比较低，可通过 nvidia-smi 实时产看显卡显存利用率（Memory Usage 及 GPU_Util 参数）。
+    可能原因 2：模型是轻计算、重调度的类型，计算负载较大的 matmul、conv 等操作占比较低，可通过 nvidia-smi 实时查看显卡显存利用率（Memory Usage 及 GPU_Util 参数）。
 
     针对上述原因，建议关闭混合精度训练。
 

--- a/docs/install/pip/macos-pip.md
+++ b/docs/install/pip/macos-pip.md
@@ -75,7 +75,6 @@
 
 
 注:
-* macOS 上您需要安装 unrar 以支持 PaddlePaddle，可以使用命令`brew install unrar`
 * 请确认需要安装 PaddlePaddle 的 Python 是您预期的位置，因为您计算机可能有多个 Python。根据您的环境您可能需要将说明中所有命令行中的 python3 替换为具体的 Python 路径。
 * 默认下载最新稳定版的安装包，如需获取 develop 版本 nightly build 的安装包，请参考[这里](https://www.paddlepaddle.org.cn/install/quick/zh/1.8.5-windows-pip)
 * 使用 macOS 中自带 Python 可能会导致安装失败。请使用[python 官网](https://www.python.org/downloads/mac-osx/)提供的 python3.8.x、python3.9.x、python3.10.x、python3.11.x、python3.12.x。


### PR DESCRIPTION
来源： [文档修复（文档团）](https://shimo.im/sheets/1d3aMbB67WSLEb3g/MODOC)

本次修改：

- 修正已废弃的 paddle.fluid 
- macos pip 安装 paddle 无需依赖已下线的 unrar
- ‘产看' --> '查看'
- 修正模型保存常见问题失效链接
- “标椎" --> "标准"