### PR TITLE
[NVIDIA] Refine API difference of `all_gather_object`

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.all_gather_object.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.all_gather_object.md
@@ -18,7 +18,7 @@ paddle.distributed.all_gather_object(object_list, obj, group=None)
 
 | PyTorch  | PaddlePaddle | 备注                                          |
 | -------- | ------------ | --------------------------------------------- |
-| object_list |             | 表示用于保存聚合结果的列表。需初始化成与group等长的列表 |
+| object_list |             | 表示用于保存聚合结果的列表。需初始化成与 `group` 等长的列表 |
 |             | object_list | 表示用于保存聚合结果的列表。需初始化成空列表           |
 | obj      | obj          | 表示待聚合的对象。                  |
 | group    | group        | 表示执行该操作的进程组实例。                            |
@@ -28,7 +28,7 @@ paddle.distributed.all_gather_object(object_list, obj, group=None)
 ```python
 # PyTorch 写法
 import torch.distributed as dist
-object_list = [{}, {}] #NOTE: world size is 2
+object_list = [{}, {}] # NOTE: world size is 2
 if dist.get_rank() == 0:
     obj = {"foo": [1, 2, 3]}
 else:
@@ -37,7 +37,7 @@ dist.all_gather_object(object_list, obj)
 
 # Paddle 写法
 import paddle.distributed as dist
-object_list = [] #No need to pre-allocate
+object_list = [] # No need to pre-allocate
 if dist.get_rank() == 0:
     obj = {"foo": [1, 2, 3]}
 else:

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.all_gather_object.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/distributed/torch.distributed.all_gather_object.md
@@ -12,12 +12,35 @@ torch.distributed.all_gather_object(object_list, obj, group=None)
 paddle.distributed.all_gather_object(object_list, obj, group=None)
 ```
 
-功能一致，参数完全一致，具体如下：
+功能一致，参数几乎完全一致。但`object_list`的初始化方式不同。具体如下：
 
 ### 参数映射
 
 | PyTorch  | PaddlePaddle | 备注                                          |
 | -------- | ------------ | --------------------------------------------- |
-| object_list   | object_list       | 表示用于保存聚合结果的列表。                           |
+| object_list |             | 表示用于保存聚合结果的列表。需初始化成与group等长的列表 |
+|             | object_list | 表示用于保存聚合结果的列表。需初始化成空列表           |
 | obj      | obj          | 表示待聚合的对象。                  |
 | group    | group        | 表示执行该操作的进程组实例。                            |
+
+### 转写示例
+
+```python
+# PyTorch 写法
+import torch.distributed as dist
+object_list = [{}, {}] #NOTE: world size is 2
+if dist.get_rank() == 0:
+    obj = {"foo": [1, 2, 3]}
+else:
+    obj = {"bar": [4, 5, 6]}
+dist.all_gather_object(object_list, obj)
+
+# Paddle 写法
+import paddle.distributed as dist
+object_list = [] #No need to pre-allocate
+if dist.get_rank() == 0:
+    obj = {"foo": [1, 2, 3]}
+else:
+    obj = {"bar": [4, 5, 6]}
+dist.all_gather_object(object_list, obj)
+```


### PR DESCRIPTION
Unlike PyTorch, using paddle don't need to pre-allocate `object_list` to equal size of group size.