### PR TITLE
【Type Hints】将 typehints 显示在描述中而不是函数签名中

### DIFF
--- a/ci_scripts/doc-build-config/en/conf.py
+++ b/ci_scripts/doc-build-config/en/conf.py
@@ -104,6 +104,10 @@ language = "en"
 version = ""
 templates_path = ["/templates"]
 
+# Show type hints in the description
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
+
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 # today = ''

--- a/ci_scripts/doc-build-config/zh/conf.py
+++ b/ci_scripts/doc-build-config/zh/conf.py
@@ -139,6 +139,10 @@ version = ""
 
 # html_permalinks_icon='P'
 
+# Show type hints in the description
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [

--- a/docs/api/paddle/audio/save_cn.rst
+++ b/docs/api/paddle/audio/save_cn.rst
@@ -10,12 +10,12 @@ save
 参数
 ::::::::::::
 
-    - **filepath** (str 或者 Path) - 保存音频路径。
+    - **filepath** (str) - 保存音频路径。
     - **src** (Tensor) - 音频数据。
     - **sample_rate** (int) - 采样率。
     - **channels_first** (bool，可选) - 如果是 True，那么 src 的 Tensor 形状是[channel，time]，如果是 False，则是[time，channel]。默认是 True。
     - **encoding** (str|None，可选) - 默认是 None，编码信息。
-    - **bits_per_sample** (int，可选) - 默认是 16，编码位长。
+    - **bits_per_sample** (int|None，可选) - 默认是 16，编码位长。
 返回
 :::::::::
 无

--- a/docs/api/paddle/audio/save_cn.rst
+++ b/docs/api/paddle/audio/save_cn.rst
@@ -11,11 +11,11 @@ save
 ::::::::::::
 
     - **filepath** (str 或者 Path) - 保存音频路径。
-    - **src** (paddle.Tensor) - 音频数据。
+    - **src** (Tensor) - 音频数据。
     - **sample_rate** (int) - 采样率。
-    - **channels_first** (bool，可选) - 如果是 True，那么 src 的 Tensor 形状是[channel，time]，如果是 False，则是[time，channel]。
-    - **encoding** (Optional[str]，可选) - 默认是 None，编码信息。
-    - **bits_per_sample** (Optional[int]，可选) - 默认是 16，编码位长。
+    - **channels_first** (bool，可选) - 如果是 True，那么 src 的 Tensor 形状是[channel，time]，如果是 False，则是[time，channel]。默认是 True。
+    - **encoding** (str|None，可选) - 默认是 None，编码信息。
+    - **bits_per_sample** (int，可选) - 默认是 16，编码位长。
 返回
 :::::::::
 无

--- a/docs/api/paddle/audio/save_cn.rst
+++ b/docs/api/paddle/audio/save_cn.rst
@@ -3,7 +3,7 @@
 save
 -------------------------------
 
-.. py:function:: paddle.audio.save(filepath: str, src: paddle.Tensor, sample_rate: int, channels_first: bool = True, encoding: Optional[str] = None, bits_per_sample: Optional[int] = 16)
+.. py:function:: paddle.audio.save(filepath, src, sample_rate, channels_first=True, encoding=None, bits_per_sample=16)
 
 保存音频数据。
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

将 typehints 显示在描述中，而不是函数签名中 ～

建议：

- 在中文文档中不要写 type 。目前 torch、tf、keras 等，均没有在文档中的函数签名中写 type。
- 在 api 的 docstring 中需要写类型

以本 PR 中的 api `paddle.audio.save` 为例，原 api 代码中：

- 增加 `from __future__ import annotations`
- Optional 改为 `|`
- docstring 中增加数据类型


``` python
def save(
    filepath: str,
    src: paddle.Tensor,
    sample_rate: int,
    channels_first: bool = True,
    encoding: Optional[str] = None,
    bits_per_sample: Optional[int] = 16, # 注：此处不应该使用 Optional
):
    """
    Save audio tensor to file.

    Args:
        filepath: ...
        src: ...
        sample_rate: ...
        channels_first: ...
        encoding: ...
        bits_per_sample: ...

    Returns:
        None
...
    """
```

需要改为：

``` python
from __future__ import annotations
...
def save(
    filepath: str,
    src: paddle.Tensor,
    sample_rate: int,
    channels_first: bool = True,
    encoding: str|None = None,
    bits_per_sample: int = 16,
) -> None:
    """
    Save audio tensor to file.

    Args:
        filepath (str): ...
        src (Tensor): ...
        sample_rate (int): ...
        channels_first (bool, optional): ...
        encoding (str|None, optional): ...
        bits_per_sample (int, optional): ...

    Returns:
        None
...
    """
```

此 api 的中文文档中，需要修改：

- 签名中不写 type

``` rst
.. py:function:: paddle.audio.save(filepath: str, src: paddle.Tensor, sample_rate: int, channels_first: bool = True, encoding: Optional[str] = None, bits_per_sample: Optional[int] = 16)
```

需要改为

``` rst
.. py:function:: paddle.audio.save(filepath, src, sample_rate, channels_first=True, encoding=None, bits_per_sample=16)
```

修改后，原中文文档的页面：

![image](https://github.com/PaddlePaddle/docs/assets/26616326/6756ccc4-beb7-4ee3-8c70-59aba0cc1060)

变更为：

![image](https://github.com/PaddlePaddle/docs/assets/26616326/96cf0017-3fe5-4a4a-9f28-b1f5eae5bcba)

原英文文档的页面：

![image](https://github.com/PaddlePaddle/docs/assets/26616326/1fa1715c-76e4-4958-b8cc-0e688c2a01e8)

变更为 ：

![image](https://github.com/PaddlePaddle/docs/assets/26616326/899b505d-f99b-4ac0-a835-e13089765649)

注意：此时还未修改此 api 的 docstring，英文文档中，描述中的参数类型，是 sphinx 自动加进去的 ～ 

但是，如果修改了 api 的 docstring，添加了数据类型，sphinx 理论上会 merge 函数签名中的类型与描述中的参数类型 ～ 因此，此处具体效果还需要后续观察 ～

@sunzhongkai588  @SigureMo 
