### PR TITLE
[CI] Remove useless check from en ci scripts

### DIFF
--- a/ci_scripts/ci_start_en.sh
+++ b/ci_scripts/ci_start_en.sh
@@ -86,32 +86,7 @@ if [ "${BUILD_DOC}" = "true" ] &&  [ -x /usr/local/bin/sphinx-build ] ; then
     fi
 fi
 
-check_parameters=OFF
-if [ "${check_parameters}" = "OFF" ] ; then
-    #echo "chinese api doc fileslist is empty, skip check."
-    echo "check_api_parameters is not stable, close it temporarily."
-else
-    jsonfn=${OUTPUTDIR}/en/${VERSIONSTR}/gen_doc_output/api_info_all.json
-    if [ -f $jsonfn ] ; then
-        echo "$jsonfn exists."
-        /bin/bash ${DIR_PATH}/check_api_parameters.sh "${need_check_cn_doc_files}" ${jsonfn}
-        if [ $? -ne 0 ];then
-            exit 1
-        fi
-    else
-        echo "$jsonfn not exists."
-        exit 1
-    fi
-fi
-
-EXIT_CODE=0
-# 3 check code style/format.
-/bin/bash  ${DIR_PATH}/check_code.sh
-if [ $? -ne 0 ];then
-    EXIT_CODE=1
-fi
-
-# 4 check docs style/format
+# 3 check docs style/format
 cd ${PADDLE_DIR}
 git merge --no-edit upstream/${BRANCH}
 need_check_api_py_files=$(find_all_api_py_files_modified_by_pr)
@@ -131,14 +106,6 @@ else
         exit 1
     fi
 fi
-
-
-# 5 Approval check
-/bin/bash  ${DIR_PATH}/checkapproval.sh
-if [ $? -ne 0 ];then
-    exit 1
-fi
-
 
 echo "PADDLE_WHL=${PADDLE_WHL}"
 # print preview url

--- a/ci_scripts/ci_start_en.sh
+++ b/ci_scripts/ci_start_en.sh
@@ -86,7 +86,7 @@ if [ "${BUILD_DOC}" = "true" ] &&  [ -x /usr/local/bin/sphinx-build ] ; then
     fi
 fi
 
-# 3 check docs style/format
+# 3 check docs syntax
 cd ${PADDLE_DIR}
 git merge --no-edit upstream/${BRANCH}
 need_check_api_py_files=$(find_all_api_py_files_modified_by_pr)
@@ -99,10 +99,10 @@ fi
 if [ "${need_check_api_py_files}" = "" ] ; then
     echo "api python file list is empty, skip check system message in docs"
 else
-    echo 'need check api pyhon file: ', $need_check_api_py_files
+    echo 'need check api python file: ', $need_check_api_py_files
     /bin/bash ${DIR_PATH}/check_api_docs_en.sh ${jsonfn} ${OUTPUTDIR}/en/${VERSIONSTR}/api/ "${need_check_api_py_files}"
     if [ $? -ne 0 ]; then
-        echo 'Docs Style Check is failed, please check the style in the above docs'
+        echo 'Docs syntax check is failed, please check the syntax in the above docs, mostly caused by incorrect formatting written in the docstring.'
         exit 1
     fi
 fi


### PR DESCRIPTION
移除以下在英文 CI（PR-CI-Paddle-Doc-Preview）中无用的检查

- 参数检查，跑的是 docs 的检查，一直关着，没用
- codestyle 检查，只检查不报错，没用，而且用的是 docs 的检查
- approval check，跑的是 docs 的检查，没用

相关代码明显是直接 copy 的 `ci_stact.sh` 的，也不知道清理一下没用的……