### PR TITLE
[Typing] 增加生成 python src file 与 api 映射文件

### DIFF
--- a/docs/api/.gitignore
+++ b/docs/api/.gitignore
@@ -2,3 +2,4 @@ api_info_all.json
 api_info_dict.json
 api_label
 en_cn_files_diff
+api_info_mapping.md

--- a/docs/api/.gitignore
+++ b/docs/api/.gitignore
@@ -2,4 +2,4 @@ api_info_all.json
 api_info_dict.json
 api_label
 en_cn_files_diff
-api_info_mapping.md
+api_info_mapping.*

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -723,7 +723,7 @@ def check_cn_en_match(path="./paddle", diff_file="en_cn_files_diff"):
 
 
 # generate api and src file mapping
-def gen_api_mapping(api_info_all_filename, output_filename):
+def gen_api_mapping(api_info_all_filename, output_filename, need_md=False):
     """We have api `type`:
     {
         "VariableMetaClass",
@@ -766,16 +766,22 @@ def gen_api_mapping(api_info_all_filename, output_filename):
             ):
                 api_mapping[src_file].add(api_info.get("short_name"))
 
-    with open(output_filename, "w") as f:
-        f.write("| src_file | apis | count |\n")
-        f.write("| - | - | - |\n")
-        count = 0
-        for src_file, apis in sorted(api_mapping.items(), key=lambda x: x[0]):
-            _count = len(apis)
-            count += _count
-            f.write(f"| `{src_file}` | {apis} | {_count} |\n")
+    if need_md:
+        with open(output_filename + ".md", "w") as f:
+            f.write("| src_file | apis | count |\n")
+            f.write("| - | - | - |\n")
+            count = 0
+            for src_file, apis in sorted(
+                api_mapping.items(), key=lambda x: x[0]
+            ):
+                _count = len(apis)
+                count += _count
+                f.write(f"| `{src_file}` | {apis} | {_count} |\n")
 
-        f.write(f"| 总计: {len(api_mapping)} | ~ | {count} |\n")
+            f.write(f"| 总计: {len(api_mapping)} | ~ | {count} |\n")
+
+    with open(output_filename + ".json", "w") as f:
+        json.dump({k: sorted(v) for k, v in api_mapping.items()}, f, indent=4)
 
 
 class EnDocGenerator:
@@ -1158,7 +1164,7 @@ if __name__ == "__main__":
             "__all__" in realattrs and realattr == "__all__"
         ):
             if args.gen_api_mapping:
-                gen_api_mapping(jsonfn, "api_info_mapping.md")
+                gen_api_mapping(jsonfn, "api_info_mapping", True)
 
         filter_out_object_of_api_info_dict()
         json.dump(api_info_dict, open(jsonfn, "w"), indent=4)

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -773,7 +773,7 @@ def gen_api_mapping(api_info_all_filename, output_filename):
         for src_file, apis in api_mapping.items():
             _count = len(apis)
             count += _count
-            f.write(f"| {src_file} | {apis} | {_count} |\n")
+            f.write(f"| `{src_file}` | {apis} | {_count} |\n")
 
         f.write(f"| 总计: {len(api_mapping)} | ~ | {count} |\n")
 

--- a/docs/api/gen_doc.py
+++ b/docs/api/gen_doc.py
@@ -770,7 +770,7 @@ def gen_api_mapping(api_info_all_filename, output_filename):
         f.write("| src_file | apis | count |\n")
         f.write("| - | - | - |\n")
         count = 0
-        for src_file, apis in api_mapping.items():
+        for src_file, apis in sorted(api_mapping.items(), key=lambda x: x[0]):
             _count = len(apis)
             count += _count
             f.write(f"| `{src_file}` | {apis} | {_count} |\n")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

- 增加生成 python src file 与 api 映射文件 `api_info_mapping.md`
- 增加命令 `--gen-api-mapping` ，默认不生成 

<details>

<summary>
<h5>api_info_mapping.md</h5>
</summary>

| src_file | apis | count |
| - | - | - |
| `/paddle/amp/__init__.py` | {'is_float16_supported', 'is_bfloat16_supported'} | 2 |
| `/paddle/amp/auto_cast.py` | {'auto_cast', 'decorate'} | 2 |
| `/paddle/amp/debugging.py` | {'check_numerics', 'check_layer_numerics', 'TensorCheckerConfig', 'enable_tensor_checker', 'collect_operator_stats', 'disable_operator_stats_collection', 'disable_tensor_checker', 'compare_accuracy', 'enable_operator_stats_collection'} | 9 |
| `/paddle/amp/grad_scaler.py` | {'GradScaler'} | 1 |
| `/paddle/audio/backends/init_backend.py` | {'set_backend', 'list_available_backends', 'get_current_backend'} | 3 |
| `/paddle/audio/backends/wave_backend.py` | {'load', 'info', 'save'} | 3 |
| `/paddle/audio/datasets/esc50.py` | {'ESC50'} | 1 |
| `/paddle/audio/datasets/tess.py` | {'TESS'} | 1 |
| `/paddle/audio/features/layers.py` | {'Spectrogram', 'MelSpectrogram', 'LogMelSpectrogram', 'MFCC'} | 4 |
| `/paddle/audio/functional/functional.py` | {'mel_frequencies', 'mel_to_hz', 'power_to_db', 'hz_to_mel', 'fft_frequencies', 'compute_fbank_matrix', 'create_dct'} | 7 |
| `/paddle/audio/functional/window.py` | {'get_window'} | 1 |
| `/paddle/autograd/autograd.py` | {'hessian', 'jacobian'} | 2 |
| `/paddle/autograd/backward_mode.py` | {'backward'} | 1 |
| `/paddle/autograd/ir_backward.py` | {'calc_gradient', 'grad', 'calc_gradient_helper'} | 3 |
| `/paddle/autograd/py_layer.py` | {'PyLayerContext'} | 1 |
| `/paddle/autograd/saved_tensors_hooks.py` | {'saved_tensors_hooks'} | 1 |
| `/paddle/base/backward.py` | {'gradients', 'append_backward'} | 2 |
| `/paddle/base/compiler.py` | {'IpuStrategy', 'IpuCompiledProgram', 'CompiledProgram'} | 3 |
| `/paddle/base/data_feeder.py` | {'check_shape'} | 1 |
| `/paddle/base/dygraph/base.py` | {'enable_grad', 'no_grad_', 'grad', 'set_grad_enabled', 'enable_dygraph', 'is_grad_enabled', 'disable_dygraph'} | 7 |
| `/paddle/base/executor.py` | {'scope_guard', 'global_scope', 'Executor'} | 3 |
| `/paddle/base/framework.py` | {'program_guard', 'require_version', 'in_dygraph_mode', 'is_compiled_with_rocm', 'Program', 'default_main_program', 'is_compiled_with_distribute', 'get_flags', 'default_startup_program', 'disable_signal_handler', 'set_ipu_shard', 'is_compiled_with_cinn', 'is_compiled_with_cuda', 'set_flags', 'cpu_places', 'device_guard', 'cuda_places', 'xpu_places', 'ipu_shard_guard', 'name_scope'} | 20 |
| `/paddle/base/initializer.py` | {'set_global_initializer'} | 1 |
| `/paddle/base/param_attr.py` | {'WeightNormParamAttr', 'ParamAttr'} | 2 |
| `/paddle/base/unique_name.py` | {'guard', 'switch', 'generate'} | 3 |
| `/paddle/batch.py` | {'batch'} | 1 |
| `/paddle/device/__init__.py` | {'get_all_custom_device_type', 'set_device', 'get_all_device_type', 'get_cudnn_version', 'stream_guard', 'is_compiled_with_xpu', 'is_compiled_with_ipu', 'Stream', 'synchronize', 'get_available_device', 'set_stream', 'IPUPlace', 'current_stream', 'Event', 'get_device', 'XPUPlace', 'is_compiled_with_custom_device', 'get_available_custom_device'} | 18 |
| `/paddle/device/cuda/__init__.py` | {'get_device_name', 'max_memory_reserved', 'get_device_capability', 'stream_guard', 'get_device_properties', 'device_count', 'empty_cache', 'max_memory_allocated', 'current_stream', 'synchronize', 'memory_reserved', 'memory_allocated'} | 12 |
| `/paddle/device/xpu/__init__.py` | {'synchronize'} | 1 |
| `/paddle/distributed/auto_parallel/api.py` | {'shard_scaler', 'unshard_dtensor', 'Strategy', 'to_static', 'shard_layer', 'DistModel', 'shard_dataloader', 'shard_tensor', 'ShardingStage2', 'shard_optimizer', 'ShardingStage1', 'dtensor_from_fn', 'ShardingStage3', 'reshard'} | 14 |
| `/paddle/distributed/checkpoint/load_state_dict.py` | {'load_state_dict'} | 1 |
| `/paddle/distributed/checkpoint/save_state_dict.py` | {'save_state_dict'} | 1 |
| `/paddle/distributed/collective.py` | {'new_group', 'is_available'} | 2 |
| `/paddle/distributed/communication/all_gather.py` | {'all_gather_object', 'all_gather'} | 2 |
| `/paddle/distributed/communication/all_reduce.py` | {'all_reduce'} | 1 |
| `/paddle/distributed/communication/all_to_all.py` | {'alltoall_single', 'alltoall'} | 2 |
| `/paddle/distributed/communication/broadcast.py` | {'broadcast_object_list', 'broadcast'} | 2 |
| `/paddle/distributed/communication/gather.py` | {'gather'} | 1 |
| `/paddle/distributed/communication/group.py` | {'get_group', 'wait', 'destroy_process_group', 'get_backend', 'barrier', 'is_initialized'} | 6 |
| `/paddle/distributed/communication/recv.py` | {'recv', 'irecv'} | 2 |
| `/paddle/distributed/communication/reduce.py` | {'ReduceOp', 'reduce'} | 2 |
| `/paddle/distributed/communication/reduce_scatter.py` | {'reduce_scatter'} | 1 |
| `/paddle/distributed/communication/scatter.py` | {'scatter', 'scatter_object_list'} | 2 |
| `/paddle/distributed/communication/send.py` | {'isend', 'send'} | 2 |
| `/paddle/distributed/communication/stream/all_gather.py` | {'all_gather'} | 1 |
| `/paddle/distributed/communication/stream/all_reduce.py` | {'all_reduce'} | 1 |
| `/paddle/distributed/communication/stream/all_to_all.py` | {'alltoall_single', 'alltoall'} | 2 |
| `/paddle/distributed/communication/stream/broadcast.py` | {'broadcast'} | 1 |
| `/paddle/distributed/communication/stream/gather.py` | {'gather'} | 1 |
| `/paddle/distributed/communication/stream/recv.py` | {'recv'} | 1 |
| `/paddle/distributed/communication/stream/reduce.py` | {'reduce'} | 1 |
| `/paddle/distributed/communication/stream/reduce_scatter.py` | {'reduce_scatter'} | 1 |
| `/paddle/distributed/communication/stream/scatter.py` | {'scatter'} | 1 |
| `/paddle/distributed/communication/stream/send.py` | {'send'} | 1 |
| `/paddle/distributed/entry_attr.py` | {'ShowClickEntry', 'CountFilterEntry', 'ProbabilityEntry'} | 3 |
| `/paddle/distributed/fleet/base/distributed_strategy.py` | {'DistributedStrategy'} | 1 |
| `/paddle/distributed/fleet/base/role_maker.py` | {'UserDefinedRoleMaker', 'PaddleCloudRoleMaker', 'Role'} | 3 |
| `/paddle/distributed/fleet/base/topology.py` | {'ParallelMode', 'HybridCommunicateGroup', 'CommunicateTopology'} | 3 |
| `/paddle/distributed/fleet/base/util_factory.py` | {'UtilBase'} | 1 |
| `/paddle/distributed/fleet/data_generator/data_generator.py` | {'MultiSlotStringDataGenerator', 'MultiSlotDataGenerator'} | 2 |
| `/paddle/distributed/fleet/dataset/dataset.py` | {'QueueDataset', 'InMemoryDataset'} | 2 |
| `/paddle/distributed/fleet/fleet.py` | {'Fleet'} | 1 |
| `/paddle/distributed/fleet/layers/mpu/mp_ops.py` | {'split'} | 1 |
| `/paddle/distributed/fleet/recompute/recompute.py` | {'recompute_sequential'} | 1 |
| `/paddle/distributed/fleet/recompute/recompute_hybrid.py` | {'recompute_hybrid'} | 1 |
| `/paddle/distributed/fleet/utils/__init__.py` | {'recompute'} | 1 |
| `/paddle/distributed/fleet/utils/fs.py` | {'HDFSClient', 'LocalFS'} | 2 |
| `/paddle/distributed/fleet/utils/ps_util.py` | {'DistributedInfer'} | 1 |
| `/paddle/distributed/parallel.py` | {'DataParallel', 'get_world_size', 'init_parallel_env', 'ParallelEnv', 'get_rank'} | 5 |
| `/paddle/distributed/parallel_with_gloo.py` | {'gloo_init_parallel_env', 'gloo_release', 'gloo_barrier'} | 3 |
| `/paddle/distributed/passes/pass_base.py` | {'PassManager', 'PassContext', 'new_pass'} | 3 |
| `/paddle/distributed/ps/the_one_ps.py` | {'DenseTable', 'TensorTable', 'SparseTable', 'GeoSparseTable', 'BarrierTable', 'Table'} | 6 |
| `/paddle/distributed/ps/utils/ps_program_builder.py` | {'GpuPsProgramBuilder', 'GeoPsProgramBuilder', 'PsProgramBuilder', 'CpuSyncPsProgramBuilder', 'FlPsProgramBuilder', 'CpuAsyncPsProgramBuilder', 'HeterAsyncPsProgramBuilder', 'NuPsProgramBuilder'} | 8 |
| `/paddle/distributed/rpc/rpc.py` | {'get_current_worker_info', 'init_rpc', 'get_all_worker_infos', 'rpc_sync', 'rpc_async', 'shutdown', 'get_worker_info'} | 7 |
| `/paddle/distributed/sharding/group_sharded.py` | {'group_sharded_parallel', 'save_group_sharded_model'} | 2 |
| `/paddle/distributed/spawn.py` | {'spawn'} | 1 |
| `/paddle/distribution/bernoulli.py` | {'Bernoulli'} | 1 |
| `/paddle/distribution/beta.py` | {'Beta'} | 1 |
| `/paddle/distribution/binomial.py` | {'Binomial'} | 1 |
| `/paddle/distribution/categorical.py` | {'Categorical'} | 1 |
| `/paddle/distribution/cauchy.py` | {'Cauchy'} | 1 |
| `/paddle/distribution/chi2.py` | {'Chi2'} | 1 |
| `/paddle/distribution/continuous_bernoulli.py` | {'ContinuousBernoulli'} | 1 |
| `/paddle/distribution/dirichlet.py` | {'Dirichlet'} | 1 |
| `/paddle/distribution/distribution.py` | {'Distribution'} | 1 |
| `/paddle/distribution/exponential.py` | {'Exponential'} | 1 |
| `/paddle/distribution/exponential_family.py` | {'ExponentialFamily'} | 1 |
| `/paddle/distribution/gamma.py` | {'Gamma'} | 1 |
| `/paddle/distribution/geometric.py` | {'Geometric'} | 1 |
| `/paddle/distribution/gumbel.py` | {'Gumbel'} | 1 |
| `/paddle/distribution/independent.py` | {'Independent'} | 1 |
| `/paddle/distribution/kl.py` | {'kl_divergence', 'register_kl'} | 2 |
| `/paddle/distribution/laplace.py` | {'Laplace'} | 1 |
| `/paddle/distribution/lkj_cholesky.py` | {'LKJCholesky'} | 1 |
| `/paddle/distribution/lognormal.py` | {'LogNormal'} | 1 |
| `/paddle/distribution/multinomial.py` | {'Multinomial'} | 1 |
| `/paddle/distribution/multivariate_normal.py` | {'MultivariateNormal'} | 1 |
| `/paddle/distribution/normal.py` | {'Normal'} | 1 |
| `/paddle/distribution/poisson.py` | {'Poisson'} | 1 |
| `/paddle/distribution/student_t.py` | {'StudentT'} | 1 |
| `/paddle/distribution/transform.py` | {'ReshapeTransform', 'AbsTransform', 'SoftmaxTransform', 'StickBreakingTransform', 'ExpTransform', 'TanhTransform', 'StackTransform', 'ChainTransform', 'SigmoidTransform', 'AffineTransform', 'PowerTransform', 'IndependentTransform', 'Transform'} | 13 |
| `/paddle/distribution/transformed_distribution.py` | {'TransformedDistribution'} | 1 |
| `/paddle/distribution/uniform.py` | {'Uniform'} | 1 |
| `/paddle/fft.py` | {'hfft2', 'irfft2', 'fft2', 'ifft2', 'ifft', 'irfftn', 'fftn', 'fftfreq', 'rfft', 'rfft2', 'rfftfreq', 'hfftn', 'hfft', 'ihfft', 'fftshift', 'ihfft2', 'irfft', 'ifftn', 'ihfftn', 'rfftn', 'ifftshift', 'fft'} | 22 |
| `/paddle/framework/dtype.py` | {'iinfo', 'finfo'} | 2 |
| `/paddle/framework/framework.py` | {'set_default_dtype', 'get_default_dtype'} | 2 |
| `/paddle/framework/io.py` | {'load', 'save'} | 2 |
| `/paddle/framework/random.py` | {'set_cuda_rng_state', 'get_rng_state', 'set_rng_state', 'get_cuda_rng_state', 'seed'} | 5 |
| `/paddle/geometric/math.py` | {'segment_min', 'segment_sum', 'segment_mean', 'segment_max'} | 4 |
| `/paddle/geometric/message_passing/send_recv.py` | {'send_u_recv', 'send_uv', 'send_ue_recv'} | 3 |
| `/paddle/geometric/reindex.py` | {'reindex_graph', 'reindex_heter_graph'} | 2 |
| `/paddle/geometric/sampling/neighbors.py` | {'weighted_sample_neighbors', 'sample_neighbors'} | 2 |
| `/paddle/hapi/callbacks.py` | {'ReduceLROnPlateau', 'ProgBarLogger', 'WandbCallback', 'VisualDL', 'EarlyStopping', 'LRScheduler', 'Callback', 'ModelCheckpoint'} | 8 |
| `/paddle/hapi/dynamic_flops.py` | {'flops'} | 1 |
| `/paddle/hapi/hub.py` | {'list', 'load', 'help'} | 3 |
| `/paddle/hapi/model.py` | {'Model'} | 1 |
| `/paddle/hapi/model_summary.py` | {'summary'} | 1 |
| `/paddle/incubate/asp/asp.py` | {'reset_excluded_layers', 'prune_model', 'set_excluded_layers', 'decorate'} | 4 |
| `/paddle/incubate/asp/supported_layer_list.py` | {'add_supported_layer'} | 1 |
| `/paddle/incubate/asp/utils.py` | {'calculate_density'} | 1 |
| `/paddle/incubate/autograd/functional.py` | {'jvp', 'Hessian', 'Jacobian', 'vjp'} | 4 |
| `/paddle/incubate/autograd/primapi.py` | {'forward_grad', 'grad'} | 2 |
| `/paddle/incubate/autograd/utils.py` | {'enable_prim', 'disable_prim'} | 2 |
| `/paddle/incubate/autotune.py` | {'set_config'} | 1 |
| `/paddle/incubate/distributed/utils/io/dist_save.py` | {'save'} | 1 |
| `/paddle/incubate/distributed/utils/io/save_for_auto.py` | {'save_for_auto_inference'} | 1 |
| `/paddle/incubate/jit/inference_decorator.py` | {'inference'} | 1 |
| `/paddle/incubate/nn/functional/blha_get_max_len.py` | {'blha_get_max_len'} | 1 |
| `/paddle/incubate/nn/functional/block_multihead_attention.py` | {'block_multihead_attention'} | 1 |
| `/paddle/incubate/nn/functional/fused_dropout_add.py` | {'fused_dropout_add'} | 1 |
| `/paddle/incubate/nn/functional/fused_ec_moe.py` | {'fused_ec_moe'} | 1 |
| `/paddle/incubate/nn/functional/fused_layer_norm.py` | {'fused_layer_norm'} | 1 |
| `/paddle/incubate/nn/functional/fused_matmul_bias.py` | {'fused_linear', 'fused_linear_activation', 'fused_matmul_bias'} | 3 |
| `/paddle/incubate/nn/functional/fused_rms_norm.py` | {'fused_rms_norm'} | 1 |
| `/paddle/incubate/nn/functional/fused_rotary_position_embedding.py` | {'fused_rotary_position_embedding'} | 1 |
| `/paddle/incubate/nn/functional/fused_transformer.py` | {'fused_feedforward', 'fused_multi_transformer', 'fused_multi_head_attention', 'fused_bias_dropout_residual_layer_norm'} | 4 |
| `/paddle/incubate/nn/functional/masked_multihead_attention.py` | {'masked_multihead_attention'} | 1 |
| `/paddle/incubate/nn/functional/swiglu.py` | {'swiglu'} | 1 |
| `/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py` | {'variable_length_memory_efficient_attention'} | 1 |
| `/paddle/incubate/nn/layer/fused_dropout_add.py` | {'FusedDropoutAdd'} | 1 |
| `/paddle/incubate/nn/layer/fused_ec_moe.py` | {'FusedEcMoe'} | 1 |
| `/paddle/incubate/nn/layer/fused_linear.py` | {'FusedLinear'} | 1 |
| `/paddle/incubate/nn/layer/fused_transformer.py` | {'FusedFeedForward', 'FusedMultiHeadAttention', 'FusedTransformerEncoderLayer', 'FusedMultiTransformer', 'FusedBiasDropoutResidualLayerNorm'} | 5 |
| `/paddle/incubate/nn/loss.py` | {'identity_loss'} | 1 |
| `/paddle/incubate/operators/graph_khop_sampler.py` | {'graph_khop_sampler'} | 1 |
| `/paddle/incubate/operators/graph_reindex.py` | {'graph_reindex'} | 1 |
| `/paddle/incubate/operators/graph_sample_neighbors.py` | {'graph_sample_neighbors'} | 1 |
| `/paddle/incubate/operators/graph_send_recv.py` | {'graph_send_recv'} | 1 |
| `/paddle/incubate/operators/softmax_mask_fuse.py` | {'softmax_mask_fuse'} | 1 |
| `/paddle/incubate/operators/softmax_mask_fuse_upper_triangle.py` | {'softmax_mask_fuse_upper_triangle'} | 1 |
| `/paddle/incubate/optimizer/functional/bfgs.py` | {'minimize_bfgs'} | 1 |
| `/paddle/incubate/optimizer/functional/lbfgs.py` | {'minimize_lbfgs'} | 1 |
| `/paddle/incubate/optimizer/lbfgs.py` | {'LBFGS'} | 1 |
| `/paddle/incubate/optimizer/lookahead.py` | {'LookAhead'} | 1 |
| `/paddle/incubate/optimizer/modelaverage.py` | {'ModelAverage'} | 1 |
| `/paddle/incubate/tensor/math.py` | {'segment_min', 'segment_sum', 'segment_mean', 'segment_max'} | 4 |
| `/paddle/incubate/xpu/resnet_block.py` | {'resnet_basic_block', 'ResNetBasicBlock'} | 2 |
| `/paddle/inference/wrapper.py` | {'convert_to_mixed_precision', 'tensor_copy_from_cpu', 'tensor_share_external_data'} | 3 |
| `/paddle/io/dataloader/batch_sampler.py` | {'DistributedBatchSampler', 'BatchSampler'} | 2 |
| `/paddle/io/dataloader/dataset.py` | {'ConcatDataset', 'Subset', 'ComposeDataset', 'Dataset', 'IterableDataset', 'ChainDataset', 'TensorDataset', 'random_split'} | 8 |
| `/paddle/io/dataloader/sampler.py` | {'RandomSampler', 'SequenceSampler', 'Sampler', 'WeightedRandomSampler', 'SubsetRandomSampler'} | 5 |
| `/paddle/io/dataloader/worker.py` | {'get_worker_info'} | 1 |
| `/paddle/io/reader.py` | {'DataLoader'} | 1 |
| `/paddle/jit/api.py` | {'ignore_module', 'not_to_static', 'load', 'to_static', 'save'} | 5 |
| `/paddle/jit/dy2static/logging_utils.py` | {'set_verbosity', 'set_code_level'} | 2 |
| `/paddle/jit/dy2static/program_translator.py` | {'enable_to_static'} | 1 |
| `/paddle/jit/translated_layer.py` | {'TranslatedLayer'} | 1 |
| `/paddle/metric/metrics.py` | {'accuracy', 'Auc', 'Precision', 'Recall', 'Accuracy', 'Metric'} | 6 |
| `/paddle/nn/clip.py` | {'ClipGradByGlobalNorm', 'ClipGradByNorm', 'ClipGradByValue'} | 3 |
| `/paddle/nn/decode.py` | {'dynamic_decode', 'BeamSearchDecoder'} | 2 |
| `/paddle/nn/functional/activation.py` | {'relu', 'hardshrink', 'log_softmax', 'maxout', 'thresholded_relu_', 'log_sigmoid', 'mish', 'relu_', 'hardtanh', 'swish', 'softsign', 'hardsigmoid', 'rrelu', 'gelu', 'hardtanh_', 'elu_', 'elu', 'gumbel_softmax', 'thresholded_relu', 'silu', 'hardswish', 'glu', 'tanhshrink', 'celu', 'relu6', 'leaky_relu', 'softmax', 'prelu', 'softplus', 'leaky_relu_', 'selu', 'softmax_', 'softshrink'} | 33 |
| `/paddle/nn/functional/common.py` | {'linear', 'alpha_dropout', 'dropout', 'cosine_similarity', 'label_smooth', 'feature_alpha_dropout', 'unfold', 'pad', 'fold', 'dropout3d', 'zeropad2d', 'bilinear', 'dropout2d', 'upsample', 'class_center_sample', 'interpolate'} | 16 |
| `/paddle/nn/functional/conv.py` | {'conv1d', 'conv2d_transpose', 'conv3d_transpose', 'conv3d', 'conv2d', 'conv1d_transpose'} | 6 |
| `/paddle/nn/functional/distance.py` | {'pairwise_distance', 'pdist'} | 2 |
| `/paddle/nn/functional/extension.py` | {'sequence_mask', 'gather_tree', 'temporal_shift'} | 3 |
| `/paddle/nn/functional/flash_attention.py` | {'scaled_dot_product_attention', 'flash_attn_varlen_qkvpacked', 'flash_attention_with_sparse_mask', 'flash_attn_qkvpacked'} | 4 |
| `/paddle/nn/functional/input.py` | {'one_hot', 'embedding'} | 2 |
| `/paddle/nn/functional/loss.py` | {'kl_div', 'adaptive_log_softmax_with_loss', 'soft_margin_loss', 'dice_loss', 'multi_margin_loss', 'sigmoid_focal_loss', 'binary_cross_entropy_with_logits', 'mse_loss', 'ctc_loss', 'npair_loss', 'triplet_margin_with_distance_loss', 'margin_ranking_loss', 'triplet_margin_loss', 'square_error_cost', 'hsigmoid_loss', 'cosine_embedding_loss', 'hinge_embedding_loss', 'margin_cross_entropy', 'log_loss', 'l1_loss', 'rnnt_loss', 'gaussian_nll_loss', 'cross_entropy', 'binary_cross_entropy', 'smooth_l1_loss', 'multi_label_soft_margin_loss', 'softmax_with_cross_entropy', 'nll_loss', 'poisson_nll_loss'} | 29 |
| `/paddle/nn/functional/norm.py` | {'local_response_norm', 'normalize', 'layer_norm', 'group_norm', 'instance_norm', 'batch_norm'} | 6 |
| `/paddle/nn/functional/pooling.py` | {'avg_pool3d', 'adaptive_avg_pool2d', 'max_unpool3d', 'adaptive_max_pool2d', 'avg_pool2d', 'adaptive_avg_pool3d', 'avg_pool1d', 'fractional_max_pool3d', 'max_pool1d', 'adaptive_max_pool3d', 'max_pool2d', 'adaptive_avg_pool1d', 'max_pool3d', 'max_unpool1d', 'adaptive_max_pool1d', 'lp_pool2d', 'max_unpool2d', 'fractional_max_pool2d', 'lp_pool1d'} | 19 |
| `/paddle/nn/functional/sparse_attention.py` | {'sparse_attention'} | 1 |
| `/paddle/nn/functional/vision.py` | {'grid_sample', 'channel_shuffle', 'affine_grid', 'pixel_shuffle', 'pixel_unshuffle'} | 5 |
| `/paddle/nn/initializer/assign.py` | {'Assign'} | 1 |
| `/paddle/nn/initializer/bilinear.py` | {'Bilinear'} | 1 |
| `/paddle/nn/initializer/constant.py` | {'Constant'} | 1 |
| `/paddle/nn/initializer/dirac.py` | {'Dirac'} | 1 |
| `/paddle/nn/initializer/initializer.py` | {'calculate_gain'} | 1 |
| `/paddle/nn/initializer/kaiming.py` | {'KaimingUniform', 'KaimingNormal'} | 2 |
| `/paddle/nn/initializer/lazy_init.py` | {'LazyGuard'} | 1 |
| `/paddle/nn/initializer/normal.py` | {'Normal', 'TruncatedNormal'} | 2 |
| `/paddle/nn/initializer/orthogonal.py` | {'Orthogonal'} | 1 |
| `/paddle/nn/initializer/uniform.py` | {'Uniform'} | 1 |
| `/paddle/nn/initializer/xavier.py` | {'XavierNormal', 'XavierUniform'} | 2 |
| `/paddle/nn/layer/activation.py` | {'Hardsigmoid', 'GLU', 'LogSoftmax', 'ELU', 'ReLU6', 'Tanh', 'Mish', 'Softmax2D', 'Silu', 'Tanhshrink', 'Softplus', 'Swish', 'LeakyReLU', 'CELU', 'Sigmoid', 'PReLU', 'Hardtanh', 'SELU', 'Hardshrink', 'Maxout', 'RReLU', 'Softshrink', 'Softsign', 'LogSigmoid', 'GELU', 'ThresholdedReLU', 'Hardswish', 'ReLU', 'Softmax'} | 29 |
| `/paddle/nn/layer/common.py` | {'Unfold', 'Identity', 'Pad2D', 'Unflatten', 'FeatureAlphaDropout', 'Pad1D', 'Bilinear', 'UpsamplingNearest2D', 'AlphaDropout', 'Fold', 'Linear', 'UpsamplingBilinear2D', 'Dropout3D', 'Dropout2D', 'Upsample', 'ZeroPad2D', 'Dropout', 'Embedding', 'CosineSimilarity', 'ZeroPad1D', 'Pad3D', 'Flatten', 'ZeroPad3D'} | 23 |
| `/paddle/nn/layer/container.py` | {'ParameterList', 'LayerList', 'Sequential', 'LayerDict'} | 4 |
| `/paddle/nn/layer/conv.py` | {'Conv3D', 'Conv3DTranspose', 'Conv2DTranspose', 'Conv1D', 'Conv1DTranspose', 'Conv2D'} | 6 |
| `/paddle/nn/layer/distance.py` | {'PairwiseDistance'} | 1 |
| `/paddle/nn/layer/layers.py` | {'Layer'} | 1 |
| `/paddle/nn/layer/loss.py` | {'RNNTLoss', 'BCEWithLogitsLoss', 'MarginRankingLoss', 'GaussianNLLLoss', 'CrossEntropyLoss', 'CosineEmbeddingLoss', 'TripletMarginLoss', 'NLLLoss', 'SmoothL1Loss', 'L1Loss', 'PoissonNLLLoss', 'MultiMarginLoss', 'MSELoss', 'SoftMarginLoss', 'HingeEmbeddingLoss', 'AdaptiveLogSoftmaxWithLoss', 'CTCLoss', 'MultiLabelSoftMarginLoss', 'HSigmoidLoss', 'BCELoss', 'KLDivLoss', 'TripletMarginWithDistanceLoss'} | 22 |
| `/paddle/nn/layer/norm.py` | {'InstanceNorm1D', 'SpectralNorm', 'GroupNorm', 'LocalResponseNorm', 'SyncBatchNorm', 'InstanceNorm2D', 'InstanceNorm3D', 'BatchNorm', 'BatchNorm3D', 'BatchNorm1D', 'LayerNorm', 'BatchNorm2D'} | 12 |
| `/paddle/nn/layer/pooling.py` | {'AdaptiveAvgPool2D', 'MaxUnPool2D', 'AdaptiveMaxPool2D', 'MaxPool3D', 'MaxPool2D', 'AvgPool2D', 'AdaptiveAvgPool3D', 'AdaptiveAvgPool1D', 'FractionalMaxPool3D', 'AvgPool3D', 'LPPool1D', 'LPPool2D', 'MaxUnPool3D', 'AdaptiveMaxPool3D', 'MaxUnPool1D', 'AvgPool1D', 'AdaptiveMaxPool1D', 'FractionalMaxPool2D', 'MaxPool1D'} | 19 |
| `/paddle/nn/layer/rnn.py` | {'SimpleRNN', 'RNNCellBase', 'RNN', 'SimpleRNNCell', 'LSTMCell', 'GRUCell', 'GRU', 'BiRNN', 'LSTM'} | 9 |
| `/paddle/nn/layer/transformer.py` | {'TransformerDecoder', 'TransformerEncoderLayer', 'TransformerEncoder', 'TransformerDecoderLayer', 'MultiHeadAttention', 'Transformer'} | 6 |
| `/paddle/nn/layer/vision.py` | {'ChannelShuffle', 'PixelShuffle', 'PixelUnshuffle'} | 3 |
| `/paddle/nn/quant/quant_layers.py` | {'FakeQuantAbsMax', 'QuantizedConv2D', 'QuantizedColumnParallelLinear', 'QuantizedLinear', 'MovingAverageAbsMaxScale', 'QuantizedRowParallelLinear', 'FakeQuantChannelWiseAbsMax', 'FakeQuantMAOutputScaleLayer', 'QuantizedMatmul', 'QuantizedConv2DTranspose', 'FakeQuantMovingAverageAbsMax', 'MAOutputScaleLayer'} | 12 |
| `/paddle/nn/quant/quantized_linear.py` | {'weight_dequantize', 'llm_int8_linear', 'weight_quantize', 'weight_only_linear'} | 4 |
| `/paddle/nn/quant/stub.py` | {'Stub'} | 1 |
| `/paddle/nn/utils/clip_grad_norm_.py` | {'clip_grad_norm_'} | 1 |
| `/paddle/nn/utils/clip_grad_value_.py` | {'clip_grad_value_'} | 1 |
| `/paddle/nn/utils/spectral_norm_hook.py` | {'spectral_norm'} | 1 |
| `/paddle/nn/utils/transform_parameters.py` | {'parameters_to_vector', 'vector_to_parameters'} | 2 |
| `/paddle/nn/utils/weight_norm_hook.py` | {'weight_norm', 'remove_weight_norm'} | 2 |
| `/paddle/onnx/export.py` | {'export'} | 1 |
| `/paddle/optimizer/adadelta.py` | {'Adadelta'} | 1 |
| `/paddle/optimizer/adagrad.py` | {'Adagrad'} | 1 |
| `/paddle/optimizer/adam.py` | {'Adam'} | 1 |
| `/paddle/optimizer/adamax.py` | {'Adamax'} | 1 |
| `/paddle/optimizer/adamw.py` | {'AdamW'} | 1 |
| `/paddle/optimizer/asgd.py` | {'ASGD'} | 1 |
| `/paddle/optimizer/lamb.py` | {'Lamb'} | 1 |
| `/paddle/optimizer/lbfgs.py` | {'LBFGS'} | 1 |
| `/paddle/optimizer/lr.py` | {'NaturalExpDecay', 'CyclicLR', 'NoamDecay', 'CosineAnnealingWarmRestarts', 'MultiplicativeDecay', 'PiecewiseDecay', 'ExponentialDecay', 'LambdaDecay', 'MultiStepDecay', 'LinearWarmup', 'OneCycleLR', 'ReduceOnPlateau', 'LRScheduler', 'PolynomialDecay', 'CosineAnnealingDecay', 'LinearLR', 'StepDecay', 'InverseTimeDecay'} | 18 |
| `/paddle/optimizer/momentum.py` | {'Momentum'} | 1 |
| `/paddle/optimizer/nadam.py` | {'NAdam'} | 1 |
| `/paddle/optimizer/optimizer.py` | {'Optimizer'} | 1 |
| `/paddle/optimizer/radam.py` | {'RAdam'} | 1 |
| `/paddle/optimizer/rmsprop.py` | {'RMSProp'} | 1 |
| `/paddle/optimizer/rprop.py` | {'Rprop'} | 1 |
| `/paddle/optimizer/sgd.py` | {'SGD'} | 1 |
| `/paddle/profiler/profiler.py` | {'make_scheduler', 'Profiler', 'export_chrome_tracing', 'export_protobuf'} | 4 |
| `/paddle/profiler/utils.py` | {'RecordEvent', 'load_profiler_result'} | 2 |
| `/paddle/quantization/base_observer.py` | {'BaseObserver'} | 1 |
| `/paddle/quantization/base_quanter.py` | {'BaseQuanter'} | 1 |
| `/paddle/quantization/config.py` | {'QuantConfig'} | 1 |
| `/paddle/quantization/factory.py` | {'quanter'} | 1 |
| `/paddle/quantization/ptq.py` | {'PTQ'} | 1 |
| `/paddle/quantization/qat.py` | {'QAT'} | 1 |
| `/paddle/regularizer.py` | {'L1Decay', 'L2Decay'} | 2 |
| `/paddle/signal.py` | {'istft', 'stft'} | 2 |
| `/paddle/sparse/binary.py` | {'subtract', 'add', 'matmul', 'divide', 'is_same_shape', 'masked_matmul', 'mask_as', 'multiply', 'mv'} | 9 |
| `/paddle/sparse/creation.py` | {'sparse_coo_tensor', 'sparse_csr_tensor'} | 2 |
| `/paddle/sparse/multiary.py` | {'addmm'} | 1 |
| `/paddle/sparse/nn/functional/activation.py` | {'softmax', 'relu', 'relu6', 'leaky_relu'} | 4 |
| `/paddle/sparse/nn/functional/conv.py` | {'subm_conv2d_igemm', 'subm_conv3d', 'subm_conv3d_igemm', 'conv3d', 'conv2d', 'subm_conv2d'} | 6 |
| `/paddle/sparse/nn/functional/pooling.py` | {'max_pool3d'} | 1 |
| `/paddle/sparse/nn/functional/transformer.py` | {'attention'} | 1 |
| `/paddle/sparse/nn/layer/activation.py` | {'ReLU', 'LeakyReLU', 'Softmax', 'ReLU6'} | 4 |
| `/paddle/sparse/nn/layer/conv.py` | {'Conv3D', 'Conv2D', 'SubmConv2D', 'SubmConv3D'} | 4 |
| `/paddle/sparse/nn/layer/norm.py` | {'BatchNorm', 'SyncBatchNorm'} | 2 |
| `/paddle/sparse/nn/layer/pooling.py` | {'MaxPool3D'} | 1 |
| `/paddle/sparse/unary.py` | {'pca_lowrank', 'coalesce', 'tan', 'abs', 'cast', 'expm1', 'slice', 'asin', 'sqrt', 'square', 'atan', 'pow', 'transpose', 'neg', 'sinh', 'asinh', 'reshape', 'rad2deg', 'sin', 'log1p', 'isnan', 'atanh', 'deg2rad', 'sum', 'tanh'} | 25 |
| `/paddle/static/input.py` | {'InputSpec', 'data'} | 2 |
| `/paddle/static/io.py` | {'deserialize_program', 'save_inference_model', 'load', 'load_program_state', 'normalize_program', 'save_to_file', 'set_program_state', 'serialize_persistables', 'save', 'load_from_file', 'deserialize_persistables', 'serialize_program', 'load_inference_model'} | 13 |
| `/paddle/static/nn/common.py` | {'bilinear_tensor_product', 'data_norm', 'spectral_norm', 'conv3d', 'instance_norm', 'py_func', 'batch_norm', 'conv2d', 'layer_norm', 'row_conv', 'ExponentialMovingAverage', 'prelu', 'sparse_embedding', 'conv2d_transpose', 'conv3d_transpose', 'embedding', 'group_norm', 'deform_conv2d', 'fc'} | 19 |
| `/paddle/static/nn/control_flow.py` | {'switch_case', 'case', 'cond', 'while_loop', 'Print'} | 5 |
| `/paddle/static/nn/loss.py` | {'nce'} | 1 |
| `/paddle/static/nn/metric.py` | {'accuracy', 'auc', 'ctr_metric_bundle'} | 3 |
| `/paddle/static/nn/sequence_lod.py` | {'sequence_conv', 'sequence_softmax', 'sequence_expand_as', 'sequence_unpad', 'sequence_reshape', 'sequence_first_step', 'sequence_slice', 'sequence_expand', 'sequence_last_step', 'sequence_pool', 'sequence_scatter', 'sequence_pad', 'sequence_enumerate'} | 13 |
| `/paddle/static/nn/static_pylayer.py` | {'static_pylayer'} | 1 |
| `/paddle/sysconfig.py` | {'get_include', 'get_lib'} | 2 |
| `/paddle/tensor/attribute.py` | {'shape', 'is_complex', 'is_integer', 'rank', 'is_floating_point', 'imag', 'real'} | 7 |
| `/paddle/tensor/creation.py` | {'full', 'diag', 'eye', 'meshgrid', 'diagflat', 'geometric_', 'full_like', 'linspace', 'polar', 'tril_', 'tril', 'ones', 'cauchy_', 'create_parameter', 'create_global_var', 'diag_embed', 'create_tensor', 'clone', 'empty', 'tril_indices', 'to_tensor', 'zeros', 'triu_', 'complex', 'ones_like', 'logspace', 'triu_indices', 'empty_like', 'triu', 'assign', 'arange', 'zeros_like'} | 32 |
| `/paddle/tensor/einsum.py` | {'einsum'} | 1 |
| `/paddle/tensor/linalg.py` | {'pca_lowrank', 'cholesky', 'lu', 'matrix_norm', 'fp8_fp8_half_gemm_fused', 'qr', 'dot', 'cholesky_inverse', 'lu_unpack', 't_', 'slogdet', 'dist', 'eigvals', 'triangular_solve', 'bmm', 'pinv', 'lstsq', 'transpose_', 'svd', 'det', 'histogramdd', 't', 'histogram', 'transpose', 'cond', 'matrix_rank', 'norm', 'ormqr', 'matrix_exp', 'eigvalsh', 'solve', 'bincount', 'cdist', 'histogram_bin_edges', 'mv', 'matrix_power', 'cholesky_solve', 'matmul', 'cross', 'corrcoef', 'eigh', 'multi_dot', 'svd_lowrank', 'cov', 'householder_product', 'vector_norm', 'eig'} | 47 |
| `/paddle/tensor/logic.py` | {'equal', 'logical_xor', 'bitwise_xor', 'logical_not_', 'bitwise_xor_', 'equal_', 'greater_than', 'logical_not', 'not_equal_', 'greater_equal_', 'bitwise_or', 'logical_xor_', 'less_equal', 'equal_all', 'isclose', 'logical_or_', 'greater_equal', 'not_equal', 'allclose', 'bitwise_and_', 'less_than', 'bitwise_not', 'bitwise_not_', 'bitwise_or_', 'greater_than_', 'less_equal_', 'less_than_', 'is_tensor', 'bitwise_and', 'logical_and', 'is_empty', 'logical_and_', 'logical_or'} | 33 |
| `/paddle/tensor/manipulation.py` | {'fill_', 'tile', 'masked_fill', 'gather', 'unsqueeze_', 'masked_fill_', 'vstack', 'as_complex', 'slice_scatter', 'index_add_', 'index_fill', 'reshape_', 'squeeze', 'dstack', 'repeat_interleave', 'as_strided', 'reshape', 'view_as', 'as_real', 'scatter', 'split', 'flip', 'index_add', 'broadcast_to', 'unbind', 'tolist', 'unstack', 'stack', 'cast_', 'strided_slice', 'cast', 'slice', 'fill_diagonal_tensor_', 'masked_scatter_', 'zero_', 'expand', 'fill_diagonal_tensor', 'moveaxis', 'hstack', 'take_along_axis', 'index_put', 'atleast_2d', 'unique', 'select_scatter', 'diagonal_scatter', 'scatter_nd', 'expand_as', 'view', 'crop', 'unfold', 'shard_index', 'scatter_nd_add', 'rot90', 'roll', 'put_along_axis', 'broadcast_tensors', 'tensor_split', 'atleast_3d', 'vsplit', 'flatten', 'gather_nd', 'block_diag', 'unflatten', 'unsqueeze', 'column_stack', 'masked_scatter', 'atleast_1d', 'row_stack', 'concat', 'index_fill_', 'squeeze_', 'index_put_', 'tensordot', 'fill_diagonal_', 'chunk', 'flatten_', 'unique_consecutive', 'put_along_axis_', 'hsplit', 'scatter_', 'dsplit'} | 81 |
| `/paddle/tensor/math.py` | {'cumprod_', 'atan2', 'angle', 'fmax', 'trunc_', 'gcd', 'neg_', 'isneginf', 'scale_', 'isin', 'take', 'digamma', 'polygamma_', 'tanh_', 'inverse', 'subtract_', 'bitwise_right_shift_', 'log2_', 'hypot', 'vander', 'gammaln', 'divide_', 'nextafter', 'add_', 'clip_', 'frexp', 'sinc', 'conj', 'digamma_', 'isinf', 'add', 'ldexp', 'renorm', 'multigammaln', 'max', 'nansum', 'tanh', 'multiply', 'amin', 'i0e', 'prod', 'logit_', 'cartesian_prod', 'cummax', 'add_n', 'isreal', 'nan_to_num', 'copysign_', 'isposinf', 'reduce_as', 'count_nonzero', 'increment', 'nan_to_num_', 'fmin', 'log10', 'all', 'addmm', 'scale', 'kron', 'minimum', 'renorm_', 'log_', 'cumsum', 'polygamma', 'neg', 'floor_divide', 'logcumsumexp', 'bitwise_right_shift', 'sinc_', 'logit', 'isfinite', 'log1p', 'erfinv', 'log', 'sgn', 'lcm_', 'pow_', 'trunc', 'trace', 'i0', 'lerp_', 'lerp', 'combinations', 'gammaincc', 'remainder', 'nanmean', 'addmm_', 'maximum', 'erfinv_', 'min', 'outer', 'pow', 'i1', 'lgamma', 'broadcast_shape', 'mm', 'gammaincc_', 'log10_', 'deg2rad', 'frac_', 'bitwise_left_shift_', 'trapezoid', 'ldexp_', 'diff', 'hypot_', 'frac', 'i0_', 'amax', 'clip', 'divide', 'lcm', 'multiplex', 'logaddexp', 'lgamma_', 'remainder_', 'subtract', 'bitwise_left_shift', 'any', 'i1e', 'multiply_', 'inner', 'logsumexp', 'floor_divide_', 'log1p_', 'stanh', 'gcd_', 'cumprod', 'gammainc', 'cumulative_trapezoid', 'sign', 'cummin', 'gammainc_', 'diagonal', 'rad2deg', 'copysign', 'signbit', 'isnan', 'cumsum_', 'gammaln_', 'heaviside', 'log2', 'sum', 'multigammaln_'} | 143 |
| `/paddle/tensor/ops.py` | {'floor', 'round', 'cos', 'tan', 'abs', 'expm1', 'exp', 'asin', 'cosh', 'sigmoid', 'acos', 'sqrt', 'square', 'round_', 'atan', 'asinh', 'sinh', 'sin', 'ceil', 'erf', 'acosh', 'atanh', 'reciprocal', 'rsqrt'} | 24 |
| `/paddle/tensor/random.py` | {'multinomial', 'bernoulli_', 'randperm', 'standard_gamma', 'randn', 'randint_like', 'log_normal_', 'binomial', 'bernoulli', 'uniform', 'standard_normal', 'uniform_', 'randint', 'log_normal', 'exponential_', 'normal', 'normal_', 'poisson', 'rand'} | 19 |
| `/paddle/tensor/search.py` | {'nonzero', 'kthvalue', 'where', 'index_select', 'where_', 'masked_select', 'topk', 'sort', 'bucketize', 'argsort', 'argmax', 'mode', 'top_p_sampling', 'index_sample', 'searchsorted', 'argmin'} | 16 |
| `/paddle/tensor/stat.py` | {'nanquantile', 'mean', 'numel', 'nanmedian', 'quantile', 'std', 'var', 'median'} | 8 |
| `/paddle/tensor/to_string.py` | {'set_printoptions'} | 1 |
| `/paddle/text/datasets/conll05.py` | {'Conll05st'} | 1 |
| `/paddle/text/datasets/imdb.py` | {'Imdb'} | 1 |
| `/paddle/text/datasets/imikolov.py` | {'Imikolov'} | 1 |
| `/paddle/text/datasets/movielens.py` | {'Movielens'} | 1 |
| `/paddle/text/datasets/uci_housing.py` | {'UCIHousing'} | 1 |
| `/paddle/text/datasets/wmt14.py` | {'WMT14'} | 1 |
| `/paddle/text/datasets/wmt16.py` | {'WMT16'} | 1 |
| `/paddle/text/viterbi_decode.py` | {'ViterbiDecoder', 'viterbi_decode'} | 2 |
| `/paddle/utils/cpp_extension/cpp_extension.py` | {'CppExtension', 'CUDAExtension', 'setup', 'load'} | 4 |
| `/paddle/utils/cpp_extension/extension_utils.py` | {'get_build_directory'} | 1 |
| `/paddle/utils/deprecated.py` | {'deprecated'} | 1 |
| `/paddle/utils/dlpack.py` | {'from_dlpack', 'to_dlpack'} | 2 |
| `/paddle/utils/download.py` | {'get_weights_path_from_url'} | 1 |
| `/paddle/utils/install_check.py` | {'run_check'} | 1 |
| `/paddle/utils/lazy_import.py` | {'try_import'} | 1 |
| `/paddle/version/__init__.py` | {'xpu_xhpc', 'xpu', 'xpu_xccl', 'xpu_xre', 'cuda', 'cudnn', 'show', 'nccl'} | 8 |
| `/paddle/vision/datasets/cifar.py` | {'Cifar100', 'Cifar10'} | 2 |
| `/paddle/vision/datasets/flowers.py` | {'Flowers'} | 1 |
| `/paddle/vision/datasets/folder.py` | {'DatasetFolder', 'ImageFolder'} | 2 |
| `/paddle/vision/datasets/mnist.py` | {'FashionMNIST', 'MNIST'} | 2 |
| `/paddle/vision/datasets/voc2012.py` | {'VOC2012'} | 1 |
| `/paddle/vision/image.py` | {'set_image_backend', 'image_load', 'get_image_backend'} | 3 |
| `/paddle/vision/models/alexnet.py` | {'alexnet', 'AlexNet'} | 2 |
| `/paddle/vision/models/densenet.py` | {'densenet264', 'densenet201', 'densenet161', 'densenet121', 'densenet169', 'DenseNet'} | 6 |
| `/paddle/vision/models/googlenet.py` | {'GoogLeNet', 'googlenet'} | 2 |
| `/paddle/vision/models/inceptionv3.py` | {'inception_v3', 'InceptionV3'} | 2 |
| `/paddle/vision/models/lenet.py` | {'LeNet'} | 1 |
| `/paddle/vision/models/mobilenetv1.py` | {'MobileNetV1', 'mobilenet_v1'} | 2 |
| `/paddle/vision/models/mobilenetv2.py` | {'MobileNetV2', 'mobilenet_v2'} | 2 |
| `/paddle/vision/models/mobilenetv3.py` | {'mobilenet_v3_small', 'MobileNetV3Large', 'mobilenet_v3_large', 'MobileNetV3Small'} | 4 |
| `/paddle/vision/models/resnet.py` | {'resnet50', 'resnet101', 'resnet34', 'resnext101_32x4d', 'resnext101_64x4d', 'wide_resnet50_2', 'resnet18', 'resnext50_32x4d', 'wide_resnet101_2', 'resnext50_64x4d', 'resnext152_32x4d', 'resnext152_64x4d', 'ResNet', 'resnet152'} | 14 |
| `/paddle/vision/models/shufflenetv2.py` | {'shufflenet_v2_x0_33', 'shufflenet_v2_swish', 'ShuffleNetV2', 'shufflenet_v2_x1_5', 'shufflenet_v2_x0_25', 'shufflenet_v2_x0_5', 'shufflenet_v2_x1_0', 'shufflenet_v2_x2_0'} | 8 |
| `/paddle/vision/models/squeezenet.py` | {'squeezenet1_1', 'squeezenet1_0', 'SqueezeNet'} | 3 |
| `/paddle/vision/models/vgg.py` | {'vgg13', 'vgg19', 'VGG', 'vgg11', 'vgg16'} | 5 |
| `/paddle/vision/ops.py` | {'RoIPool', 'yolo_loss', 'decode_jpeg', 'generate_proposals', 'distribute_fpn_proposals', 'box_coder', 'yolo_box', 'psroi_pool', 'deform_conv2d', 'matrix_nms', 'prior_box', 'roi_pool', 'DeformConv2D', 'nms', 'read_file', 'RoIAlign', 'roi_align', 'PSRoIPool'} | 18 |
| `/paddle/vision/transforms/functional.py` | {'normalize', 'hflip', 'to_tensor', 'erase', 'adjust_hue', 'crop', 'vflip', 'pad', 'rotate', 'center_crop', 'affine', 'adjust_brightness', 'to_grayscale', 'perspective', 'resize', 'adjust_contrast'} | 16 |
| 总计: 309 | ~ | 1429 |

</details>

@sunzhongkai588 @SigureMo 