### PR TITLE
[docs] 修复 api 文档中函数声明的名称【Part1】

### DIFF
--- a/docs/api/paddle/DataParallel_cn.rst
+++ b/docs/api/paddle/DataParallel_cn.rst
@@ -46,17 +46,24 @@ COPY-FROM: paddle.DataParallel:dp-example
 ::::::::::::
 COPY-FROM: paddle.DataParallel:dp-pylayer-example
 
-.. py:function:: no_sync()
 
-用于暂停梯度同步的上下文管理器。在 no_sync()中参数梯度只会在模型上累加；直到 with 之外的第一个 forward-backward，梯度才会被同步。
+
 
 代码示例
 ::::::::::::
 
-COPY-FROM: paddle.DataParallel.no_sync
+
 
 方法
 ::::::::::::
+no_sync()
+'''''''''
+用于暂停梯度同步的上下文管理器。在 no_sync()中参数梯度只会在模型上累加；直到 with 之外的第一个 forward-backward，梯度才会被同步。
+
+**代码示例**
+
+COPY-FROM: paddle.DataParallel.no_sync
+
 state_dict(destination=None, include_sublayers=True)
 '''''''''
 

--- a/docs/api/paddle/DataParallel_cn.rst
+++ b/docs/api/paddle/DataParallel_cn.rst
@@ -47,13 +47,6 @@ COPY-FROM: paddle.DataParallel:dp-example
 COPY-FROM: paddle.DataParallel:dp-pylayer-example
 
 
-
-
-代码示例
-::::::::::::
-
-
-
 方法
 ::::::::::::
 no_sync()

--- a/docs/api/paddle/distributed/destroy_process_group_cn.rst
+++ b/docs/api/paddle/distributed/destroy_process_group_cn.rst
@@ -4,7 +4,7 @@ destroy_process_group
 -------------------------------
 
 
-.. py:function:: destroy_process_group(group=None)
+.. py:function:: paddle.distributed.destroy_process_group(group=None)
 
 销毁一个指定的通信组。
 

--- a/docs/api/paddle/distributed/get_group_cn.rst
+++ b/docs/api/paddle/distributed/get_group_cn.rst
@@ -3,7 +3,7 @@
 get_group
 -------------------------------
 
-.. py:function:: get_group(id=0)
+.. py:function:: paddle.distributed.get_group(id=0)
 
 通过通信组 id 获取通信组实例
 

--- a/docs/api/paddle/distributed/get_rank_cn.rst
+++ b/docs/api/paddle/distributed/get_rank_cn.rst
@@ -3,7 +3,7 @@
 get_rank
 ----------
 
-..  py:function:: paddle.distributed.get_rank(group=None)
+.. py:function:: paddle.distributed.get_rank(group=None)
 
 返回当前进程在给定通信组下的 rank，rank 是在 [0, world_size) 范围内的连续整数。如果没有指定通信组，则默认使用全局通信组。
 

--- a/docs/api/paddle/distributed/new_group_cn.rst
+++ b/docs/api/paddle/distributed/new_group_cn.rst
@@ -4,7 +4,7 @@ new_group
 -------------------------------
 
 
-.. py:function:: new_group(ranks=None, backend=None)
+.. py:function:: paddle.distributed.new_group(ranks=None, backend=None)
 
 创建分布式通信组。
 

--- a/docs/api/paddle/distributed/to_static_cn.rst
+++ b/docs/api/paddle/distributed/to_static_cn.rst
@@ -3,7 +3,7 @@
 to_static
 -------------------------------
 
-.. py:function:: to_static(layer, loader, loss=None, optimizer=None, strategy=None)
+.. py:function:: paddle.distributed.to_static(layer, loader, loss=None, optimizer=None, strategy=None)
 
 将带有分布式切分信息的动态图 ``layer`` 转换为静态图分布式模型, 可在静态图模式下进行分布式训练；同时将动态图下所使用的数据迭代器 ``loader`` 转换为静态图分布式训练所使用的数据迭代器。
 

--- a/docs/api/paddle/distributed/unshard_dtensor_cn.rst
+++ b/docs/api/paddle/distributed/unshard_dtensor_cn.rst
@@ -3,7 +3,7 @@
 unshard_dtensor
 -------------------------------
 
-.. py:function:: unshard_dtensor(dist_tensor)
+.. py:function:: paddle.distributed.unshard_dtensor(dist_tensor)
 
 将带有分布式信息的分布式 Tensor 转换为普通 Tensor。
 

--- a/docs/api/paddle/distributed/wait_cn.rst
+++ b/docs/api/paddle/distributed/wait_cn.rst
@@ -4,7 +4,7 @@ wait
 -------------------------------
 
 
-.. py:function:: wait(tensor, group=None, use_calc_stream=True)
+.. py:function:: paddle.distributed.wait(tensor, group=None, use_calc_stream=True)
 
 
 同步通信组

--- a/docs/api/paddle/incubate/LookAhead_cn.rst
+++ b/docs/api/paddle/incubate/LookAhead_cn.rst
@@ -3,7 +3,7 @@
 LookAhead
 -------------------------------
 
-.. py:function:: class paddle.incubate.LookAhead(inner_optimizer, alpha=0.5, k=5, name=None)
+.. py:class:: paddle.incubate.LookAhead(inner_optimizer, alpha=0.5, k=5, name=None)
 此 API 为论文 `Lookahead Optimizer: k steps forward, 1 step back <https://arxiv.org/abs/1907.08610>`_ 中 Lookahead 优化器的实现。
 Lookahead 保留两组参数：fast_params 和 slow_params。每次训练迭代中 inner_optimizer 更新 fast_params。
 Lookahead 每 k 次训练迭代更新 slow_params 和 fast_params，如下所示：

--- a/docs/api/paddle/incubate/xpu/resnet_block/ResNetBasicBlock_cn.rst
+++ b/docs/api/paddle/incubate/xpu/resnet_block/ResNetBasicBlock_cn.rst
@@ -2,7 +2,7 @@
 
 ResNetBasicBlock
 -------------------------------
-.. py:class:: paddle.incubate.xpu.ResNetBasicBlock(num_channels1, num_filter1, filter1_size, num_channels2, num_filter2, filter2_size, num_channels3, num_filter3, filter3_size, stride1=1, stride2=1, stride3=1, act='relu', momentum=0.9, eps=1e-5, data_format='NCHW', has_shortcut=False, use_global_stats=False, is_test=False, filter1_attr=None, scale1_attr=None, bias1_attr=None, moving_mean1_name=None, moving_var1_name=None, filter2_attr=None, scale2_attr=None, bias2_attr=None, moving_mean2_name=None, moving_var2_name=None, ilter3_attr=None, scale3_attr=None, bias3_attr=None, moving_mean3_name=None, moving_var3_name=None, padding1=0, padding2=0, padding3=0, dilation1=1, dilation2=1, dilation3=1, trainable_statistics=False, find_conv_max=True)
+.. py:class:: paddle.incubate.xpu.resnet_block.ResNetBasicBlock(num_channels1, num_filter1, filter1_size, num_channels2, num_filter2, filter2_size, num_channels3, num_filter3, filter3_size, stride1=1, stride2=1, stride3=1, act='relu', momentum=0.9, eps=1e-5, data_format='NCHW', has_shortcut=False, use_global_stats=False, is_test=False, filter1_attr=None, scale1_attr=None, bias1_attr=None, moving_mean1_name=None, moving_var1_name=None, filter2_attr=None, scale2_attr=None, bias2_attr=None, moving_mean2_name=None, moving_var2_name=None, ilter3_attr=None, scale3_attr=None, bias3_attr=None, moving_mean3_name=None, moving_var3_name=None, padding1=0, padding2=0, padding3=0, dilation1=1, dilation2=1, dilation3=1, trainable_statistics=False, find_conv_max=True)
 
 该接口用于构建 ``ResNetBasicBlock`` 类的一个可调用对象，实现一次性计算多个 ``Conv2D``、 ``BatchNorm`` 和 ``ReLU`` 的功能，排列顺序参见源码链接。
 


### PR DESCRIPTION
- 修改中文 api 文档中的函数声明部分
    - 函数名（与文档所在位置相对应，但是不能保证一定是公开函数名）
    - 正确的 `.. py:class::` 等标识
- 类方法不使用 `.. py:function::` 进行表示，放在 **方法** 下
@sunzhongkai588 @SigureMo 
