### PR TITLE
[Docathon][Add Inplace CN Doc No.40]

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -205,6 +205,7 @@ tensor 数学操作原位（inplace）版本
     " :ref:`paddle.expm1_ <cn_api_paddle_expm1_>` ", "Inplace 版本的 expm1 API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.flatten_ <cn_api_paddle_flatten_>` ", "Inplace 版本的 flatten API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.floor_ <cn_api_paddle_floor_>` ", "Inplace 版本的 floor API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.pow_ <cn_api_paddle_pow_>` ", "Inplace 版本的 pow API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.floor_divide_ <cn_api_paddle_floor_divide_>` ", "Inplace 版本的 floor_divide API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.frac_ <cn_api_paddle_frac_>` ", "Inplace 版本的 frac API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.gammaincc_ <cn_api_paddle_gammaincc_>` ", "Inplace 版本的 gammaincc API，对输入 x 采用 Inplace 策略"

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -4,7 +4,7 @@ pow\_
 -------------------------------
 
 .. py:function:: paddle.pow_(x)
-Inplace 版本的 :ref:`cn_api_paddle_add` API，对输入 x 采用 Inplace 策略。
+Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 x 采用 Inplace 策略。
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
 

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -8,4 +8,5 @@ pow\_
 Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 `x` 采用 Inplace 策略。
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
 .. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -1,11 +1,11 @@
+@@ -0,0 +1,11 @@
 .. _cn_api_paddle_pow_:
 
 pow\_
 -------------------------------
 
-.. py:function:: paddle.pow_(x，y,name)
-Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 x 采用 Inplace 策略。
-
+.. py:function:: paddle.pow_(x,y,name)
+Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 `x` 采用 Inplace 策略。
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
 

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -1,4 +1,3 @@
-@@ -0,0 +1,11 @@
 .. _cn_api_paddle_pow_:
 
 pow\_

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -1,0 +1,11 @@
+.. _cn_api_paddle_pow_:
+
+pow\_
+-------------------------------
+
+.. py:function:: paddle.pow_(x)
+Inplace 版本的 :ref:`cn_api_paddle_add` API，对输入 x 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -8,5 +8,4 @@ pow\_
 Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 `x` 采用 Inplace 策略。
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
-
 .. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -3,8 +3,9 @@
 pow\_
 -------------------------------
 
-.. py:function:: paddle.pow_(x)
+.. py:function:: paddle.pow_(x，y,name)
 Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 x 采用 Inplace 策略。
+
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
 

--- a/docs/api/paddle/pow__cn.rst
+++ b/docs/api/paddle/pow__cn.rst
@@ -3,7 +3,7 @@
 pow\_
 -------------------------------
 
-.. py:function:: paddle.pow_(x,y,name)
+.. py:function:: paddle.pow_(x,y,name=None)
 Inplace 版本的 :ref:`cn_api_paddle_pow` API，对输入 `x` 采用 Inplace 策略。
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。


### PR DESCRIPTION
.. _cn_api_paddle_paw_:

paw\_
-------------------------------

.. py:function:: paddle.paw_(x) 
Inplace 版本的 :ref:`cn_api_paddle_paw` API，对输入 x 采用 Inplace 策略。

更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。

.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3