### PR TITLE
[Typing][Fix] 使英文文档中 API 不显示 `type hints`

### DIFF
--- a/ci_scripts/doc-build-config/en/conf.py
+++ b/ci_scripts/doc-build-config/en/conf.py
@@ -104,9 +104,8 @@ language = "en"
 version = ""
 templates_path = ["/templates"]
 
-# Show type hints in the description
-autodoc_typehints = "description"
-autodoc_typehints_description_target = "documented"
+# Do NOT show type hints
+autodoc_typehints = "none"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/ci_scripts/doc-build-config/en/conf.py
+++ b/ci_scripts/doc-build-config/en/conf.py
@@ -105,7 +105,7 @@ version = ""
 templates_path = ["/templates"]
 
 # Show type hints in the description
-autodoc_typehints = "none"
+autodoc_typehints = "description"
 autodoc_typehints_description_target = "documented"
 
 # There are two options for replacing |today|: either, you set today to some

--- a/ci_scripts/doc-build-config/en/conf.py
+++ b/ci_scripts/doc-build-config/en/conf.py
@@ -105,7 +105,7 @@ version = ""
 templates_path = ["/templates"]
 
 # Show type hints in the description
-autodoc_typehints = "description"
+autodoc_typehints = "none"
 autodoc_typehints_description_target = "documented"
 
 # There are two options for replacing |today|: either, you set today to some

--- a/ci_scripts/doc-build-config/zh/conf.py
+++ b/ci_scripts/doc-build-config/zh/conf.py
@@ -139,9 +139,8 @@ version = ""
 
 # html_permalinks_icon='P'
 
-# Show type hints in the description
-autodoc_typehints = "description"
-autodoc_typehints_description_target = "documented"
+# Do NOT show type hints
+autodoc_typehints = "none"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

使英文文档中 API 签名不显示 `type hints`。

之前的 PR https://github.com/PaddlePaddle/docs/pull/6676 中设置 sphinx 不在接口签名中显示 `type hints` ，

![image](https://github.com/PaddlePaddle/docs/assets/26616326/899b505d-f99b-4ac0-a835-e13089765649)

但，不知道这段时间有什么地方引入了 BUG ，使之前的设置不生效了 ... ... 

目前 （20240826 ）接口的英文文档

![image](https://github.com/user-attachments/assets/ff0dd986-003a-499b-9234-5bd6ab4ff979)

特此，重新设置 `autodoc_typehints = "none"` ，看一下是否生效 ～

@sunzhongkai588  @SigureMo 
