### PR TITLE
[Docathon][Add Inplace CN Doc No.36]

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -233,6 +233,7 @@ tensor 数学操作原位（inplace）版本
     " :ref:`paddle.bitwise_left_shift_ <cn_api_paddle_bitwise_left_shift_>` ", "Inplace 版本的 bitwise_left_shift API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.bitwise_right_shift_ <cn_api_paddle_bitwise_right_shift_>` ", "Inplace 版本的 bitwise_right_shift API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.log_normal_ <cn_api_paddle_log_normal_>` ", "Inplace 版本的 log_normal API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.nan_to_num_ <cn_api_paddle_nan_to_num_>` ", "Inplace 版本的 nan_to_num API，对输入 x 采用 Inplace 策略"
 
 
 .. _tensor_logic:

--- a/docs/api/paddle/nan_to_num__cn.rst
+++ b/docs/api/paddle/nan_to_num__cn.rst
@@ -3,7 +3,7 @@
 nan\_to\_num\_
 -------------------------------
 
-.. py:function:: paddle.nan_to_num_(x: Tensor, nan: float = 0.0, posinf: float | None = None, neginf: float | None = None, name: str | None = None)
+.. py:function:: paddle.nan_to_num_(x, nan = 0.0, posinf = None, neginf = None, name = None)
 
 Inplace 版本的 :ref:`cn_api_paddle_nan_to_num` API，对输入 `x` 采用 Inplace 策略。
 

--- a/docs/api/paddle/nan_to_num__cn.rst
+++ b/docs/api/paddle/nan_to_num__cn.rst
@@ -1,0 +1,12 @@
+.. _cn_api_paddle_nan_to_num_:
+
+nan\_to\_num\_
+-------------------------------
+
+.. py:function:: paddle.nan_to_num_(x: Tensor, nan: float = 0.0, posinf: float | None = None, neginf: float | None = None, name: str | None = None)
+
+Inplace 版本的 :ref:`cn_api_paddle_nan_to_num` API，对输入 `x` 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3


### PR DESCRIPTION
描述：
为paddle.nan_to_num_添加中文文档
增加：
paddle.nan_to_num__cn.rst文件
修改：
在Overview_cn.rst中新增新添加的API相关信息（均在“tensor 数学操作原位（inplace）版本”标题下）
issue：https://github.com/PaddlePaddle/docs/issues/7090
英文文档链接：
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/nan_to_num__en.html

@sunzhongkai588