### PR TITLE
Skip system message check if inferred doc file not exists

### DIFF
--- a/ci_scripts/check_api_docs_en.py
+++ b/ci_scripts/check_api_docs_en.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import sys
 
 source_to_doc_dict = {}
@@ -68,6 +69,9 @@ def check_system_message_in_doc(doc_file):
     return: True or False
     """
     pass_check = True
+    if not os.path.exists(doc_file):
+        return pass_check
+
     with open(doc_file, "r") as f:
         for line, row in enumerate(f):
             if SYSTEM_MESSAGE_WARNING in row:


### PR DESCRIPTION
跳过默认推导出的文件名不存在时仍然进行检查导致的问题