### PR TITLE
新增 torchvision 和 paddle.vision 的对应关系（第三批）

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.datasets.VOCDetection.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.datasets.VOCDetection.md
@@ -3,7 +3,7 @@
 ### [torchvision.datasets.VOCDetection](https://pytorch.org/vision/main/generated/torchvision.datasets.VOCDetection.html)
 
 ```python
-torchvision.datasets.VOCDetection(root: Union[str, Path], year: str = '2012', image_set: str = 'train', download: bool = False, transform: Optional[Callable] = None, target_transform: Optional[Callable] = None)
+torchvision.datasets.VOCDetection(root: Union[str, Path], year: str = '2012', image_set: str = 'train', download: bool = False, transform: Optional[Callable] = None, target_transform: Optional[Callable] = None, transforms: Optional[Callable] = None)
 ```
 
 ### [paddle.vision.datasets.VOC2012](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/datasets/VOC2012_cn.html)
@@ -24,6 +24,7 @@ paddle.vision.datasets.VOC2012(data_file: Optional[str] = None, mode: str = 'tra
 | transform              | transform             | 图片数据的预处理。           |
 | target_transform       | -                     | 接受目标数据并转换，Paddle 无此参数，暂无转写方式。    |
 | download               | download              | 是否自动下载数据集文件。 |
+| transforms             | -                     | 输入样本及其目标，返回转换后的版本，Paddle 无此参数，暂无转写方式。 |
 | -                      | backend               | 指定图像类型，PyTorch 无此参数，Paddle 保持默认即可。 |
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
@@ -19,7 +19,7 @@ paddle.vision.models.alexnet(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 AlexNet_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.alexnet
+
+### [torchvision.models.alexnet](https://pytorch.org/vision/stable/models/alexnet.html)
+
+```python
+torchvision.models.alexnet(*, weights: Optional[AlexNet_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.alexnet](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/alexnet_cn.html)
+
+```python
+paddle.vision.models.alexnet(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 AlexNet_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
@@ -18,6 +18,16 @@ paddle.vision.models.alexnet(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 AlexNet_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 AlexNet_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.alexnet(weights=torchvision.models.AlexNet_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.alexnet(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.alexnet.md
@@ -1,6 +1,6 @@
 ## [输入参数类型不一致]torchvision.models.alexnet
 
-### [torchvision.models.alexnet](https://pytorch.org/vision/stable/models/alexnet.html)
+### [torchvision.models.alexnet](https://pytorch.org/vision/stable/models/generated/torchvision.models.alexnet.html)
 
 ```python
 torchvision.models.alexnet(*, weights: Optional[AlexNet_Weights] = None, progress: bool = True, **kwargs: Any)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet121.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet121.md
@@ -19,7 +19,7 @@ paddle.vision.models.densenet121(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet121_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet121.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet121.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.densenet121
+
+### [torchvision.models.densenet121](https://pytorch.org/vision/main/models/generated/torchvision.models.densenet121.html)
+
+```python
+torchvision.models.densenet121(*, weights: Optional[DenseNet121_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.densenet121](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/densenet121_cn.html)
+
+```python
+paddle.vision.models.densenet121(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet121_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet121.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet121.md
@@ -18,6 +18,16 @@ paddle.vision.models.densenet121(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet121_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet121_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.densenet121(weights=torchvision.models.DenseNet121_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.densenet121(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet161.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet161.md
@@ -19,7 +19,7 @@ paddle.vision.models.densenet161(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet161_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet161.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet161.md
@@ -18,6 +18,17 @@ paddle.vision.models.densenet161(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet161_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet161_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.densenet161(weights=torchvision.models.DenseNet161_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.densenet161(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet161.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet161.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.densenet161
+
+### [torchvision.models.densenet161](https://pytorch.org/vision/main/models/generated/torchvision.models.densenet161.html)
+
+```python
+torchvision.models.densenet161(*, weights: Optional[DenseNet161_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.densenet161](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/densenet161_cn.html)
+
+```python
+paddle.vision.models.densenet161(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet161_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet169.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet169.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.densenet169
+
+### [torchvision.models.densenet169](https://pytorch.org/vision/main/models/generated/torchvision.models.densenet169.html)
+
+```python
+torchvision.models.densenet169(*, weights: Optional[DenseNet169_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.densenet169](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/densenet169_cn.html)
+
+```python
+paddle.vision.models.densenet169(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet169_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet169.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet169.md
@@ -18,6 +18,16 @@ paddle.vision.models.densenet169(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet169_Weights 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet169_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.densenet169(weights=torchvision.models.DenseNet169_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.densenet169(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet201.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet201.md
@@ -19,7 +19,7 @@ paddle.vision.models.densenet201(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet201_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet201.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet201.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.densenet201
+
+### [torchvision.models.densenet201](https://pytorch.org/vision/main/models/generated/torchvision.models.densenet201.html)
+
+```python
+torchvision.models.densenet201(*, weights: Optional[DenseNet201_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.densenet201](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/densenet201_cn.html)
+
+```python
+paddle.vision.models.densenet201(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet201_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet201.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.densenet201.md
@@ -18,6 +18,17 @@ paddle.vision.models.densenet201(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 DenseNet201_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 DenseNet201_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.densenet201(weights=torchvision.models.DenseNet201_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.densenet201(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.googlenet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.googlenet.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.googlenet
+
+### [torchvision.models.googlenet](https://pytorch.org/vision/main/models/generated/torchvision.models.googlenet.html)
+
+```python
+torchvision.models.googlenet(*, weights: Optional[GoogLeNet_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.googlenet](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/googlenet_cn.html)
+
+```python
+paddle.vision.models.googlenet(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 GoogLeNet_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.googlenet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.googlenet.md
@@ -18,6 +18,16 @@ paddle.vision.models.googlenet(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 GoogLeNet_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 GoogLeNet_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.googlenet(weights=torchvision.models.GoogLeNet_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.googlenet(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.googlenet.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.googlenet.md
@@ -19,7 +19,7 @@ paddle.vision.models.googlenet(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 GoogLeNet_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.inception_v3.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.inception_v3.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.inception_v3
+
+### [torchvision.models.inception_v3](https://pytorch.org/vision/main/models/generated/torchvision.models.inception_v3.html)
+
+```python
+torchvision.models.inception_v3(*, weights: Optional[Inception_V3_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.inception_v3](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/inception_v3_cn.html)
+
+```python
+paddle.vision.models.inception_v3(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 Inception_V3_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.inception_v3.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.inception_v3.md
@@ -18,6 +18,16 @@ paddle.vision.models.inception_v3(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 Inception_V3_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 Inception_V3_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.inception_v3(weights=torchvision.models.Inception_V3_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.inception_v3(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.inception_v3.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.inception_v3.md
@@ -19,7 +19,7 @@ paddle.vision.models.inception_v3(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 Inception_V3_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
@@ -21,7 +21,7 @@ paddle.vision.models.mobilenet_v2(pretrained=False, scale=1.0, **kwargs)
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 MobileNet_V2_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | -           | scale        | 模型通道数的缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.mobilenet_v2
+
+### [torchvision.models.mobilenet_v2](https://pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html)
+
+```python
+torchvision.models.mobilenet_v2(*, weights: Optional[MobileNet_V2_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.mobilenet_v2](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/mobilenet_v2_cn.html)
+
+```python
+paddle.vision.models.mobilenet_v2(pretrained=False, scale=1.0, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 MobileNet_V2_Weights 类型，需要转写。|
+| -           | scale        | 模型通道数的缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
@@ -12,7 +12,8 @@ torchvision.models.mobilenet_v2(*, weights: Optional[MobileNet_V2_Weights] = Non
 paddle.vision.models.mobilenet_v2(pretrained=False, scale=1.0, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 MobileNet_V2_Weights.IMAGENET1K_V1 和 MobileNet_V2_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v2.md
@@ -19,7 +19,17 @@ paddle.vision.models.mobilenet_v2(pretrained=False, scale=1.0, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 MobileNet_V2_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 MobileNet_V2_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | -           | scale        | 模型通道数的缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.mobilenet_v2(weights=torchvision.models.MobileNet_V2_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.mobilenet_v2(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
@@ -20,7 +20,7 @@ paddle.vision.models.mobilenet_v3_large(pretrained=False, scale=1.0, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 MobileNet_V3_Large_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | -           | scale        | 通道数缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
@@ -19,7 +19,17 @@ paddle.vision.models.mobilenet_v3_large(pretrained=False, scale=1.0, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 MobileNet_V3_Large_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 MobileNet_V3_Large_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | scale        | 通道数缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.mobilenet_v3_large(weights=torchvision.models.MobileNet_V3_Large_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.mobilenet_v3_large(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
@@ -12,7 +12,8 @@ torchvision.models.mobilenet_v3_large(*, weights: Optional[MobileNet_V3_Large_We
 paddle.vision.models.mobilenet_v3_large(pretrained=False, scale=1.0, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 MobileNet_V3_Large_Weights.IMAGENET1K_V1 和 MobileNet_V3_Large_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_large.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.mobilenet_v3_large
+
+### [torchvision.models.mobilenet_v3_large](https://pytorch.org/vision/main/models/generated/torchvision.models.mobilenet_v3_large.html)
+
+```python
+torchvision.models.mobilenet_v3_large(*, weights: Optional[MobileNet_V3_Large_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.mobilenet_v3_large](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/mobilenet_v3_large_cn.html)
+
+```python
+paddle.vision.models.mobilenet_v3_large(pretrained=False, scale=1.0, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 MobileNet_V3_Large_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | scale        | 通道数缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_small.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_small.md
@@ -18,7 +18,17 @@ paddle.vision.models.mobilenet_v3_small(pretrained=False, scale=1.0, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 MobileNet_V3_Small_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 MobileNet_V3_Small_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | scale        | 通道数缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.mobilenet_v3_small(weights=torchvision.models.MobileNet_V3_Small_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.mobilenet_v3_small(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_small.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_small.md
@@ -19,7 +19,7 @@ paddle.vision.models.mobilenet_v3_small(pretrained=False, scale=1.0, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 MobileNet_V3_Small_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | -           | scale        | 通道数缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_small.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.mobilenet_v3_small.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.mobilenet_v3_small
+
+### [torchvision.models.mobilenet_v3_small](https://pytorch.org/vision/main/models/generated/torchvision.models.mobilenet_v3_small.html)
+
+```python
+torchvision.models.mobilenet_v3_small(*, weights: Optional[MobileNet_V3_Small_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.mobilenet_v3_small](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/mobilenet_v3_small_cn.html)
+
+```python
+paddle.vision.models.mobilenet_v3_small(pretrained=False, scale=1.0, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 MobileNet_V3_Small_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | scale        | 通道数缩放比例，PyTorch 无此参数，Paddle 保持默认即可。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
@@ -12,7 +12,8 @@ torchvision.models.resnet101(*, weights: Optional[ResNet101_Weights] = None, pro
 paddle.vision.models.resnet101(pretrained=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 ResNet101_Weights.IMAGENET1K_V1 和 ResNet101_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnet101
+
+### [torchvision.models.resnet101](https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet101.html)
+
+```python
+torchvision.models.resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnet101](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnet101_cn.html)
+
+```python
+paddle.vision.models.resnet101(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet101_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
@@ -19,6 +19,16 @@ paddle.vision.models.resnet101(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet101_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet101_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnet101(weights=torchvision.models.ResNet101_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnet101(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet101.md
@@ -20,7 +20,7 @@ paddle.vision.models.resnet101(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet101_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
@@ -12,7 +12,8 @@ torchvision.models.resnet152(*, weights: Optional[ResNet152_Weights] = None, pro
 paddle.vision.models.resnet152(pretrained=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 ResNet152_Weights.IMAGENET1K_V1 和 ResNet152_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
@@ -20,7 +20,7 @@ paddle.vision.models.resnet152(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet152_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnet152
+
+### [torchvision.models.resnet152](https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet152.html)
+
+```python
+torchvision.models.resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnet152](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnet152_cn.html)
+
+```python
+paddle.vision.models.resnet152(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet152_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet152.md
@@ -19,6 +19,16 @@ paddle.vision.models.resnet152(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet152_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet152_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnet152(weights=torchvision.models.ResNet152_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnet152(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet18.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet18.md
@@ -18,6 +18,16 @@ paddle.vision.models.resnet18(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet18_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet18_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnet18(weights=torchvision.models.ResNet18_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnet18(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet18.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet18.md
@@ -19,7 +19,7 @@ paddle.vision.models.resnet18(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet18_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet18.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet18.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnet18
+
+### [torchvision.models.resnet18](https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet18.html)
+
+```python
+torchvision.models.resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnet18](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnet18_cn.html)
+
+```python
+paddle.vision.models.resnet18(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet18_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet34.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet34.md
@@ -18,6 +18,16 @@ paddle.vision.models.resnet34(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet34_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet34_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnet34(weights=torchvision.models.ResNet34_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnet34(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet34.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet34.md
@@ -19,7 +19,7 @@ paddle.vision.models.resnet34(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet34_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet34.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet34.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnet34
+
+### [torchvision.models.resnet34](https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet34.html)
+
+```python
+torchvision.models.resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnet34](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnet34_cn.html)
+
+```python
+paddle.vision.models.resnet34(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet34_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnet50
+
+### [torchvision.models.resnet50](https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet50.html)
+
+```python
+torchvision.models.resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnet50](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnet50_cn.html)
+
+```python
+paddle.vision.models.resnet50(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet50_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
@@ -12,7 +12,8 @@ torchvision.models.resnet50(*, weights: Optional[ResNet50_Weights] = None, progr
 paddle.vision.models.resnet50(pretrained=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 ResNet50_Weights.IMAGENET1K_V1 和 ResNet50_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
@@ -19,6 +19,16 @@ paddle.vision.models.resnet50(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNet50_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet50_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnet50(weights=torchvision.models.ResNet50_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnet50(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnet50.md
@@ -20,7 +20,7 @@ paddle.vision.models.resnet50(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNet50_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext101_64x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext101_64x4d.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnext101_64x4d
+
+### [torchvision.models.resnext101_64x4d](https://pytorch.org/vision/main/models/generated/torchvision.models.resnext101_64x4d.html)
+
+```python
+torchvision.models.resnext101_64x4d(*, weights: Optional[ResNeXt101_64X4D_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnext101_64x4d](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnext101_64x4d_cn.html)
+
+```python
+paddle.vision.models.resnext101_64x4d(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNeXt101_64X4D_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext101_64x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext101_64x4d.md
@@ -18,6 +18,16 @@ paddle.vision.models.resnext101_64x4d(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNeXt101_64X4D_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNeXt101_64X4D_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnext101_64x4d(weights=torchvision.models.ResNeXt101_64X4D_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnext101_64x4d(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext101_64x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext101_64x4d.md
@@ -19,7 +19,7 @@ paddle.vision.models.resnext101_64x4d(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNeXt101_64X4D_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.resnext50_32x4d
+
+### [torchvision.models.resnext50_32x4d](https://pytorch.org/vision/main/models/generated/torchvision.models.resnext50_32x4d.html)
+
+```python
+torchvision.models.resnext50_32x4d(*, weights: Optional[ResNeXt50_32X4D_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.resnext50_32x4d](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/resnext50_32x4d_cn.html)
+
+```python
+paddle.vision.models.resnext50_32x4d(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNeXt50_32X4D_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
@@ -12,7 +12,8 @@ torchvision.models.resnext50_32x4d(*, weights: Optional[ResNeXt50_32X4D_Weights]
 paddle.vision.models.resnext50_32x4d(pretrained=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 ResNeXt50_32X4D_Weights.IMAGENET1K_V1 和 ResNeXt50_32X4D_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
@@ -20,7 +20,7 @@ paddle.vision.models.resnext50_32x4d(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNeXt50_32X4D_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.resnext50_32x4d.md
@@ -19,6 +19,16 @@ paddle.vision.models.resnext50_32x4d(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ResNeXt50_32X4D_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ResNeXt50_32X4D_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.resnext50_32x4d(weights=torchvision.models.ResNeXt50_32X4D_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.resnext50_32x4d(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x0_5.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x0_5.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.shufflenet_v2_x0_5
+
+### [torchvision.models.shufflenet_v2_x0_5](https://pytorch.org/vision/main/models/generated/torchvision.models.shufflenet_v2_x0_5.html)
+
+```python
+torchvision.models.shufflenet_v2_x0_5(*, weights: Optional[ShuffleNet_V2_X0_5_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.shufflenet_v2_x0_5](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/shufflenet_v2_x0_5_cn.html)
+
+```python
+paddle.vision.models.shufflenet_v2_x0_5(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X0_5_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x0_5.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x0_5.md
@@ -18,6 +18,16 @@ paddle.vision.models.shufflenet_v2_x0_5(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X0_5_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X0_5_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.shufflenet_v2_x0_5(weights=torchvision.models.ShuffleNet_V2_X0_5_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.shufflenet_v2_x0_5(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x0_5.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x0_5.md
@@ -19,7 +19,7 @@ paddle.vision.models.shufflenet_v2_x0_5(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X0_5_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_0.md
@@ -19,7 +19,7 @@ paddle.vision.models.shufflenet_v2_x1_0(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X1_0_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_0.md
@@ -18,6 +18,16 @@ paddle.vision.models.shufflenet_v2_x1_0(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X1_0_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X1_0_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.shufflenet_v2_x1_0(weights=torchvision.models.ShuffleNet_V2_X1_0_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.shufflenet_v2_x1_0(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_0.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.shufflenet_v2_x1_0
+
+### [torchvision.models.shufflenet_v2_x1_0](https://pytorch.org/vision/main/models/generated/torchvision.models.shufflenet_v2_x1_0.html)
+
+```python
+torchvision.models.shufflenet_v2_x1_0(*, weights: Optional[ShuffleNet_V2_X1_0_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.shufflenet_v2_x1_0](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/shufflenet_v2_x1_0_cn.html)
+
+```python
+paddle.vision.models.shufflenet_v2_x1_0(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X1_0_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_5.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_5.md
@@ -18,6 +18,16 @@ paddle.vision.models.shufflenet_v2_x1_5(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X1_5_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X1_5_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.shufflenet_v2_x1_5(weights=torchvision.models.ShuffleNet_V2_X1_5_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.shufflenet_v2_x1_5(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_5.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_5.md
@@ -19,7 +19,7 @@ paddle.vision.models.shufflenet_v2_x1_5(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X1_5_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_5.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x1_5.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.shufflenet_v2_x1_5
+
+### [torchvision.models.shufflenet_v2_x1_5](https://pytorch.org/vision/main/models/generated/torchvision.models.shufflenet_v2_x1_5.html)
+
+```python
+torchvision.models.shufflenet_v2_x1_5(*, weights: Optional[ShuffleNet_V2_X1_5_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.shufflenet_v2_x1_5](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/shufflenet_v2_x1_5_cn.html)
+
+```python
+paddle.vision.models.shufflenet_v2_x1_5(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X1_5_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x2_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x2_0.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.shufflenet_v2_x2_0
+
+### [torchvision.models.shufflenet_v2_x2_0](https://pytorch.org/vision/main/models/generated/torchvision.models.shufflenet_v2_x2_0.html)
+
+```python
+torchvision.models.shufflenet_v2_x2_0(*, weights: Optional[ShuffleNet_V2_X2_0_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.shufflenet_v2_x2_0](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/shufflenet_v2_x2_0_cn.html)
+
+```python
+paddle.vision.models.shufflenet_v2_x2_0(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X2_0_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x2_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x2_0.md
@@ -18,6 +18,16 @@ paddle.vision.models.shufflenet_v2_x2_0(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 ShuffleNet_V2_X2_0_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X2_0_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.shufflenet_v2_x2_0(weights=torchvision.models.ShuffleNet_V2_X2_0_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.shufflenet_v2_x2_0(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x2_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.shufflenet_v2_x2_0.md
@@ -19,7 +19,7 @@ paddle.vision.models.shufflenet_v2_x2_0(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 ShuffleNet_V2_X2_0_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_0.md
@@ -18,6 +18,16 @@ paddle.vision.models.squeezenet1_0(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 SqueezeNet1_0_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 SqueezeNet1_0_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.squeezenet1_0(weights=torchvision.models.SqueezeNet1_0_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.squeezenet1_0(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_0.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.squeezenet1_0
+
+### [torchvision.models.squeezenet1_0](https://pytorch.org/vision/main/models/generated/torchvision.models.squeezenet1_0.html)
+
+```python
+torchvision.models.squeezenet1_0(*, weights: Optional[SqueezeNet1_0_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.squeezenet1_0](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/squeezenet1_0_cn.html)
+
+```python
+paddle.vision.models.squeezenet1_0(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 SqueezeNet1_0_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_0.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_0.md
@@ -19,7 +19,7 @@ paddle.vision.models.squeezenet1_0(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 SqueezeNet1_0_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_1.md
@@ -18,6 +18,16 @@ paddle.vision.models.squeezenet1_1(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 SqueezeNet1_1_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 SqueezeNet1_1_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.squeezenet1_1(weights=torchvision.models.SqueezeNet1_1_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.squeezenet1_1(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_1.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.squeezenet1_1
+
+### [torchvision.models.squeezenet1_1](https://pytorch.org/vision/main/models/generated/torchvision.models.squeezenet1_1.html)
+
+```python
+torchvision.models.squeezenet1_1(*, weights: Optional[SqueezeNet1_1_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.squeezenet1_1](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/squeezenet1_1_cn.html)
+
+```python
+paddle.vision.models.squeezenet1_1(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 SqueezeNet1_1_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.squeezenet1_1.md
@@ -19,7 +19,7 @@ paddle.vision.models.squeezenet1_1(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 SqueezeNet1_1_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
@@ -30,5 +30,5 @@ paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
 torchvision.models.vgg11(weights=torchvision.models.VGG11_Weights.DEFAULT)
 
 # Paddle 写法
-paddle.vision.models.vgg11(pretrained=True, batch_norm=False)
+paddle.vision.models.vgg11(pretrained=True)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg11
+
+### [torchvision.models.vgg11](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg11.html)
+
+```python
+torchvision.models.vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg11](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg11_cn.html)
+
+```python
+paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG11_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
@@ -19,8 +19,8 @@ paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG11_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
-| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG11_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG11_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg11(weights=torchvision.models.VGG11_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg11(pretrained=True, batch_norm=False)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11_bn.md
@@ -19,7 +19,7 @@ paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG11_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11_bn.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg11_bn
+
+### [torchvision.models.vgg11_bn](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg11_bn.html)
+
+```python
+torchvision.models.vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg11](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg11_cn.html)
+
+```python
+paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG11_BN_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg11_bn.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg11(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG11_BN_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG11_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg11_bn(weights=torchvision.models.VGG11_BN_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg11_bn(pretrained=True, batch_norm=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
@@ -19,8 +19,8 @@ paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG13_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
-| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
@@ -30,5 +30,5 @@ paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
 torchvision.models.vgg13(weights=torchvision.models.VGG13_Weights.DEFAULT)
 
 # Paddle 写法
-paddle.vision.models.vgg13(pretrained=True, batch_norm=False)
+paddle.vision.models.vgg13(pretrained=True)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg13
+
+### [torchvision.models.vgg13](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg13.html)
+
+```python
+torchvision.models.vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg13](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg13_cn.html)
+
+```python
+paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG13_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG13_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG13_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg13(weights=torchvision.models.VGG13_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg13(pretrained=True, batch_norm=False)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13_bn.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg13_bn
+
+### [torchvision.models.vgg13_bn](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg13_bn.html)
+
+```python
+torchvision.models.vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg13](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg13_cn.html)
+
+```python
+paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG13_BN_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13_bn.md
@@ -19,7 +19,7 @@ paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG13_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg13_bn.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg13(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG13_BN_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG13_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg13_bn(weights=torchvision.models.VGG13_BN_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg13_bn(pretrained=True, batch_norm=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg16
+
+### [torchvision.models.vgg16](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg16.html)
+
+```python
+torchvision.models.vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg16](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg16_cn.html)
+
+```python
+paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG16_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
@@ -31,5 +31,5 @@ paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
 torchvision.models.vgg16(weights=torchvision.models.VGG16_Weights.DEFAULT)
 
 # Paddle 写法
-paddle.vision.models.vgg16(pretrained=True, batch_norm=False)
+paddle.vision.models.vgg16(pretrained=True)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
@@ -19,7 +19,17 @@ paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG16_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG16_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg16(weights=torchvision.models.VGG16_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg16(pretrained=True, batch_norm=False)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
@@ -12,7 +12,8 @@ torchvision.models.vgg16(*, weights: Optional[VGG16_Weights] = None, progress: b
 paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 VGG16_Weights.IMAGENET1K_V1 和 VGG16_Weights.IMAGENET1K_FEATURES。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16.md
@@ -20,8 +20,8 @@ paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG16_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
-| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16_bn.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG16_BN_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG16_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg16_bn(weights=torchvision.models.VGG16_BN_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg16_bn(pretrained=True, batch_norm=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16_bn.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg16_bn
+
+### [torchvision.models.vgg16_bn](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg16_bn.html)
+
+```python
+torchvision.models.vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg16](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg16_cn.html)
+
+```python
+paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG16_BN_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg16_bn.md
@@ -19,7 +19,7 @@ paddle.vision.models.vgg16(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG16_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
@@ -19,8 +19,8 @@ paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG19_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
-| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 保持默认即可。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
@@ -30,5 +30,5 @@ paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
 torchvision.models.vgg19(weights=torchvision.models.VGG19_Weights.DEFAULT)
 
 # Paddle 写法
-paddle.vision.models.vgg19(pretrained=True, batch_norm=False)
+paddle.vision.models.vgg19(pretrained=True)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG19_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG19_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg19(weights=torchvision.models.VGG19_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg19(pretrained=True, batch_norm=False)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg19
+
+### [torchvision.models.vgg19](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg19.html)
+
+```python
+torchvision.models.vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg19](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg19_cn.html)
+
+```python
+paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG19_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 False。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19_bn.md
@@ -18,7 +18,17 @@ paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG19_BN_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG19_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.vgg19_bn(weights=torchvision.models.VGG19_BN_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.vgg19_bn(pretrained=True, batch_norm=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19_bn.md
@@ -1,0 +1,24 @@
+## [输入参数类型不一致]torchvision.models.vgg19_bn
+
+### [torchvision.models.vgg19_bn](https://pytorch.org/vision/main/models/generated/torchvision.models.vgg19_bn.html)
+
+```python
+torchvision.models.vgg19_bn(*, weights: Optional[VGG19_BN_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.vgg19](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/vgg19_cn.html)
+
+```python
+paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 VGG19_BN_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19_bn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.vgg19_bn.md
@@ -19,7 +19,7 @@ paddle.vision.models.vgg19(pretrained=False, batch_norm=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 VGG19_BN_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | -           | batch_norm   | 是否使用批归一化，PyTorch 无此参数，Paddle 应设置为 True。 |
 | kwargs      | kwargs       | 附加的关键字参数。|
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
@@ -20,7 +20,7 @@ paddle.vision.models.wide_resnet101_2(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 WideResNet101_2_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.wide_resnet101_2
+
+### [torchvision.models.wide_resnet101_2](https://pytorch.org/vision/stable/models/generated/torchvision.models.wide_resnet101_2.html)
+
+```python
+torchvision.models.wide_resnet101_2(*, weights: Optional[WideResNet101_2_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.wide_resnet101_2](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/wide_resnet101_2_cn.html)
+
+```python
+paddle.vision.models.wide_resnet101_2(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 WideResNet101_2_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
@@ -12,7 +12,8 @@ torchvision.models.wide_resnet101_2(*, weights: Optional[WideResNet101_2_Weights
 paddle.vision.models.wide_resnet101_2(pretrained=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 Wide_ResNet101_2_Weights.IMAGENET1K_V1 和 Wide_ResNet101_2_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet101_2.md
@@ -19,6 +19,16 @@ paddle.vision.models.wide_resnet101_2(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 WideResNet101_2_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 WideResNet101_2_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.wide_resnet101_2(weights=torchvision.models.WideResNet101_2_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.wide_resnet101_2(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
@@ -1,0 +1,23 @@
+## [输入参数类型不一致]torchvision.models.wide_resnet50_2
+
+### [torchvision.models.wide_resnet50_2](https://pytorch.org/vision/stable/models/generated/torchvision.models.wide_resnet50_2.html)
+
+```python
+torchvision.models.wide_resnet50_2(*, weights: Optional[WideResNet50_2_Weights] = None, progress: bool = True, **kwargs: Any)
+```
+
+### [paddle.vision.models.wide_resnet50_2](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/models/wide_resnet50_2_cn.html)
+
+```python
+paddle.vision.models.wide_resnet50_2(pretrained=False, **kwargs)
+```
+
+两者功能一致但参数类型不一致，具体如下：
+
+### 参数映射
+
+| torchvision | PaddlePaddle | 备注 |
+| ----------- | ------------ | ---- |
+| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 WideResNet50_2_Weights 类型，需要转写。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| kwargs      | kwargs       | 附加的关键字参数。|

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
@@ -20,6 +20,16 @@ paddle.vision.models.wide_resnet50_2(pretrained=False, **kwargs)
 
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
-| weights     | pretrained   | 预训练权重，Paddle 参数 pretrained 为 bool 类型，PyTorch 参数 weights 为 WideResNet50_2_Weights 类型，需要转写。|
+| weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 WideResNet50_2_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
 | progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
 | kwargs      | kwargs       | 附加的关键字参数。|
+
+### 转写示例
+#### weights: 预训练权重
+```python
+# PyTorch 写法
+torchvision.models.wide_resnet50_2(weights=torchvision.models.WideResNet50_2_Weights.DEFAULT)
+
+# Paddle 写法
+paddle.vision.models.wide_resnet50_2(pretrained=True)
+```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
@@ -12,7 +12,9 @@ torchvision.models.wide_resnet50_2(*, weights: Optional[WideResNet50_2_Weights] 
 paddle.vision.models.wide_resnet50_2(pretrained=False, **kwargs)
 ```
 
-两者功能一致但参数类型不一致，具体如下：
+
+两者功能一致，但参数类型不一致。 具体而言，PyTorch 框架中内置了两种预训练权重模型，分别为 Wide_ResNet50_2_Weights.IMAGENET1K_V1 和 Wide_ResNet50_2_Weights.IMAGENET1K_V2。而 PaddlePaddle 框架中仅内置了一种预训练权重模型。
+在使用模型转换工具 PaConvert 时，无论用户在 PyTorch 中选择使用哪种预训练权重类型，均会统一转换为 PaddlePaddle 中的 pretrained=True 参数配置。
 
 ### 参数映射
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.models.wide_resnet50_2.md
@@ -21,7 +21,7 @@ paddle.vision.models.wide_resnet50_2(pretrained=False, **kwargs)
 | torchvision | PaddlePaddle | 备注 |
 | ----------- | ------------ | ---- |
 | weights     | pretrained   | 预训练权重，PyTorch 参数 weights 为 WideResNet50_2_Weights 枚举类或 String 类型，Paddle 参数 pretrained 为 bool 类型，需要转写。|
-| progress    | -            | 是否显示下载进度条，Paddle 无此参数，暂无转写方式。|
+| progress    | -            | 是否显示下载进度条，Paddle 无此参数，一般对网络训练结果影响不大，可直接删除。|
 | kwargs      | kwargs       | 附加的关键字参数。|
 
 ### 转写示例

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.ops.DeformConv2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.ops.DeformConv2d.md
@@ -1,4 +1,4 @@
-## [Paddle 参数更多]torchvision.ops.DeformConv2d
+## [paddle 参数更多]torchvision.ops.DeformConv2d
 
 ### [torchvision.ops.DeformConv2d](https://pytorch.org/vision/main/generated/torchvision.ops.DeformConv2d.html)
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.ops.DeformConv2d.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference_third_party/torchvision/torchvision.ops.DeformConv2d.md
@@ -1,4 +1,4 @@
-## [输入参数用法不一致]torchvision.ops.DeformConv2d
+## [Paddle 参数更多]torchvision.ops.DeformConv2d
 
 ### [torchvision.ops.DeformConv2d](https://pytorch.org/vision/main/generated/torchvision.ops.DeformConv2d.html)
 
@@ -6,7 +6,7 @@
 torchvision.ops.DeformConv2d(in_channels: int, out_channels: int, kernel_size: int, stride: int = 1, padding: int = 0, dilation: int = 1, groups: int = 1, bias: bool = True)
 ```
 
-### [paddle.vision.ops.DeformConv2D](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/transforms/pad_cn.html)
+### [paddle.vision.ops.DeformConv2D](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/vision/ops/DeformConv2D_cn.html)
 
 ```python
 paddle.vision.ops.DeformConv2D(in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, deformable_groups=1, groups=1, weight_attr=None, bias_attr=None)
@@ -26,5 +26,5 @@ PyTorch 相比 Paddle 支持更多其他参数，具体如下：
 | dilation         | dilation             | 空洞大小。       |
 | -               | deformable_groups    | 可变形卷积组数，PyTorch 无此参数，Paddle 保持默认即可。       |
 | groups          | groups               | 三维卷积层的组数。       |
-| bias            | bias_attr            | 可变形卷积偏置项。      |
+| bias            | bias_attr            | 可变形卷积偏置项，仅参数名不一致。      |
 | -               | weight_attr          | 二维卷积层的可学习参数/权重的属性，PyTorch 无此参数，Paddle 保持默认即可。       |

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -13,10 +13,10 @@
 | [torch.XX](#id1) | 主要为`torch.XX`类 API |
 | [torch.nn.XX](#id2) | 主要为`torch.nn.XX`类 API |
 | [torch.nn.functional.XX](#id3) | 主要为`torch.nn.functional.XX`类 API |
-| [torch.nn.init.XX](#id4) | 主要为`torch.nn.init.XX`类 API |
-| [torch.nn.utils.XX](#id5) | 主要为`torch.nn.utils.XX`类 API |
-| [torch.nn.Module.XX](#id6) | 主要为`torch.nn.Module.XX`类 API |
-| [torch.Tensor.XX](#id7) | 主要为`torch.Tensor.XX`类 API |
+| [torch.Tensor.XX](#id4) | 主要为`torch.Tensor.XX`类 API |
+| [torch.nn.init.XX](#id5) | 主要为`torch.nn.init.XX`类 API |
+| [torch.nn.utils.XX](#id6) | 主要为`torch.nn.utils.XX`类 API |
+| [torch.nn.Module.XX](#id7) | 主要为`torch.nn.Module.XX`类 API |
 | [torch.autograd.XX](#id8) | 主要为`torch.autograd.XX`类 API |
 | [torch.cuda.XX](#id9) | 主要为`torch.cuda.XX`类 API |
 | [torch.distributed.XX](#id10) | 主要为`torch.distributed.XX`类 API |
@@ -25,8 +25,8 @@
 | [torch.hub.XX](#id13)   | 主要为`torch.hub.XX`类 API |
 | [torch.linalg.XX](#id14)   | 主要为`torch.linalg.XX`类 API |
 | [torch.onnx.XX](#id15)   | 主要为`torch.onnx.XX`类 API |
-| [torch.profiler.XX](#id16)   | 主要为`torch.profiler.XX`类 API |
-| [torch.optim.XX](#id17)   | 主要为`torch.optim.XX`类 API |
+| [torch.optim.XX](#id16)   | 主要为`torch.optim.XX`类 API |
+| [torch.profiler.XX](#id17)   | 主要为`torch.profiler.XX`类 API |
 | [torch.sparse.XX](#id18)   | 主要为`torch.sparse.XX`类 API |
 | [torch 其他](#id19)   | PyTorch 其他 API |
 | [fairscale.xx](#id20)   | 第三方库 fairscale API |
@@ -63,7 +63,7 @@
 
 ***持续更新...***
 
-## <span id="id7">torch.Tensor.XX API 映射列表</span>
+## <span id="id4">torch.Tensor.XX API 映射列表</span>
 
 梳理了`torch.Tensor.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -73,7 +73,7 @@
 
 ***持续更新...***
 
-## <span id="id4">torch.nn.init.XX API 映射列表</span>
+## <span id="id5">torch.nn.init.XX API 映射列表</span>
 
 梳理了`torch.nn.init.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -83,7 +83,7 @@
 
 ***持续更新...***
 
-## <span id="id5">torch.nn.utils.XX API 映射列表</span>
+## <span id="id6">torch.nn.utils.XX API 映射列表</span>
 
 梳理了`torch.nn.utils.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -93,7 +93,7 @@
 
 ***持续更新...***
 
-## <span id="id6">torch.nn.Module.XX API 映射列表</span>
+## <span id="id7">torch.nn.Module.XX API 映射列表</span>
 
 梳理了`torch.nn.Module.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -179,7 +179,7 @@
 
 ***持续更新...***
 
-## <span id="id17">torch.optim.XX API 映射列表</span>
+## <span id="id16">torch.optim.XX API 映射列表</span>
 梳理了`torch.optim.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -188,7 +188,7 @@
 
 ***持续更新...***
 
-## <span id="id16">torch.profiler.XX API 映射列表</span>
+## <span id="id17">torch.profiler.XX API 映射列表</span>
 
 梳理了`torch.profiler.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -32,6 +32,7 @@
 | [fairscale.xx](#id23)   | 第三方库 fairscale API |
 | [transformers.xx](#id24)   | 第三方库 transformers API |
 | [flash_attn.xx](#id25)   | 第三方库 flash_attn API |
+| [torchvision.xx](#id26)   | 第三方库 torchvision API |
 
 ## torch.XX API 映射列表
 
@@ -235,6 +236,14 @@
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
 | ----- | ----------- | ----------------- | ----------- | ------- |
 | REFERENCE-MAPPING-TABLE(`flash_attn.`) |
+
+***持续更新...***
+
+## torchvision.XX API 映射列表
+
+| 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
+| ----- | ----------- | ----------------- | ----------- | ------- |
+| REFERENCE-MAPPING-TABLE(`torchvision.`) |
 
 ***持续更新...***
 

--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -15,26 +15,26 @@
 | [torch.nn.functional.XX](#id3) | 主要为`torch.nn.functional.XX`类 API |
 | [torch.nn.init.XX](#id4) | 主要为`torch.nn.init.XX`类 API |
 | [torch.nn.utils.XX](#id5) | 主要为`torch.nn.utils.XX`类 API |
-| [torch.nn.Module.XX](#id15) | 主要为`torch.nn.Module.XX`类 API |
-| [torch.Tensor.XX](#id6) | 主要为`torch.Tensor.XX`类 API |
-| [torch.autograd.XX](#id20) | 主要为`torch.autograd.XX`类 API |
-| [torch.cuda.XX](#id7) | 主要为`torch.cuda.XX`类 API |
-| [torch.distributed.XX](#id8) | 主要为`torch.distributed.XX`类 API |
-| [torch.distributions.XX](#id9)   | 主要为`torch.distributions.XX`类 API |
-| [torch.fft.XX](#id10)   | 主要为`torch.fft.XX`类 API |
-| [torch.hub.XX](#id14)   | 主要为`torch.hub.XX`类 API |
-| [torch.linalg.XX](#id11)   | 主要为`torch.linalg.XX`类 API |
+| [torch.nn.Module.XX](#id6) | 主要为`torch.nn.Module.XX`类 API |
+| [torch.Tensor.XX](#id7) | 主要为`torch.Tensor.XX`类 API |
+| [torch.autograd.XX](#id8) | 主要为`torch.autograd.XX`类 API |
+| [torch.cuda.XX](#id9) | 主要为`torch.cuda.XX`类 API |
+| [torch.distributed.XX](#id10) | 主要为`torch.distributed.XX`类 API |
+| [torch.distributions.XX](#id11)   | 主要为`torch.distributions.XX`类 API |
+| [torch.fft.XX](#id12)   | 主要为`torch.fft.XX`类 API |
+| [torch.hub.XX](#id13)   | 主要为`torch.hub.XX`类 API |
+| [torch.linalg.XX](#id14)   | 主要为`torch.linalg.XX`类 API |
 | [torch.onnx.XX](#id15)   | 主要为`torch.onnx.XX`类 API |
-| [torch.profiler.XX](#id21)   | 主要为`torch.profiler.XX`类 API |
-| [torch.optim.XX](#id22)   | 主要为`torch.optim.XX`类 API |
-| [torch.sparse.XX](#id12)   | 主要为`torch.sparse.XX`类 API |
-| [torch 其他](#id13)   | PyTorch 其他 API |
-| [fairscale.xx](#id23)   | 第三方库 fairscale API |
-| [transformers.xx](#id24)   | 第三方库 transformers API |
-| [flash_attn.xx](#id25)   | 第三方库 flash_attn API |
-| [torchvision.xx](#id26)   | 第三方库 torchvision API |
+| [torch.profiler.XX](#id16)   | 主要为`torch.profiler.XX`类 API |
+| [torch.optim.XX](#id17)   | 主要为`torch.optim.XX`类 API |
+| [torch.sparse.XX](#id18)   | 主要为`torch.sparse.XX`类 API |
+| [torch 其他](#id19)   | PyTorch 其他 API |
+| [fairscale.xx](#id20)   | 第三方库 fairscale API |
+| [transformers.xx](#id21)   | 第三方库 transformers API |
+| [flash_attn.xx](#id22)   | 第三方库 flash_attn API |
+| [torchvision.xx](#id23)   | 第三方库 torchvision API |
 
-## torch.XX API 映射列表
+## <span id="id1">torch.XX API 映射列表</span>
 
 梳理了`torch.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -44,7 +44,7 @@
 
 ***持续更新...***
 
-## torch.nn.XX API 映射列表
+## <span id="id2">torch.nn.XX API 映射列表</span>
 
 梳理了`torch.nn.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -54,7 +54,7 @@
 
 ***持续更新...***
 
-## torch.nn.functional.XX API 映射列表
+## <span id="id3">torch.nn.functional.XX API 映射列表</span>
 梳理了`torch.nn.functional.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -63,7 +63,7 @@
 
 ***持续更新...***
 
-## torch.Tensor.XX API 映射列表
+## <span id="id7">torch.Tensor.XX API 映射列表</span>
 
 梳理了`torch.Tensor.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -73,7 +73,8 @@
 
 ***持续更新...***
 
-## torch.nn.init.XX API 映射列表
+## <span id="id4">torch.nn.init.XX API 映射列表</span>
+
 梳理了`torch.nn.init.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -82,7 +83,8 @@
 
 ***持续更新...***
 
-## torch.nn.utils.XX API 映射列表
+## <span id="id5">torch.nn.utils.XX API 映射列表</span>
+
 梳理了`torch.nn.utils.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -91,7 +93,8 @@
 
 ***持续更新...***
 
-## torch.nn.Module.XX API 映射列表
+## <span id="id6">torch.nn.Module.XX API 映射列表</span>
+
 梳理了`torch.nn.Module.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -100,7 +103,7 @@
 
 ***持续更新...***
 
-## torch.autograd.XX API 映射列表
+## <span id="id8">torch.autograd.XX API 映射列表</span>
 梳理了`torch.autograd.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -109,7 +112,7 @@
 
 ***持续更新...***
 
-## torch.cuda.XX API 映射列表
+## <span id="id9">torch.cuda.XX API 映射列表</span>
 梳理了`torch.cuda.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -118,7 +121,7 @@
 
 ***持续更新...***
 
-## torch.distributed.XX API 映射列表
+## <span id="id10">torch.distributed.XX API 映射列表</span>
 梳理了`torch.distributed.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -127,7 +130,7 @@
 
 ***持续更新...***
 
-## torch.distributions.XX API 映射列表
+## <span id="id11">torch.distributions.XX API 映射列表</span>
 梳理了`torch.distributions.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -136,7 +139,7 @@
 
 ***持续更新...***
 
-## torch.fft.XX API 映射列表
+## <span id="id12">torch.fft.XX API 映射列表</span>
 梳理了`torch.fft.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -145,7 +148,7 @@
 
 ***持续更新...***
 
-## torch.hub.XX API 映射列表
+## <span id="id13">torch.hub.XX API 映射列表</span>
 
 梳理了`torch.hub.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -156,7 +159,7 @@
 
 ***持续更新...***
 
-## torch.linalg.XX API 映射列表
+## <span id="id14">torch.linalg.XX API 映射列表</span>
 
 梳理了`torch.linalg.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -166,7 +169,7 @@
 
 ***持续更新...***
 
-## torch.onnx.XX API 映射列表
+## <span id="id15">torch.onnx.XX API 映射列表</span>
 
 梳理了`torch.onnx.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -176,7 +179,7 @@
 
 ***持续更新...***
 
-## torch.optim.XX API 映射列表
+## <span id="id17">torch.optim.XX API 映射列表</span>
 梳理了`torch.optim.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
@@ -185,7 +188,7 @@
 
 ***持续更新...***
 
-## torch.profiler.XX API 映射列表
+## <span id="id16">torch.profiler.XX API 映射列表</span>
 
 梳理了`torch.profiler.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -195,7 +198,7 @@
 
 ***持续更新...***
 
-## torch.sparse.XX API 映射列表
+## <span id="id18">torch.sparse.XX API 映射列表</span>
 
 梳理了`torch.sparse.XX`类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -205,7 +208,7 @@
 
 ***持续更新...***
 
-## PyTorch 其他类 API 映射列表
+## <span id="id19">PyTorch 其他类 API 映射列表</span>
 
 梳理了 PyTorch 其他类 API 的 PyTorch-PaddlePaddle API 映射列表。
 
@@ -215,7 +218,7 @@
 
 ***持续更新...***
 
-## fairscale.XX API 映射列表
+## <span id="id20">fairscale.XX API 映射列表</span>
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
 | ----- | ----------- | ----------------- | ----------- | ------- |
@@ -223,7 +226,7 @@
 
 ***持续更新...***
 
-## transformers.XX API 映射列表
+## <span id="id21">transformers.XX API 映射列表</span>
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
 | ----- | ----------- | ----------------- | ----------- | ------- |
@@ -231,7 +234,7 @@
 
 ***持续更新...***
 
-## flash_attn.XX API 映射列表
+## <span id="id22">flash_attn.XX API 映射列表</span>
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
 | ----- | ----------- | ----------------- | ----------- | ------- |
@@ -239,7 +242,7 @@
 
 ***持续更新...***
 
-## torchvision.XX API 映射列表
+## <span id="id23">torchvision.XX API 映射列表</span>
 
 | 序号 | Pytorch 最新 release | Paddle develop | 映射关系分类 | 备注 |
 | ----- | ----------- | ----------------- | ----------- | ------- |


### PR DESCRIPTION
1. 修复 `torchvision.datasets.VOCDetection` `torchvision.ops.DeformConv2d` 的对应关系中的问题
2. 新增 33 个和内置模型相关的 torchvision 和 paddle.vision 的对应关系
```python
torchvision.models.alexnet
torchvision.models.densenet121
torchvision.models.densenet161
torchvision.models.densenet169
torchvision.models.densenet201
torchvision.models.googlenet
torchvision.models.inception_v3
torchvision.models.mobilenet_v2
torchvision.models.mobilenet_v3_large
torchvision.models.mobilenet_v3_small
torchvision.models.resnet101
torchvision.models.resnet152
torchvision.models.resnet18
torchvision.models.resnet34
torchvision.models.resnet50
torchvision.models.resnext101_64x4d
torchvision.models.resnext50_32x4d
torchvision.models.shufflenet_v2_x0_5
torchvision.models.shufflenet_v2_x1_0
torchvision.models.shufflenet_v2_x1_5
torchvision.models.shufflenet_v2_x2_0
torchvision.models.squeezenet1_0
torchvision.models.squeezenet1_1
torchvision.models.vgg11
torchvision.models.vgg11_bn
torchvision.models.vgg13
torchvision.models.vgg13_bn
torchvision.models.vgg16
torchvision.models.vgg16_bn
torchvision.models.vgg19
torchvision.models.vgg19_bn
torchvision.models.wide_resnet101_2
torchvision.models.wide_resnet50_2
```