### PR TITLE
Fix description error in broadcast_tensors.

### DIFF
--- a/docs/api/paddle/broadcast_tensors_cn.rst
+++ b/docs/api/paddle/broadcast_tensors_cn.rst
@@ -13,7 +13,15 @@ broadcast_tensors
 
     .. _Tensor 介绍: ../../guides/beginner/tensor_cn.html#id7
 
-下图展示将三个 Tensor 广播到同一维度的过程。三个 Tensor 的尺寸分别为 [4, 1, 3]、[2, 3]、[4, 2, 1]，在广播时，会从最后一个维度开始对齐，对于每一个维度，任意两个 Tensor 的在该维度大小相等；或者其中一个 Tensor 的维度等于 1；或者其中一个 Tensor 的维度不存在。在下图中，最后一个维度中，Tenser3 取值为 1，Tensor1 和 Tensor2 取值为 3，所有 Tensor 的该维度被扩张为 3；倒数第二个维度中，Tenser1 取值为 1，Tensor2 和 Tensor3 取值为 2，所有 Tensor 的该维度被扩张为 2；倒数第三个维度中，Tenser2 为空，Tensor1 和 Tensor3 取值为 4，所有 Tensor 的该维度被扩张为 4。最终，所有 Tensor 都被扩张到 [4, 2, 3]。
+下图展示将三个 Tensor 广播到同一维度的过程。三个 Tensor 的尺寸分别为 [4, 1, 3]、[2, 3]、[4, 2, 1]，在广播时，会从最后一个维度开始对齐，对于每一个维度，任意两个 Tensor 的在该维度大小相等；或者其中一个 Tensor 的维度等于 1；或者其中一个 Tensor 的维度不存在。
+
+在下图中，
+
+- 最后一个维度中，Tenser3 取值为 1，Tensor1 和 Tensor2 取值为 3，所有 Tensor 的该维度被扩张为 3；
+- 倒数第二个维度中，Tenser1 取值为 1，Tensor2 和 Tensor3 取值为 2，所有 Tensor 的该维度被扩张为 2；
+- 倒数第三个维度中，Tenser2 为空，Tensor1 和 Tensor3 取值为 4，所有 Tensor 的该维度被扩张为 4。
+
+最终，所有 Tensor 都被扩张到 [4, 2, 3]。
 
 .. figure:: ../../images/api_legend/broadcast.png
    :width: 800

--- a/docs/api/paddle/broadcast_tensors_cn.rst
+++ b/docs/api/paddle/broadcast_tensors_cn.rst
@@ -13,7 +13,7 @@ broadcast_tensors
 
     .. _Tensor 介绍: ../../guides/beginner/tensor_cn.html#id7
 
-下图展示将三个 Tensor 广播到同一维度的过程。三个 Tensor 的尺寸分别为 [4, 1, 3]、[2, 3]、[4, 2, 1]，在广播时，会从最后一个维度开始对齐，对于每一个维度，任意两个 Tensor 的在该维度大小相等；或者其中一个 Tensor 的维度等于 1；或者其中一个 Tensor 的维度不存在。在下图中，最后一个维度中，Tenser3 取值为 1，Tensor1 和 Tensor2 取值为 3，所有 Tensor 的该维度被扩张为 3；倒数第二个维度中，Tenser1 取值为 2，Tensor2 和 Tensor3 取值为 2，所有 Tensor 的该维度被扩张为 2；倒数第三个维度中，Tenser2 为空，Tensor1 和 Tensor3 取值为 4，所有 Tensor 的该维度被扩张为 4。最终，所有 Tensor 都被扩张到 [4, 2, 3]。
+下图展示将三个 Tensor 广播到同一维度的过程。三个 Tensor 的尺寸分别为 [4, 1, 3]、[2, 3]、[4, 2, 1]，在广播时，会从最后一个维度开始对齐，对于每一个维度，任意两个 Tensor 的在该维度大小相等；或者其中一个 Tensor 的维度等于 1；或者其中一个 Tensor 的维度不存在。在下图中，最后一个维度中，Tenser3 取值为 1，Tensor1 和 Tensor2 取值为 3，所有 Tensor 的该维度被扩张为 3；倒数第二个维度中，Tenser1 取值为 1，Tensor2 和 Tensor3 取值为 2，所有 Tensor 的该维度被扩张为 2；倒数第三个维度中，Tenser2 为空，Tensor1 和 Tensor3 取值为 4，所有 Tensor 的该维度被扩张为 4。最终，所有 Tensor 都被扩张到 [4, 2, 3]。
 
 .. figure:: ../../images/api_legend/broadcast.png
    :width: 800


### PR DESCRIPTION
位于 https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/broadcast_tensors_cn.html#broadcast-tensors 中，Tenser1 取值应该为 1。

> 倒数第二个维度中，Tenser1 取值为 2，Tensor2 和 Tensor3 取值为 2，所有 Tensor 的该维度被扩张为 2；

改为

> 倒数第二个维度中，Tenser1 取值为 1，Tensor2 和 Tensor3 取值为 2，所有 Tensor 的该维度被扩张为 2；