### PR TITLE
Modify pytorch write to paddle write and corrected a clerical error

### DIFF
--- a/docs/api/paddle/vision/ops/roi_pool_cn.rst
+++ b/docs/api/paddle/vision/ops/roi_pool_cn.rst
@@ -5,7 +5,7 @@ roi_pool
 
 .. py:function:: paddle.vision.ops.roi_pool(x, boxes, boxes_num, output_size, spatial_scale=1.0, name=None)
 
-实现 roi_cooling 层，位置敏感的兴趣区域池化（也称为 ROIPooling），是对非均匀大小的输入执行最大池，以获得固定大小的特征图（例如 7*7）。共三步：1.将每个区域分成大小相等的部分，并使用 output_size（h，w）。2.查找每个部分中的最大值 3。将这些最大值复制到输出缓冲区。有关详细信息，请参阅：https://stackoverflow.com/questions/43430056/what-is-roi-layer-in-fast-rcnn
+实现 roi_pooling 层，位置敏感的兴趣区域池化（也称为 ROIPooling），是对非均匀大小的输入执行最大池，以获得固定大小的特征图（例如 7*7）。共三步：1.将每个区域分成大小相等的部分，并使用 output_size（h，w）。2.查找每个部分中的最大值 3。将这些最大值复制到输出缓冲区。有关详细信息，请参阅：https://stackoverflow.com/questions/43430056/what-is-roi-layer-in-fast-rcnn
 
 
 参数

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.max.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/torch/torch.max.md
@@ -52,7 +52,7 @@ paddle.assign(paddle.max(a), y)
 result = torch.max(a, dim=1)
 
 # Paddle 写法
-result = torch.max(a, dim=1), torch.argmax(a, dim=1)
+result = paddle.max(a, axis=1), paddle.argmax(a, axis=1)
 ```
 
 --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## PR types
Bug fixes

## PR changes
Docs
## Description
1. 将torch.max.md中原来的代码的pytorch写法修改为注释所说的paddle写法
2. 修改roi_pool_cn.rst中笔误"roi_cooling"为"roi_pooling"