### PR TITLE
【Paddle Tensor No.22】新增`paddle.less`,`Tensor.less`中文文档

### DIFF
--- a/docs/api/paddle/Tensor_cn.rst
+++ b/docs/api/paddle/Tensor_cn.rst
@@ -1610,6 +1610,15 @@ less_than(y, name=None)
 
 请参考 :ref:`cn_api_paddle_less_than`
 
+less(y, name=None)
+:::::::::
+
+返回：计算后的 Tensor
+
+返回类型：Tensor
+
+请参考 :ref:`cn_api_paddle_less`
+
 lgamma(name=None)
 :::::::::
 

--- a/docs/api/paddle/less_cn.rst
+++ b/docs/api/paddle/less_cn.rst
@@ -1,0 +1,29 @@
+.. _cn_api_paddle_less:
+
+less
+-------------------------------
+.. py:function:: paddle.less(x, y, name=None)
+
+
+逐元素地返回 :math:`x < y` 的逻辑值，相同位置前者输入小于后者输入则返回 True，否则返回 False。使用重载算子 `<` 可以有相同的计算函数效果。
+
+.. note::
+    输出的结果不返回梯度。
+
+参数
+::::::::::::
+
+    - **x** (Tensor) - 输入 Tensor，支持的数据类型包括 bool、bfloat16、float16、float32、float64、uint8、int8、int16、int32、int64。
+    - **y** (Tensor) - 输入 Tensor，支持的数据类型包括 bool、bfloat16、float16、float32、float64、uint8、int8、int16、int32、int64。
+    - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+
+
+返回
+::::::::::::
+输出结果的 Tensor，输出 Tensor 的 shape 和输入一致，Tensor 数据类型为 bool。
+
+
+代码示例
+::::::::::::
+
+COPY-FROM: paddle.less


### PR DESCRIPTION
## PR Category
User Experience

## PR Types
New features

## Description
新增`paddle.less`,`Tensor.less`, 中文文档.

- `less`: PaddlePaddle/Paddle#69270
- fix `less`: PaddlePaddle/Paddle#69449

我之前`import less_than as less`影响到了所有人的`docs-preiview`,侧边栏的`less_than`变成了`less`，但是内部内容依然是`less_than`的。

- #6972
- #6980

然后在昨天合入了把`import as`改成复用方法后，经过一个`Nightly`迭代，今天别人恢复了正常。

- #6988

但是我尝试自己重构建`Docs-New`，似乎并不会直接同步更新，或者说它拉取的依然是先前旧版本的`Paddle`。所以开一个新的PR来测试一下。原先的 PR 中的`Tensor.less`和`paddle.less`迁移到这个PR中，只保留了`paddle.positive`.
