### PR TITLE
Rename PyTorch-Paddle mapping type

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.BoolTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.BoolTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.BoolTensor
+## [ paddle 参数更多 ] torch.BoolTensor
 
 ### [torch.BoolTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.ByteTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.ByteTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.ByteTensor
+## [ paddle 参数更多 ] torch.ByteTensor
 
 ### [torch.ByteTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.DoubleTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.DoubleTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.DoubleTensor
+## [ paddle 参数更多 ] torch.DoubleTensor
 
 ### [torch.DoubleTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.FloatTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.FloatTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.FloatTensor
+## [ paddle 参数更多 ] torch.FloatTensor
 
 ### [torch.FloatTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.HalfTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.HalfTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.HalfTensor
+## [ paddle 参数更多 ] torch.HalfTensor
 
 ### [torch.HalfTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.IntTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.IntTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.IntTensor
+## [ paddle 参数更多 ] torch.IntTensor
 
 ### [torch.IntTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.LongTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.LongTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.LongTensor
+## [ paddle 参数更多 ] torch.LongTensor
 
 ### [torch.LongTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.ShortTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.ShortTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.ShortTensor
+## [ paddle 参数更多 ] torch.ShortTensor
 
 ### [torch.ShortTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argwhere.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.argwhere.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.argwhere
+## [ paddle 参数更多 ]torch.Tensor.argwhere
 ### [torch.Tensor.argwhere](https://pytorch.org/docs/stable/generated/torch.Tensor.argwhere.html#torch.Tensor.argwhere)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.corrcoef.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.corrcoef.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.Tensor.corrcoef
+## [ paddle 参数更多 ]torch.Tensor.corrcoef
 
 ### [torch.Tensor.corrcoef](https://pytorch.org/docs/stable/generated/torch.Tensor.corrcoef.html#torch.Tensor.corrcoef)
 
@@ -12,7 +12,7 @@ torch.Tensor.corrcoef()
 paddle.Tensor.corrcoef(rowvar=True)
 ```
 
-仅 paddle 参数更多，具体如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.count_nonzero.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.count_nonzero.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.Tensor.count_nonzero
+## [ paddle 参数更多 ]torch.Tensor.count_nonzero
 ### [torch.Tensor.count_nonzero](https://pytorch.org/docs/stable/generated/torch.Tensor.count_nonzero.html#torch.Tensor.count_nonzero)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cov.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cov.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.cov
+## [ paddle 参数更多 ]torch.Tensor.cov
 ### [torch.Tensor.cov](https://pytorch.org/docs/stable/generated/torch.Tensor.cov.html#torch.Tensor.cov)
 
 ```python
@@ -15,7 +15,7 @@ paddle.Tensor.cov(rowvar=True,
                   name=None)
 ```
 
-仅 paddle 参数更多，具体如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cummax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cummax.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.cummax
+## [ paddle 参数更多 ]torch.Tensor.cummax
 
 ### [torch.Tensor.cummax](https://pytorch.org/docs/stable/generated/torch.Tensor.cummax.html?highlight=cummax#torch.Tensor.cummax)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cummin.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.cummin.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.cummin
+## [ paddle 参数更多 ]torch.Tensor.cummin
 
 ### [torch.Tensor.cummin](https://pytorch.org/docs/stable/generated/torch.Tensor.cummin.html?highlight=cummin#torch.Tensor.cummin)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.fill_diagonal_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.fill_diagonal_.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.fill_diagonal_
+## [ paddle 参数更多 ]torch.Tensor.fill_diagonal_
 
 ### [torch.Tensor.fill_diagonal_](https://pytorch.org/docs/stable/generated/torch.Tensor.fill_diagonal_.html?highlight=fill_diagonal_#torch.Tensor.fill_diagonal_)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.fliplr.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.fliplr.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.fliplr
+## [ paddle 参数更多 ]torch.Tensor.fliplr
 
 ### [torch.Tensor.fliplr](https://pytorch.org/docs/stable/generated/torch.Tensor.fliplr.html?highlight=fliplr#torch.Tensor.fliplr)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.flipud.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.flipud.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.flipud
+## [ paddle 参数更多 ]torch.Tensor.flipud
 
 ### [torch.Tensor.flipud](https://pytorch.org/docs/stable/generated/torch.Tensor.flipud.html?highlight=flipud#torch.Tensor.flipud)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.item.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.item.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.Tensor.item
+## [ paddle 参数更多 ] torch.Tensor.item
 
 ### [torch.Tensor.item](https://pytorch.org/docs/stable/generated/torch.Tensor.item.html#torch-tensor-item)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logcumsumexp.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logcumsumexp.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.logcumsumexp
+## [ paddle 参数更多 ]torch.Tensor.logcumsumexp
 
 ### [torch.Tensor.logcumsumexp](https://pytorch.org/docs/stable/generated/torch.Tensor.logcumsumexp.html?highlight=logcumsumexp#torch.Tensor.logcumsumexp)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_and.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_and.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.Tensor.logical_and
+## [ paddle 参数更多 ] torch.Tensor.logical_and
 
 ### [torch.Tensor.logical_and](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_and.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_not.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_not.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.Tensor.logical_not
+## [ paddle 参数更多 ] torch.Tensor.logical_not
 
 ### [torch.Tensor.logical_not](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_not.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_or.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.logical_or.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.Tensor.logical_or
+## [ paddle 参数更多 ] torch.Tensor.logical_or
 
 ### [torch.Tensor.logical_or](https://pytorch.org/docs/stable/generated/torch.Tensor.logical_or.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.matmul.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.matmul
+## [ paddle 参数更多 ]torch.Tensor.matmul
 
 ### [torch.Tensor.matmul](https://pytorch.org/docs/stable/generated/torch.Tensor.matmul.html)
 
@@ -12,7 +12,7 @@ torch.Tensor.matmul(other)
 paddle.Tensor.matmul(y, transpose_x=False, transpose_y=False, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅 Paddle 参数更多，具体如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.median.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.median.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.median
+## [ paddle 参数更多 ]torch.Tensor.median
 
 ### [torch.Tensor.median](https://pytorch.org/docs/stable/generated/torch.Tensor.median.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nanmedian.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.nanmedian.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.nanmedian
+## [ paddle 参数更多 ]torch.Tensor.nanmedian
 
 ### [torch.Tensor.nanmedian](https://pytorch.org/docs/stable/generated/torch.Tensor.nanmedian.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pinverse.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.pinverse.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.pinverse
+## [ paddle 参数更多 ]torch.Tensor.pinverse
 ### [torch.Tensor.pinverse](https://pytorch.org/docs/stable/generated/torch.Tensor.pinverse.html#torch.Tensor.pinverse)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ravel.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.ravel.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.ravel
+## [ paddle 参数更多 ]torch.Tensor.ravel
 ### [torch.Tensor.ravel](https://pytorch.org/docs/stable/generated/torch.Tensor.ravel.html#torch.Tensor.ravel)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter.md
@@ -1,4 +1,4 @@
-## [ paddle 参数更多 ]torch.Tensor.scatter
+## [ 输入参数类型不一致 ]torch.Tensor.scatter
 
 ### [torch.Tensor.scatter](https://pytorch.org/docs/stable/generated/torch.Tensor.scatter.html#torch.Tensor.scatter)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.Tensor.scatter
+## [ paddle 参数更多 ]torch.Tensor.scatter
 
 ### [torch.Tensor.scatter](https://pytorch.org/docs/stable/generated/torch.Tensor.scatter.html#torch.Tensor.scatter)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter_add.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter_add.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.scatter_add
+## [ paddle 参数更多 ]torch.Tensor.scatter_add
 
 ### [torch.Tensor.scatter_add](https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_add.html#torch.Tensor.scatter_add)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter_add_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.scatter_add_.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.scatter_add_
+## [ paddle 参数更多 ]torch.Tensor.scatter_add_
 
 ### [torch.Tensor.scatter_add_](https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_add_.html#torch.Tensor.scatter_add_)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.softmax.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.softmax.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.Tensor.softmax
+## [ paddle 参数更多 ]torch.Tensor.softmax
 ### [torch.Tensor.softmax](https://pytorch.org/docs/stable/generated/torch.Tensor.softmax.html?highlight=softmax#torch.Tensor.softmax)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.take.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.Tensor.take
+## [ paddle 参数更多 ] torch.Tensor.take
 
 ### [torch.Tensor.take](https://pytorch.org/docs/stable/generated/torch.Tensor.take.html#torch.Tensor.take)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.trace.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.trace.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.Tensor.trace
+## [ paddle 参数更多 ]torch.Tensor.trace
 
 ### [torch.Tensor.trace](https://pytorch.org/docs/stable/generated/torch.Tensor.trace.html#torch-tensor-trace)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.uniform_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.uniform_.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.Tensor.uniform_
+## [ paddle 参数更多 ]torch.Tensor.uniform_
 
 ### [torch.Tensor.uniform_](https://pytorch.org/docs/stable/generated/torch.Tensor.uniform_.html#torch-tensor-uniform)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.unique_consecutive.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/Tensor/torch.Tensor.unique_consecutive.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.Tensor.unique_consecutive
+## [ paddle 参数更多 ]torch.Tensor.unique_consecutive
 
 ### [torch.Tensor.unique_consecutive](https://pytorch.org/docs/stable/generated/torch.Tensor.unique_consecutive.html#torch.Tensor.unique_consecutive)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.BoolTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.BoolTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.BoolTensor
+## [ paddle 参数更多 ] torch.cuda.BoolTensor
 
 ### [torch.cuda.BoolTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ByteTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ByteTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.ByteTensor
+## [ paddle 参数更多 ] torch.cuda.ByteTensor
 
 ### [torch.cuda.ByteTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.DoubleTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.DoubleTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.DoubleTensor
+## [ paddle 参数更多 ] torch.cuda.DoubleTensor
 
 ### [torch.cuda.DoubleTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.FloatTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.FloatTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.FloatTensor
+## [ paddle 参数更多 ] torch.cuda.FloatTensor
 
 ### [torch.cuda.FloatTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.HalfTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.HalfTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.HalfTensor
+## [ paddle 参数更多 ] torch.cuda.HalfTensor
 
 ### [torch.cuda.HalfTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.IntTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.IntTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.IntTensor
+## [ paddle 参数更多 ] torch.cuda.IntTensor
 
 ### [torch.cuda.IntTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.LongTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.LongTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.LongTensor
+## [ paddle 参数更多 ] torch.cuda.LongTensor
 
 ### [torch.cuda.LongTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ShortTensor.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.ShortTensor.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.cuda.ShortTensor
+## [ paddle 参数更多 ] torch.cuda.ShortTensor
 
 ### [torch.cuda.ShortTensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.amp.GradScaler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.amp.GradScaler.md
@@ -1,4 +1,4 @@
-## [仅参数默认值不一致]torch.cuda.amp.GradScaler
+## [ 参数默认值不一致 ]torch.cuda.amp.GradScaler
 
 ### [torch.cuda.amp.GradScaler](https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.GradScaler)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.amp.autocast.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/cuda/torch.cuda.amp.autocast.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.cuda.amp.autocast
+## [ paddle 参数更多 ]torch.cuda.amp.autocast
 
 ### [torch.cuda.amp.autocast](https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.autocast)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.conv_transpose1d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.conv_transpose1d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多 ]torch.nn.functional.conv_transpose1d
+## [ paddle 参数更多 ]torch.nn.functional.conv_transpose1d
 
 ### [torch.nn.functional.conv_transpose1d](https://pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose1d.html?highlight=conv_trans#torch.nn.functional.conv_transpose1d)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.conv_transpose2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.conv_transpose2d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多 ]torch.nn.functional.conv_transpose2d
+## [ paddle 参数更多 ]torch.nn.functional.conv_transpose2d
 
 ### [torch.nn.functional.conv_transpose2d](https://pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose2d.html?highlight=conv_#torch.nn.functional.conv_transpose2d)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.conv_transpose3d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.conv_transpose3d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多 ]torch.nn.functional.conv_transpose3d
+## [ paddle 参数更多 ]torch.nn.functional.conv_transpose3d
 
 ### [torch.nn.functional.conv_transpose3d](https://pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose3d.html?highlight=conv_#torch.nn.functional.conv_transpose3d)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.fractional_max_pool2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.fractional_max_pool2d.md
@@ -20,7 +20,7 @@ PyTorch 参数更多，具体如下：
 | ------------- | ------------ | ------------------------------------------------------ |
 | input         | x            | 表示输入的 Tensor 。仅参数名不一致。                        |
 | kernel_size   | kernel_size  | 表示核大小。参数完全一致。                                 |
-| output_size   | output_size  | 表示目标输出尺寸，PyTorch 为可选参数，Paddle 为必选参数，仅参数默认值不一致。PyTorch 的 output_size 与 output_ratio 输入二选一，如不输入 output_size，则必须输入 output_ratio，此时需要转写。转写方式与下文 output_ratio 一致。 |
+| output_size   | output_size  | 表示目标输出尺寸，PyTorch 为可选参数，Paddle 为必选参数，与 PyTorch 默认值不同。PyTorch 的 output_size 与 output_ratio 输入二选一，如不输入 output_size，则必须输入 output_ratio，此时需要转写。转写方式与下文 output_ratio 一致。 |
 | output_ratio  | -            | 表示目标输出比例。Paddle 无此参数，需要转写。                |
 | return_indices | return_mask | 表示是否返回最大值索引。仅参数名不一致。                      |
 | _random_samples | random_u   | 表示随机数。PyTorch 以列表形式的 Tensor 方式传入，Paddle 以 float 的方式传入，如果 PyTorch 的多个随机数相同，需要转写，如果 PyTorch 的多个随机数不同，暂无转写方式。  |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.group_norm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.group_norm.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.group_norm
+## [ paddle 参数更多 ]torch.nn.functional.group_norm
 
 ### [torch.nn.functional.group_norm](https://pytorch.org/docs/stable/generated/torch.nn.functional.group_norm.html#torch.nn.functional.group_norm)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.hardsigmoid.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.hardsigmoid.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.hardsigmoid
+## [ paddle 参数更多 ]torch.nn.functional.hardsigmoid
 
 ### [torch.nn.functional.hardsigmoid](https://pytorch.org/docs/stable/generated/torch.nn.functional.hardsigmoid.html)
 
@@ -12,7 +12,7 @@ torch.nn.functional.hardsigmoid(input, inplace=False)
 paddle.nn.functional.hardsigmoid(x, slope=0.1666667, offset=0.5, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅 paddle 参数更多，具体如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.pad.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.pad.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.pad
+## [ paddle 参数更多 ]torch.nn.functional.pad
 
 ### [torch.nn.functional.pad](https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.pixel_shuffle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.pixel_shuffle.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.pixel_shuffle
+## [ paddle 参数更多 ]torch.nn.functional.pixel_shuffle
 
 ### [torch.nn.functional.pixel_shuffle](https://pytorch.org/docs/stable/generated/torch.nn.functional.pixel_shuffle.html?highlight=pixel_shuffle#torch.nn.functional.pixel_shuffle)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.pixel_unshuffle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.pixel_unshuffle.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nn.functional.pixel_unshuffle
+## [ paddle 参数更多 ] torch.nn.functional.pixel_unshuffle
 
 ### [torch.nn.functional.pixel_unshuffle](https://pytorch.org/docs/stable/generated/torch.nn.functional.pixel_unshuffle.html?highlight=pixel_unshuffle#torch.nn.functional.pixel_unshuffle)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.prelu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.prelu.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.prelu
+## [ paddle 参数更多 ]torch.nn.functional.prelu
 
 ### [torch.nn.functional.prelu](https://pytorch.org/docs/stable/generated/torch.nn.functional.prelu.html?highlight=prelu#torch.nn.functional.prelu)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.rrelu_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.rrelu_.md
@@ -1,4 +1,4 @@
-## [ 仅参数默认值不一致 ]torch.nn.functional.rrelu_
+## [ 参数默认值不一致 ]torch.nn.functional.rrelu_
 
 ### [torch.nn.functional.rrelu\_](https://pytorch.org/docs/stable/generated/torch.nn.functional.rrelu_.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.upsample.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.upsample.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nn.functional.upsample
+## [ paddle 参数更多 ] torch.nn.functional.upsample
 
 ### [torch.nn.functional.upsample](https://pytorch.org/docs/stable/generated/torch.nn.functional.upsample.html?highlight=upsample#torch.nn.functional.upsample)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.upsample_bilinear.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.upsample_bilinear.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.upsample_bilinear
+## [ paddle 参数更多 ]torch.nn.functional.upsample_bilinear
 
 ### [torch.nn.functional.upsample_bilinear](https://pytorch.org/docs/stable/generated/torch.nn.functional.upsample_bilinear.html#torch.nn.functional.upsample_bilinear)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.upsample_nearest.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/functional/torch.nn.functional.upsample_nearest.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.functional.upsample_nearest
+## [ paddle 参数更多 ]torch.nn.functional.upsample_nearest
 
 ### [torch.nn.functional.upsample_nearest](https://pytorch.org/docs/stable/generated/torch.nn.functional.upsample_nearest.html#torch.nn.functional.upsample_nearest)
 
@@ -12,7 +12,8 @@ torch.nn.functional.upsample_nearest(input, size=None, scale_factor=None)
 paddle.nn.functional.upsample(x, size=None, scale_factor=None, mode='nearest', align_corners=False, align_mode=0, data_format='NCHW', name=None)
 ```
 
-仅 paddle 参数更多，具体区别如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
+
 ### 参数映射
 
 | PyTorch       | PaddlePaddle | 备注                                                   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.diagonal.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.diagonal.md
@@ -1,4 +1,4 @@
-## [ 仅参数默认值不一致 ]torch.linalg.diagonal
+## [ 参数默认值不一致 ]torch.linalg.diagonal
 ### [torch.linalg.diagonal](https://pytorch.org/docs/stable/generated/torch.linalg.diagonal.html#torch.linalg.diagonal)
 
 ```python
@@ -15,7 +15,7 @@ paddle.diagonal(x,
                 name=None)
 ```
 
-两者功能一致且参数用法一致，仅参数默认值不一致，具体如下：
+两者功能一致且参数用法一致，参数默认值不一致，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.vander.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/linalg/torch.linalg.vander.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.linalg.vander
+## [ paddle 参数更多 ]torch.linalg.vander
 
 ### [torch.linalg.vander](https://pytorch.org/docs/stable/generated/torch.linalg.vander.html#torch.linalg.vander)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.AdaptiveAvgPool2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.AdaptiveAvgPool2d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nn.AdaptiveAvgPool2d
+## [ paddle 参数更多 ] torch.nn.AdaptiveAvgPool2d
 
 ### [torch.nn.AdaptiveAvgPool2d](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool2d.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.AdaptiveAvgPool3d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.AdaptiveAvgPool3d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nn.AdaptiveAvgPool3d
+## [ paddle 参数更多 ] torch.nn.AdaptiveAvgPool3d
 
 ### [torch.nn.AdaptiveAvgPool3d](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool3d.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ChannelShuffle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ChannelShuffle.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.ChannelShuffle
+## [ paddle 参数更多 ]torch.nn.ChannelShuffle
 
 ### [torch.nn.ChannelShuffle](https://pytorch.org/docs/stable/generated/torch.nn.ChannelShuffle.html?highlight=channelshuffle#torch.nn.ChannelShuffle)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ConstantPad1d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ConstantPad1d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.ConstantPad1d
+## [ paddle 参数更多 ]torch.nn.ConstantPad1d
 ### [torch.nn.ConstantPad1d](https://pytorch.org/docs/stable/generated/torch.nn.ConstantPad1d.html?highlight=constantpad1d#torch.nn.ConstantPad1d)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ConstantPad2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ConstantPad2d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.ConstantPad2d
+## [ paddle 参数更多 ]torch.nn.ConstantPad2d
 ### [torch.nn.ConstantPad2d](https://pytorch.org/docs/stable/generated/torch.nn.ConstantPad2d.html?highlight=pad#torch.nn.ConstantPad2d)
 ```python
 torch.nn.ConstantPad2d(padding,

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ConstantPad3d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ConstantPad3d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.ConstantPad3d
+## [ paddle 参数更多 ]torch.nn.ConstantPad3d
 ### [torch.nn.ConstantPad3d](https://pytorch.org/docs/stable/generated/torch.nn.ConstantPad3d.html?highlight=pad#torch.nn.ConstantPad3d)
 ```python
 torch.nn.ConstantPad3d(padding,

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.LocalResponseNorm.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.LocalResponseNorm.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多]torch.nn.LocalResponseNorm
+## [ paddle 参数更多 ]torch.nn.LocalResponseNorm
 ### [torch.nn.LocalResponseNorm](https://pytorch.org/docs/stable/generated/torch.nn.LocalResponseNorm.html?highlight=localre#torch.nn.LocalResponseNorm)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MaxUnpool1d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MaxUnpool1d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多 ]torch.nn.MaxUnpool1d
+## [ paddle 参数更多 ]torch.nn.MaxUnpool1d
 ### [torch.nn.MaxUnpool1d](https://pytorch.org/docs/stable/generated/torch.nn.MaxUnpool1d.html?highlight=maxunpool1d#torch.nn.MaxUnpool1d)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MaxUnpool2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MaxUnpool2d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多 ]torch.nn.MaxUnpool2d
+## [ paddle 参数更多 ]torch.nn.MaxUnpool2d
 ### [torch.nn.MaxUnpool2d](https://pytorch.org/docs/stable/generated/torch.nn.MaxUnpool2d.html?highlight=maxunpool2d#torch.nn.MaxUnpool2d)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MaxUnpool3d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MaxUnpool3d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多 ]torch.nn.MaxUnpool3d
+## [ paddle 参数更多 ]torch.nn.MaxUnpool3d
 ### [torch.nn.MaxUnpool3d](https://pytorch.org/docs/stable/generated/torch.nn.MaxUnpool3d.html?highlight=maxunpool3d#torch.nn.MaxUnpool3d)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.bfloat16.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.bfloat16.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.bfloat16
+## [ paddle 参数更多 ]torch.nn.Module.bfloat16
 
 ### [torch.nn.Module.bfloat16](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.bfloat16)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.cpu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.cpu.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.cpu
+## [ paddle 参数更多 ]torch.nn.Module.cpu
 
 ### [torch.nn.Module.cpu](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.cpu)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.cuda.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.cuda.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.cuda
+## [ paddle 参数更多 ]torch.nn.Module.cuda
 
 ### [torch.nn.Module.cuda](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.cuda)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.double.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.double.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.double
+## [ paddle 参数更多 ]torch.nn.Module.double
 
 ### [torch.nn.Module.double](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.double)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.float.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.float.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.float
+## [ paddle 参数更多 ]torch.nn.Module.float
 
 ### [torch.nn.Module.float](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.float)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.half.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.half.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.half
+## [ paddle 参数更多 ]torch.nn.Module.half
 
 ### [torch.nn.Module.half](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.half)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nn.Module
+## [ paddle 参数更多 ] torch.nn.Module
 
 ### [torch.nn.Module](https://pytorch.org/docs/stable/generated/torch.nn.Module.html?highlight=torch+nn+module#torch.nn.Module)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Module.state_dict.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nn.Module.state_dict
+## [ paddle 参数更多 ] torch.nn.Module.state_dict
 ### [torch.nn.Module.state_dict](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.state_dict)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MultiLabelMarginLoss.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.MultiLabelMarginLoss.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.nn.MultiLabelMarginLoss
+## [ paddle 参数更多 ]torch.nn.MultiLabelMarginLoss
 
 ### [torch.nn.MultiLabelMarginLoss](https://pytorch.org/docs/stable/generated/torch.nn.MultiLabelMarginLoss)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.PixelShuffle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.PixelShuffle.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.PixelShuffle
+## [ paddle 参数更多 ]torch.nn.PixelShuffle
 ### [torch.nn.PixelShuffle](https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html?highlight=pixel#torch.nn.PixelShuffle)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.PixelUnshuffle.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.PixelUnshuffle.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.PixelUnshuffle
+## [ paddle 参数更多 ]torch.nn.PixelUnshuffle
 ### [torch.nn.PixelUnshuffle](https://pytorch.org/docs/stable/generated/torch.nn.PixelUnshuffle.html?highlight=pixel#torch.nn.PixelUnshuffle)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Softmax2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Softmax2d.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.nn.Softmax2d
+## [ paddle 参数更多 ]torch.nn.Softmax2d
 
 ### [torch.nn.Softmax2d](https://pytorch.org/docs/stable/generated/torch.nn.Softmax2d.html?highlight=softmax2d#torch.nn.Softmax2d)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Upsample.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.Upsample.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Upsample
+## [ paddle 参数更多 ]torch.nn.Upsample
 ### [torch.nn.Upsample](https://pytorch.org/docs/stable/generated/torch.nn.Upsample.html?highlight=upsample#torch.nn.Upsample)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.UpsamplingBilinear2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.UpsamplingBilinear2d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.UpsamplingBilinear2d
+## [ paddle 参数更多 ]torch.nn.UpsamplingBilinear2d
 
 ### [torch.nn.UpsamplingBilinear2d](https://pytorch.org/docs/stable/generated/torch.nn.UpsamplingBilinear2d.html?highlight=upsamplingbilinear2d#torch.nn.UpsamplingBilinear2d)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.UpsamplingNearest2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.UpsamplingNearest2d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.UpsamplingNearest2d
+## [ paddle 参数更多 ]torch.nn.UpsamplingNearest2d
 
 ### [torch.nn.UpsamplingNearest2d](https://pytorch.org/docs/stable/generated/torch.nn.UpsamplingNearest2d.html?highlight=upsampl#torch.nn.UpsamplingNearest2d)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ZeroPad2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/nn/torch.nn.ZeroPad2d.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.ZeroPad2d
+## [ paddle 参数更多 ]torch.nn.ZeroPad2d
 ### [torch.nn.ZeroPad2d](https://pytorch.org/docs/stable/generated/torch.nn.ZeroPad2d.html?highlight=zeropad#torch.nn.ZeroPad2d)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Tensor__upper.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.Tensor__upper.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.Tensor
+## [ paddle 参数更多 ] torch.Tensor
 
 ### [torch.Tensor](https://pytorch.org/docs/stable/tensors.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.alpha_dropout.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.alpha_dropout.md
@@ -1,4 +1,4 @@
-## [ 仅参数默认值不一致 ]torch.alpha_dropout
+## [ 参数默认值不一致 ]torch.alpha_dropout
 
 ### [torch.alpha\_dropout](https://pytorch.org/docs/master/generated/torch.nn.functional.alpha_dropout.html)
 
@@ -12,7 +12,7 @@ torch.alpha_dropout(input, p=0.5, train=False)
 paddle.nn.functional.alpha_dropout(x, p=0.5, training=True, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅参数默认值不一致，具体如下：
+其中 PyTorch 和 Paddle 功能一致，参数默认值不一致，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.argwhere.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.argwhere.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.argwhere
+## [ paddle 参数更多 ]torch.argwhere
 ### [torch.argwhere](https://pytorch.org/docs/stable/generated/torch.argwhere.html#torch.argwhere)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.count_nonzero.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.count_nonzero.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.count_nonzero
+## [ paddle 参数更多 ]torch.count_nonzero
 ### [torch.count_nonzero](https://pytorch.org/docs/stable/generated/torch.count_nonzero.html?highlight=count_nonzero#torch.count_nonzero)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.cov.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.cov.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.cov
+## [ paddle 参数更多 ]torch.cov
 ### [torch.cov](https://pytorch.org/docs/stable/generated/torch.cov.html?highlight=cov#torch.cov)
 
 ```python
@@ -19,7 +19,8 @@ paddle.linalg.cov(x,
                   name=None)
 ```
 
-仅 paddle 参数更多，具体如下：
+其中 Paddle 相比 PyTorch 支持更多其他参数，具体如下：
+
 ### 参数映射
 
 | PyTorch       | PaddlePaddle | 备注                                                   |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.fliplr.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.fliplr.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.fliplr
+## [ paddle 参数更多 ]torch.fliplr
 ### [torch.fliplr](https://pytorch.org/docs/stable/generated/torch.fliplr.html?highlight=fliplr#torch.fliplr)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.flipud.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.flipud.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.flipud
+## [ paddle 参数更多 ]torch.flipud
 ### [torch.flipud](https://pytorch.org/docs/stable/generated/torch.flipud.html?highlight=flipud#torch.flipud)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.nn.Module.modules.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.nn.Module.modules.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.nn.Module.modules
+## [ paddle 参数更多 ]torch.nn.Module.modules
 
 ### [torch.nn.Module.modules](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.modules)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rrelu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.rrelu.md
@@ -1,4 +1,4 @@
-## [ 仅参数默认值不一致 ]torch.rrelu
+## [ 参数默认值不一致 ]torch.rrelu
 
 ### [torch.rrelu](https://pytorch.org/docs/stable/generated/torch.nn.functional.rrelu.html#torch.nn.functional.rrelu)
 
@@ -12,7 +12,7 @@ torch.rrelu(input, lower=1./8, upper=1./3, training=False)
 paddle.nn.functional.rrelu(x, lower=1./8, upper=1./3, training=True, name=None)
 ```
 
-其中 PyTorch 和 Paddle 功能一致，仅参数名与参数默认值不一致，具体如下：
+其中 PyTorch 和 Paddle 功能一致，参数名与参数默认值不一致，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.scatter_add.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.scatter_add.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.scatter_add
+## [ paddle 参数更多 ]torch.scatter_add
 
 ### [torch.scatter_add](https://pytorch.org/docs/stable/generated/torch.scatter_add.html#torch.scatter_add)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.selu.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.selu.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.selu
+## [ paddle 参数更多 ]torch.selu
 
 ### [torch.selu](https://pytorch.org/docs/stable/generated/torch.nn.functional.selu.html#torch.nn.functional.selu)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.unique_consecutive.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/ops/torch.unique_consecutive.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.unique_consecutive
+## [ paddle 参数更多 ]torch.unique_consecutive
 ### [torch.unique_consecutive](https://pytorch.org/docs/stable/generated/torch.unique_consecutive.html?highlight=unique_consecutive#torch.unique_consecutive)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/optimizer/torch.optim.LBFGS.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/optimizer/torch.optim.LBFGS.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.optim.LBFGS
+## [ paddle 参数更多 ]torch.optim.LBFGS
 
 ### [torch.optim.LBFGS](https://pytorch.org/docs/stable/generated/torch.optim.LBFGS.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/optimizer/torch.optim.Optimizer.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/optimizer/torch.optim.Optimizer.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.optim.Optimizer
+## [ paddle 参数更多 ]torch.optim.Optimizer
 
 ### [torch.optim.Optimizer](https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.backward.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.Function.backward.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.autograd.Function.backward
+## [ paddle 参数更多 ]torch.autograd.Function.backward
 
 ### [torch.autograd.Function.backward](https://pytorch.org/docs/stable/generated/torch.autograd.Function.backward.html#torch.autograd.Function.backward)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.profiler.profile.export_chrome_trace.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.autograd.profiler.profile.export_chrome_trace.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.autograd.profiler.profile.export_chrome_trace
+## [ paddle 参数更多 ]torch.autograd.profiler.profile.export_chrome_trace
 
 ### [torch.autograd.profiler.profile.export_chrome_trace](https://pytorch.org/docs/stable/generated/torch.autograd.profiler.profile.export_chrome_trace.html#torch.autograd.profiler.profile.export_chrome_trace)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.cpu.amp.autocast.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.cpu.amp.autocast.md
@@ -1,4 +1,4 @@
-## [仅 paddle 参数更多]torch.cpu.amp.autocast
+## [ paddle 参数更多 ]torch.cpu.amp.autocast
 
 ### [torch.cpu.amp.autocast](https://pytorch.org/docs/stable/amp.html?highlight=autocast#torch.cpu.amp.autocast)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.nansum.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.nansum.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ] torch.nansum
+## [ paddle 参数更多 ] torch.nansum
 
 ### [torch.nansum](https://pytorch.org/docs/stable/generated/torch.nansum.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/pytorch_api_mapping_format_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/pytorch_api_mapping_format_cn.md
@@ -9,8 +9,8 @@
 为了文档整体的一致性，我们统一了 API 映射关系的分类名称，共分为 7 大类：
 > 注：第 1~3 类均为 API 层面一对一映射，根据参数层面的映射关系将其细分为三类。
 
-* 第 1 类又分为五种情况：`无参数`、`参数完全一致`、`仅参数名不一致`、`仅 paddle 参数更多`、`仅参数默认值不一致`。
-> 注：分类优先级依次递增，即如果同时 `参数名不一致` + `仅 paddle 参数更多`，则写成后者 `仅 paddle 参数更多` 。
+* 第 1 类又分为五种情况：`无参数`、`参数完全一致`、`仅参数名不一致`、`paddle 参数更多`、`仅参数默认值不一致`。
+> 注：分类优先级依次递增，即如果同时 `参数名不一致` + `paddle 参数更多`，则写成后者 `paddle 参数更多` 。
 
 * 第 2 类为 `torch 参数更多`。如果 torch 和 paddle 都支持更多参数，统一写成`torch 参数更多`。
 
@@ -55,7 +55,7 @@ Paddle API 签名
 
 * 如果 `仅参数名不一致`，无需转写示例，需要在备注栏里对该参数加一句 `仅参数名不一致`。
 
-* 如果 `仅 paddle 参数更多`，无需转写示例，需要在备注栏加一句 `PyTorch 无此参数，（Paddle 应如何设置此参数）` 。如果默认无影响，则写 `PyTorch 无此参数，Paddle 保持默认即可`。
+* 如果 `paddle 参数更多`，无需转写示例，需要在备注栏加一句 `PyTorch 无此参数，（Paddle 应如何设置此参数）` 。如果默认无影响，则写 `PyTorch 无此参数，Paddle 保持默认即可`。
 
 * 如果 `仅参数默认值不一致`，无需转写示例，需要在备注栏里加一句 `与 PyTorch 默认值不同，（Paddle 应如何设置此参数）` 。
 
@@ -177,7 +177,7 @@ paddle.dist(x,
 
 ## 模板 4
 
-### [ 仅 paddle 参数更多 ] torch.ZeroPad2d
+### [ paddle 参数更多 ] torch.ZeroPad2d
 
 ### [torch.nn.ZeroPad2d](https://pytorch.org/docs/stable/generated/torch.nn.ZeroPad2d.html?highlight=zeropad#torch.nn.ZeroPad2d)(仅作为示例)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/pytorch_api_mapping_format_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/pytorch_api_mapping_format_cn.md
@@ -9,7 +9,7 @@
 为了文档整体的一致性，我们统一了 API 映射关系的分类名称，共分为 7 大类：
 > 注：第 1~3 类均为 API 层面一对一映射，根据参数层面的映射关系将其细分为三类。
 
-* 第 1 类又分为五种情况：`无参数`、`参数完全一致`、`仅参数名不一致`、`paddle 参数更多`、`仅参数默认值不一致`。
+* 第 1 类又分为五种情况：`无参数`、`参数完全一致`、`仅参数名不一致`、`paddle 参数更多`、`参数默认值不一致`。
 > 注：分类优先级依次递增，即如果同时 `参数名不一致` + `paddle 参数更多`，则写成后者 `paddle 参数更多` 。
 
 * 第 2 类为 `torch 参数更多`。如果 torch 和 paddle 都支持更多参数，统一写成`torch 参数更多`。
@@ -57,7 +57,7 @@ Paddle API 签名
 
 * 如果 `paddle 参数更多`，无需转写示例，需要在备注栏加一句 `PyTorch 无此参数，（Paddle 应如何设置此参数）` 。如果默认无影响，则写 `PyTorch 无此参数，Paddle 保持默认即可`。
 
-* 如果 `仅参数默认值不一致`，无需转写示例，需要在备注栏里加一句 `与 PyTorch 默认值不同，（Paddle 应如何设置此参数）` 。
+* 如果 `参数默认值不一致`，无需转写示例，需要在备注栏里加一句 `与 PyTorch 默认值不同，（Paddle 应如何设置此参数）` 。
 
 * 如果 `torch 参数更多`，对每个 torch 多的参数都需要转写示例，需要在备注栏里加一句 `Paddle 无此参数，需要转写` ；如确实无法转写，需要在备注里写 `Paddle 无此参数，暂无转写方式` ；若可直接删除，则需要写 `Paddle 无此参数，一般对网络训练结果影响不大，可直接删除` 。
 
@@ -209,7 +209,7 @@ Paddle 相比 PyTorch 支持更多其他参数，具体如下：
 
 ## 模板 5
 
-## [ 仅参数默认值不一致 ] torch.linalg.svd
+## [ 参数默认值不一致 ] torch.linalg.svd
 
 ### [torch.linalg.svd](https://pytorch.org/docs/stable/generated/torch.linalg.svd.html?highlight=svd#torch.linalg.svd)
 
@@ -223,7 +223,7 @@ torch.linalg.svd(A, full_matrices=True)
 paddle.linalg.svd(x, full_matrices=False, name=None)
 ```
 
-两者功能一致且参数用法一致，仅参数默认值不一致，具体如下：
+两者功能一致且参数用法一致，参数默认值不一致，具体如下：
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.BatchSampler.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/utils/torch.utils.data.BatchSampler.md
@@ -1,4 +1,4 @@
-## [ 仅 paddle 参数更多 ]torch.utils.data.BatchSampler
+## [ paddle 参数更多 ]torch.utils.data.BatchSampler
 ### [torch.utils.data.BatchSampler](https://pytorch.org/docs/stable/data.html?highlight=batchsampler#torch.utils.data.BatchSampler)
 
 ```python

--- a/docs/guides/model_convert/convert_from_pytorch/apply_reference_from_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/apply_reference_from_api_difference.py
@@ -19,7 +19,7 @@ def mapping_type_to_description(mapping_type):
         "无参数",
         "参数完全一致",
         "仅参数名不一致",
-        "仅 paddle 参数更多",
+        "paddle 参数更多",
         "仅参数默认值不一致",
     ]
 

--- a/docs/guides/model_convert/convert_from_pytorch/apply_reference_from_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/apply_reference_from_api_difference.py
@@ -20,7 +20,7 @@ def mapping_type_to_description(mapping_type):
         "参数完全一致",
         "仅参数名不一致",
         "paddle 参数更多",
-        "仅参数默认值不一致",
+        "参数默认值不一致",
     ]
 
     if mapping_type in mapping_type_1:

--- a/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
@@ -17,7 +17,7 @@ mapping_type_set = {
     "无参数",
     "参数完全一致",
     "仅参数名不一致",
-    "仅 paddle 参数更多",
+    "paddle 参数更多",
     "仅参数默认值不一致",
     # type 2
     "torch 参数更多",
@@ -346,7 +346,7 @@ def get_meta_from_diff_file(filepath):
         "无参数",
         "参数完全一致",
         "仅参数名不一致",
-        "仅 paddle 参数更多",
+        "paddle 参数更多",
         "仅参数默认值不一致",
         # type 2
         "torch 参数更多",

--- a/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
+++ b/docs/guides/model_convert/convert_from_pytorch/validate_mapping_in_api_difference.py
@@ -18,7 +18,7 @@ mapping_type_set = {
     "参数完全一致",
     "仅参数名不一致",
     "paddle 参数更多",
-    "仅参数默认值不一致",
+    "参数默认值不一致",
     # type 2
     "torch 参数更多",
     # type 3
@@ -347,7 +347,7 @@ def get_meta_from_diff_file(filepath):
         "参数完全一致",
         "仅参数名不一致",
         "paddle 参数更多",
-        "仅参数默认值不一致",
+        "参数默认值不一致",
         # type 2
         "torch 参数更多",
         # type 3


### PR DESCRIPTION
更新了 PyTorch-Paddle 映射文档的部分映射类型名称：

- `仅 paddle 参数更多` 修改为 `paddle 参数更多`
- `仅参数默认值不一致` 修改为 `参数默认值不一致`

仅保留了参数映射表格中的相关描述，其余部分的文本均已修改且通过生成测试。