### PR TITLE
[Docathon][Add Inplace CN Doc No.35]

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -209,6 +209,7 @@ tensor 数学操作原位（inplace）版本
     " :ref:`paddle.gammainc_ <cn_api_paddle_gammainc_>` ", "Inplace 版本的 gammainc API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.gammaln_ <cn_api_paddle_gammaln_>` ", "Inplace 版本的 gammaln API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.gcd_ <cn_api_paddle_gcd_>` ", "Inplace 版本的 gcd API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.multiply_ <cn_api_paddle_multiply_>` ", "Inplace 版本的 multiply API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.reciprocal_ <cn_api_paddle_reciprocal_>` ", "Inplace 版本的 reciprocal API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.round_ <cn_api_paddle_round_>` ", "Inplace 版本的 round API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.rsqrt_ <cn_api_paddle_rsqrt_>` ", "Inplace 版本的 rsqrt API，对输入 x 采用 Inplace 策略"

--- a/docs/api/paddle/multiply__cn.rst
+++ b/docs/api/paddle/multiply__cn.rst
@@ -1,0 +1,12 @@
+.. _cn_api_paddle_multiply_:
+
+multiply\_
+-------------------------------
+
+.. py:function:: paddle.multiply_(x, y, name=None)
+
+Inplace 版本的 :ref:`cn_api_paddle_multiply` API，对输入 `x` 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3


### PR DESCRIPTION
描述：
为multiply_添加中文文档

增加：
multiply__cn.rst文件

修改：
在Overview_cn.rst中新增新添加的API相关信息（均在“tensor 数学操作原位（inplace）版本”标题下）

issue: https://github.com/PaddlePaddle/docs/issues/7090

英文文档：
multiply_: https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/multiply__en.html

@sunzhongkai588