### PR TITLE
[Docathon][Add Inplace CN Doc No.44、45、46、47]

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -11,9 +11,11 @@ paddle 目录下包含 tensor、device、framework 相关 API 以及某些高层
 -  :ref:`tensor 属性相关 <tensor_attribute>`
 -  :ref:`tensor 创建相关 <tensor_creation>`
 -  :ref:`tensor 元素查找相关 <tensor_search>`
+-  :ref:`tensor 元素查找相关原位（inplace）版本 <tensor_search_inplace>`
 -  :ref:`tensor 初始化相关 <tensor_initializer>`
 -  :ref:`tensor random 相关 <tensor_random>`
 -  :ref:`tensor 线性代数相关 <tensor_linalg>`
+-  :ref:`tensor 线性代数相关原位（inplace）版本 <tensor_linalg_inplace>`
 -  :ref:`tensor 元素操作相关（如：转置，reshape 等） <tensor_manipulation>`
 -  :ref:`tensor 元素操作相关原位（inplace）版本 <tensor_manipulation_inplace>`
 -  :ref:`爱因斯坦求和 <einsum>`
@@ -341,6 +343,17 @@ tensor 元素查找相关
     " :ref:`paddle.topk <cn_api_paddle_topk>` ", "沿着可选的 axis 查找 topk 最大或者最小的结果和结果所在的索引信息"
     " :ref:`paddle.where <cn_api_paddle_where>` ", "返回一个根据输入 condition, 选择 x 或 y 的元素组成的多维 Tensor"
 
+.. _tensor_search_inplace:
+
+tensor 元素查找相关原位（inplace）版本
+::::::::::::::::::::
+
+.. csv-table::
+    :header: "API 名称", "API 功能"
+    :widths: 10, 30
+
+    " :ref:`paddle.where_ <cn_api_paddle_where_>` ", "Inplace 版本的 where API，对输入 x 采用 Inplace 策略"
+
 .. _tensor_initializer:
 
 tensor 初始化相关
@@ -405,6 +418,18 @@ tensor 线性代数相关
     " :ref:`paddle.pdist <cn_api_paddle_pdist>` ", "计算输入形状为 N x M 的 Tensor 中 N 个向量两两组合(pairwise)的 p 范数"
     " :ref:`paddle.renorm <cn_api_paddle_renorm>` ", "计算沿轴的 p 范数"
 
+.. _tensor_linalg_inplace:
+
+tensor 线性代数相关原位（inplace）版本
+::::::::::::::::::::
+
+.. csv-table::
+    :header: "API 名称", "API 功能"
+    :widths: 10, 30
+
+    " :ref:`paddle.tril_ <cn_api_paddle_tril_>` ", "Inplace 版本的 tril API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.triu_ <cn_api_paddle_triu_>` ", "Inplace 版本的 triu API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.trunc_ <cn_api_paddle_trunc_>` ", "Inplace 版本的 trunc API，对输入 x 采用 Inplace 策略"
 
 .. _tensor_manipulation:
 

--- a/docs/api/paddle/tril__cn.rst
+++ b/docs/api/paddle/tril__cn.rst
@@ -1,0 +1,11 @@
+.. _cn_api_paddle_tril_:
+
+tril\_
+-------------------------------
+
+.. py:function:: paddle.tril_(x, diagonal=0, name=None)
+Inplace 版本的 :ref:`cn_api_paddle_tril` API，对输入 x 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3

--- a/docs/api/paddle/triu__cn.rst
+++ b/docs/api/paddle/triu__cn.rst
@@ -1,0 +1,11 @@
+.. _cn_api_paddle_triu_:
+
+triu\_
+-------------------------------
+
+.. py:function:: paddle.triu_(x, diagonal=0, name=None)
+Inplace 版本的 :ref:`cn_api_paddle_triu` API，对输入 x 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3

--- a/docs/api/paddle/trunc__cn.rst
+++ b/docs/api/paddle/trunc__cn.rst
@@ -1,0 +1,11 @@
+.. _cn_api_paddle_trunc_:
+
+trunc\_
+-------------------------------
+
+.. py:function:: paddle.trunc_(input, name=None)
+Inplace 版本的 :ref:`cn_api_paddle_trunc` API，对输入 x 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3

--- a/docs/api/paddle/where__cn.rst
+++ b/docs/api/paddle/where__cn.rst
@@ -1,0 +1,11 @@
+.. _cn_api_paddle_where_:
+
+where\_
+-------------------------------
+
+.. py:function:: paddle.where_(condition, x=None, y=None, name=None)
+Inplace 版本的 :ref:`cn_api_paddle_where` API，对输入 x 采用 Inplace 策略。
+
+更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
+
+.. _3.1.3 原位（Inplace）操作和非原位操作的区别: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/tensor_cn.html#id3


### PR DESCRIPTION
新增了tril__cn.rst、triu__cn.rst、trunc__cn.rst、where__cn.rst中文文档，在Overview_cn.rst中新增tril_、triu_、trunc_、where_说明。
issue: https://github.com/PaddlePaddle/docs/issues/7090
英文文档链接：
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/tril__en.html
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/triu__en.html
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/trunc__en.html
https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/where__en.html
@sunzhongkai588