### PR TITLE
bump `dochooks` version to `v0.4.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
     -   id: remove-tabs
         types: [text]
 # Document hooks
--   repo: https://github.com/ShigureLab/dochooks
-    rev: v0.3.0
+-   repo: https://github.com/PFCCLab/dochooks
+    rev: v0.4.0
     hooks:
     -   id: insert-whitespace-between-cn-and-en-char
         files: \.md$|\.rst$

--- a/docs/install/index_cn.rst
+++ b/docs/install/index_cn.rst
@@ -96,12 +96,12 @@
             python -m pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
 
     (2). **GPU 版本** ：如果您想使用 GPU 版本请参考如下命令安装
-        
+
         注意：
 
-            * 如果您想要安装CUDA 12.3版本，该版本需要libstdc++.so.6的版本大于3.4.30。为了满足此要求，您可以选择安装GCC 12版本，或者单独升级libstdc++库。
+            * 如果您想要安装 CUDA 12.3 版本，该版本需要 libstdc++.so.6 的版本大于 3.4.30。为了满足此要求，您可以选择安装 GCC 12 版本，或者单独升级 libstdc++库。
 
-            * 如果你想要安装CUDA 11.8版本，该版本要求libstdc++.so.6的版本大于3.4.25。为了满足此要求，您可以选择安装GCC 8或者更高的GCC版本，或者单独升级libstdc++库。
+            * 如果你想要安装 CUDA 11.8 版本，该版本要求 libstdc++.so.6 的版本大于 3.4.25。为了满足此要求，您可以选择安装 GCC 8 或者更高的 GCC 版本，或者单独升级 libstdc++库。
 
         安装 GPU cuda12.3 版本的命令为：
         ::


### PR DESCRIPTION
[dochooks](https://github.com/PFCCLab/dochooks) 已经迁移到 PFCCLab，修改一下路径，虽然旧的路径也没啥问题

另外发了个新版，顺带升个级