### PR TITLE
add catch for all exception when building pytorch_mapping

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
@@ -548,6 +548,9 @@ def download_file_by_git(
     except subprocess.CalledProcessError as e:
         print(f"Failed to fetch file by git: {e}")
         sys.exit(-1)
+    except Exception as e:
+        print(f"Unexpected Error: {e}")
+        sys.exit(-2)
     finally:
         shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
完善映射文档构建时的错误捕获，当 `download_file_by_git` 失败时直接中止程序并 `exit(-2)`