### PR TITLE
[Docathon][Fix note No.11-13]

### DIFF
--- a/docs/api/paddle/nn/InstanceNorm1D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm1D_cn.rst
@@ -40,7 +40,7 @@ InstanceNorm1D
     - output：和输入形状一样。
 
 .. note::
-目前设置 track_running_stats 和 momentum 是无效的。之后的版本会修复此问题。
+    目前设置 track_running_stats 和 momentum 是无效的。之后的版本会修复此问题。
 
 
 代码示例

--- a/docs/api/paddle/nn/InstanceNorm2D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm2D_cn.rst
@@ -40,7 +40,7 @@ InstanceNorm2D
     - output：和输入形状一样。
 
 .. note::
-目前设置 track_running_stats 和 momentum 是无效的。之后的版本会修复此问题。
+    目前设置 track_running_stats 和 momentum 是无效的。之后的版本会修复此问题。
 
 
 代码示例

--- a/docs/api/paddle/nn/InstanceNorm3D_cn.rst
+++ b/docs/api/paddle/nn/InstanceNorm3D_cn.rst
@@ -39,7 +39,7 @@ InstanceNorm3D
     - output：和输入形状一样。
 
 .. note::
-目前设置 track_running_stats 和 momentum 是无效的。之后的版本会修复此问题。
+    目前设置 track_running_stats 和 momentum 是无效的。之后的版本会修复此问题。
 
 
 代码示例


### PR DESCRIPTION
内容：
调整rst note标签缩进

修改：
`docks/api/paddle/nn/InstanceNorm1D_cn.rst`
`docks/api/paddle/nn/InstanceNorm2D_cn.rst`
`docks/api/paddle/nn/InstanceNorm3D_cn.rst`

Issue: https://github.com/PaddlePaddle/docs/issues/7134
@Echo-Nie @sunzhongkai588 
