### PR TITLE
[CodeStyle] Enable more useful Ruff rules

### DIFF
--- a/docs/api/gen_alias_api.py
+++ b/docs/api/gen_alias_api.py
@@ -141,7 +141,7 @@ class AliasAPIGen:
         # sort others api by path length
         api_list.sort(key=lambda api: api.count("."))
 
-        return [real_api] + [rec_api] + api_list
+        return [real_api, rec_api, *api_list]
 
     def filter_api(self, api_list):
         for api in api_list:

--- a/docs/guides/model_convert/convert_from_pytorch/tools/validate_mapping_files.py
+++ b/docs/guides/model_convert/convert_from_pytorch/tools/validate_mapping_files.py
@@ -190,7 +190,7 @@ def get_meta_from_diff_file(
     signature_cache = None
 
     with open(filepath, "r", encoding="utf-8") as f:
-        for line in f.readlines():
+        for line in f:
             # 现在需要考虑内容信息了
             # if not line.startswith("##"):
             #     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,26 @@ select = [
     "TCH",
 
     # Ruff-specific rules
+    "RUF005",
+    "RUF008",
+    "RUF009",
     "RUF010",
+    "RUF013",
+    "RUF015",
+    "RUF016",
+    "RUF017",
+    "RUF018",
+    "RUF019",
+    "RUF020",
+    "RUF024",
+    "RUF026",
     "RUF100",
+
+    # Flake8-raise
+    "RSE",
+
+    # Refurb
+    "FURB",
 ]
 unfixable = [
     "NPY001"


### PR DESCRIPTION
PaddlePaddle/Paddle#67291 的同步，Ruff rules 扩量支持

只不过 flake8-quotes[^1] 相关 rules 并没有在这边启用，因为 docs 使用 ruff formatter，而文档中并不推荐 formatter 与 flake8-quotes 系列 rules 一起使用，并不是因为冲突，而是 formatter 会自动修复这些问题，使得 flake8-quotes rules 变得冗余

[^1]: https://docs.astral.sh/ruff/rules/#flake8-quotes-q