### PR TITLE
[Typing] not render type ignore

### DIFF
--- a/ci_scripts/doc-build-config/en/conf.py
+++ b/ci_scripts/doc-build-config/en/conf.py
@@ -356,14 +356,20 @@ def handle_api_aliases():
             exec(f'{oname}.__name__ = "{tn}"')
 
 
-def remove_doctest_directives(app, what, name, obj, options, lines):
+def remove_directives(app, what, name, obj, options, lines):
     """
-    Remove `doctest` directives from docstring
+    Remove `doctest` and `mypy` `type: ignore: xxx` directives from docstring
     """
     # Modify the lines inplace
     # remove doctest directive
     pattern_doctest = re.compile(r"\s*>>>\s*#\s*x?doctest:\s*.*")
-    lines[:] = [line for line in lines if not pattern_doctest.match(line)]
+    # remove `# type: ignore ...`
+    pattern_typing_ignore = re.compile(r"# type:[^#]*")
+    lines[:] = [
+        pattern_typing_ignore.sub("", line)
+        for line in lines
+        if not pattern_doctest.match(line)
+    ]
 
     # remove blank ps(`>>>`)
     lines[:] = [line for line in lines if not line.strip() == ">>>"]
@@ -398,4 +404,4 @@ def setup(app):
     app.add_transform(AutoStructify)
 
     # remove doctest directives and blank ps
-    app.connect("autodoc-process-docstring", remove_doctest_directives)
+    app.connect("autodoc-process-docstring", remove_directives)

--- a/docs/api/copy_codes_from_en_doc.py
+++ b/docs/api/copy_codes_from_en_doc.py
@@ -244,6 +244,7 @@ def instert_codes_into_cn_rst_if_need(cnrstfilename):
     rst_lines, copy_from_info = read_rst_lines_and_copy_info(cnrstfilename)
     update_needed = False
     pattern_doctest = re.compile(r"\s*>>>\s*#\s*doctest:\s*.*")
+    pattern_typing_ignore = re.compile(r"# type:[^#]*")
 
     if copy_from_info:
         logger.info(
@@ -266,6 +267,11 @@ def instert_codes_into_cn_rst_if_need(cnrstfilename):
         cb_new.append("")
         indent += 4
         for line in cb_need["codes"].splitlines():
+            # remove `# type: ignore ...`
+            line = pattern_typing_ignore.sub("", line)
+            if line.strip() == ">>>":
+                continue
+
             if not pattern_doctest.match(line):
                 cb_new.append(" " * indent + line)
 


### PR DESCRIPTION
不在文档中渲染 `# type: ignore` 

可以等有需求的 PR 合入后看看效果，如 https://github.com/PaddlePaddle/Paddle/pull/65082

@SigureMo @sunzhongkai588 