### PR TITLE
[numel] Add uint8, int8, complex64, complex128 in numel cn doc

### DIFF
--- a/docs/api/paddle/numel_cn.rst
+++ b/docs/api/paddle/numel_cn.rst
@@ -11,7 +11,7 @@ numel
 参数
 ::::::::::::
 
-    - **x** (Tensor) - 输入 Tensor，数据类型为 int32、int64、float16、float32、float64、int32、int64。
+    - **x** (Tensor) - 输入 Tensor，数据类型为 int32、int64、float16、float32、float64、uint8、int8、int32、int64、complex64、complex128。
     - **name** (str, 可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回


### PR DESCRIPTION
`numel`文档添加 `uint8`, `int8`，并补充原本缺失的 `complex64`, `complex128`，相关PR：<https://github.com/PaddlePaddle/Paddle/pull/68227>