### PR TITLE
[Docathon][Fix note No.29-38]

### DIFF
--- a/docs/api/paddle/static/nn/conv2d_transpose_cn.rst
+++ b/docs/api/paddle/static/nn/conv2d_transpose_cn.rst
@@ -70,12 +70,12 @@ conv2d_transpose
     & W'_{out} = (W_{in}-1)*strides[1] + dilations[1]*(W_f-1)+1 \\
 
 .. note::
-如果 output_size 为 None，则 :math:`H_{out}` = :math:`H^\prime_{out}` , :math:`W_{out}` = :math:`W^\prime_{out}`；
-否则，指定的 output_size_height（输出特征层的高） :math:`H_{out}` 应当介于 :math:`H^\prime_{out}` 和 :math:`H^\prime_{out} + strides[0]` 之间（不包含 :math:`H^\prime_{out} + strides[0]` ），并且指定的 output_size_width（输出特征层的宽） :math:`W_{out}` 应当介于 :math:`W^\prime_{out}` 和 :math:`W^\prime_{out} + strides[1]` 之间（不包含 :math:`W^\prime_{out} + strides[1]` ）。
+    如果 output_size 为 None，则 :math:`H_{out}` = :math:`H^\prime_{out}` , :math:`W_{out}` = :math:`W^\prime_{out}`；
+    否则，指定的 output_size_height（输出特征层的高） :math:`H_{out}` 应当介于 :math:`H^\prime_{out}` 和 :math:`H^\prime_{out} + strides[0]` 之间（不包含 :math:`H^\prime_{out} + strides[0]` ），并且指定的 output_size_width（输出特征层的宽） :math:`W_{out}` 应当介于 :math:`W^\prime_{out}` 和 :math:`W^\prime_{out} + strides[1]` 之间（不包含 :math:`W^\prime_{out} + strides[1]` ）。
 
-由于转置卷积可以当成是卷积的反向计算，而根据卷积的输入输出计算公式来说，不同大小的输入特征层可能对应着相同大小的输出特征层，所以对应到转置卷积来说，固定大小的输入特征层对应的输出特征层大小并不唯一。
+    由于转置卷积可以当成是卷积的反向计算，而根据卷积的输入输出计算公式来说，不同大小的输入特征层可能对应着相同大小的输出特征层，所以对应到转置卷积来说，固定大小的输入特征层对应的输出特征层大小并不唯一。
 
-如果指定了 output_size， ``conv2d_transpose`` 可以自动计算滤波器的大小。
+    如果指定了 output_size， ``conv2d_transpose`` 可以自动计算滤波器的大小。
 
 参数
 ::::::::::::

--- a/docs/api/paddle/static/nn/conv3d_transpose_cn.rst
+++ b/docs/api/paddle/static/nn/conv3d_transpose_cn.rst
@@ -77,12 +77,12 @@ conv3d_transpose
 
 .. note::
 
-如果 output_size 为 None，则 :math:`D_{out}` = :math:`D^\prime_{out}` , :math:`H_{out}` = :math:`H^\prime_{out}` , :math:`W_{out}` = :math:`W^\prime_{out}`；
-否则，指定的 output_size_depth（输出特征层的深度） :math:`D_{out}` 应当介于 :math:`D^\prime_{out}` 和 :math:`D^\prime_{out} + strides[0]` 之间（不包含 :math:`D^\prime_{out} + strides[0]` ），指定的 output_size_height（输出特征层的高） :math:`H_{out}` 应当介于 :math:`H^\prime_{out}` 和 :math:`H^\prime_{out} + strides[1]` 之间（不包含 :math:`H^\prime_{out} + strides[1]` ），并且指定的 output_size_width（输出特征层的宽） :math:`W_{out}` 应当介于 :math:`W^\prime_{out}` 和 :math:`W^\prime_{out} + strides[2]` 之间（不包含 :math:`W^\prime_{out} + strides[2]` ）。
+    如果 output_size 为 None，则 :math:`D_{out}` = :math:`D^\prime_{out}` , :math:`H_{out}` = :math:`H^\prime_{out}` , :math:`W_{out}` = :math:`W^\prime_{out}`；
+    否则，指定的 output_size_depth（输出特征层的深度） :math:`D_{out}` 应当介于 :math:`D^\prime_{out}` 和 :math:`D^\prime_{out} + strides[0]` 之间（不包含 :math:`D^\prime_{out} + strides[0]` ），指定的 output_size_height（输出特征层的高） :math:`H_{out}` 应当介于 :math:`H^\prime_{out}` 和 :math:`H^\prime_{out} + strides[1]` 之间（不包含 :math:`H^\prime_{out} + strides[1]` ），并且指定的 output_size_width（输出特征层的宽） :math:`W_{out}` 应当介于 :math:`W^\prime_{out}` 和 :math:`W^\prime_{out} + strides[2]` 之间（不包含 :math:`W^\prime_{out} + strides[2]` ）。
 
-由于转置卷积可以当成是卷积的反向计算，而根据卷积的输入输出计算公式来说，不同大小的输入特征层可能对应着相同大小的输出特征层，所以对应到转置卷积来说，固定大小的输入特征层对应的输出特征层大小并不唯一。
+    由于转置卷积可以当成是卷积的反向计算，而根据卷积的输入输出计算公式来说，不同大小的输入特征层可能对应着相同大小的输出特征层，所以对应到转置卷积来说，固定大小的输入特征层对应的输出特征层大小并不唯一。
 
-如果指定了 output_size， ``conv3d_transpose`` 可以自动计算滤波器的大小。
+    如果指定了 output_size， ``conv3d_transpose`` 可以自动计算滤波器的大小。
 
 参数
 ::::::::::::

--- a/docs/api/paddle/static/nn/embedding_cn.rst
+++ b/docs/api/paddle/static/nn/embedding_cn.rst
@@ -16,7 +16,7 @@ embedding
 输出的 Tensor 的 shape 是将输入 Tensor shape 的会在输出的 embedding 最后追加一维 emb_size。
 
 .. note::
-input 中的 id 必须满足 ``0 =< id < size[0]``，否则程序会抛异常退出。
+    input 中的 id 必须满足 ``0 =< id < size[0]``，否则程序会抛异常退出。
 
 
 ::

--- a/docs/api/paddle/static/nn/sequence_concat_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_concat_cn.rst
@@ -7,7 +7,7 @@ sequence_concat
 .. py:function:: paddle.static.nn.sequence_concat(input, name=None)
 
 .. note::
-该 OP 的输入只能是带有 LoD 信息的 Tensor，如果您需要处理的输入是一般的 Tensor 类型，请使用 :ref:`paddle.concat <cn_api_paddle_concat>` 。
+    该 OP 的输入只能是带有 LoD 信息的 Tensor，如果您需要处理的输入是一般的 Tensor 类型，请使用 :ref:`paddle.concat <cn_api_paddle_concat>` 。
 
 **该 OP 仅支持带有 LoD 信息的 Tensor**，通过 LoD 信息将输入的多个 Tensor 进行连接（concat），输出连接后的 Tensor。
 

--- a/docs/api/paddle/static/nn/sequence_conv_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_conv_cn.rst
@@ -7,8 +7,8 @@ sequence_conv
 .. py:function:: paddle.static.nn.sequence_conv(input, num_filters, filter_size=3, filter_stride=1, padding=True, padding_start=None, bias_attr=None, param_attr=None, act=None, name=None)
 
 .. note::
-1. 该 API 的输入只能是带有 LoD 信息的 Tensor，如果您需要处理的输入是普通的 Tensor 类型，请使用 :ref:`paddle.nn.functional.conv2d <cn_api_paddle_nn_functional_conv2d>` 。
-2. 参数 ``padding`` 为无用参数，将在未来的版本中被移除。
+    1. 该 API 的输入只能是带有 LoD 信息的 Tensor，如果您需要处理的输入是普通的 Tensor 类型，请使用 :ref:`paddle.nn.functional.conv2d <cn_api_paddle_nn_functional_conv2d>` 。
+    2. 参数 ``padding`` 为无用参数，将在未来的版本中被移除。
 
 
 在给定的卷积参数下（如卷积核数目、卷积核大小等），对输入的变长序列（sequence）Tensor 进行卷积操作。默认情况下，该 OP 会自适应地在每个输入序列的两端等长地填充全 0 数据，以确保卷积后的序列输出长度和输入长度一致。支持通过配置 ``padding_start`` 参数来指定序列填充的行为。

--- a/docs/api/paddle/static/nn/sequence_enumerate_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_enumerate_cn.rst
@@ -9,7 +9,7 @@ sequence_enumerate
 枚举形状为 ``[d_1, 1]`` 的输入序列所有长度为 ``win_size`` 的子序列，生成一个形状为 ``[d_1, win_size]`` 的新序列，需要时以 ``pad_value`` 填充。
 
 .. note::
-该 API 的输入 ``input`` 只能是 LodTensor。
+    该 API 的输入 ``input`` 只能是 LodTensor。
 
 范例如下：
 

--- a/docs/api/paddle/static/nn/sequence_expand_as_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_expand_as_cn.rst
@@ -9,7 +9,7 @@ sequence_expand_as
 Sequence Expand As Layer，该 OP 根据输入 ``y`` 的第 0 级 lod 对输入 ``x`` 进行扩展。当前实现要求 ``y`` 的 lod 层数（level）必须为 1，且 ``x`` 的第一维必须和 ``y`` 的第 0 层 lod 大小相同，所以扩展后的 LodTensor 具有和 ``y`` 相同的 lod。扩展结果与输入 ``x`` 的 lod 无关，所以无需考虑 ``x`` 的 lod。
 
 .. note::
-该 API 的输入 ``x`` 可以是 Tensor， ``y`` 只能是 LodTensor。
+    该 API 的输入 ``x`` 可以是 Tensor， ``y`` 只能是 LodTensor。
 
 范例解释如下：
 

--- a/docs/api/paddle/static/nn/sequence_expand_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_expand_cn.rst
@@ -11,7 +11,7 @@ sequence_expand
 序列扩张层（Sequence Expand Layer)，根据输入 ``y`` 的第 ``ref_level`` 层 lod 对输入 ``x`` 进行扩展。``x`` 的 lod level 最多为 1，若 ``x`` 的 lod level 为 1，则 ``x`` 的 lod 大小必须与 ``y`` 的第 ``ref_level`` 层 lod 大小相等；若 ``x`` 的 lod level 为 0，则 ``x`` 的第一维大小必须与 ``y`` 第 ``ref_level`` 层大小相等。``x`` 的秩最少为 2，当 ``x`` 的秩大于 2 时，将被当作是一个二维 Tensor 处理。
 
 .. note::
-该 API 的输入 ``x`` 可以是 Tensor 或 DenseTensor， ``y`` 只能是 DenseTensor。
+    该 API 的输入 ``x`` 可以是 Tensor 或 DenseTensor， ``y`` 只能是 DenseTensor。
 
 范例解释如下：
 

--- a/docs/api/paddle/static/nn/sequence_first_step_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_first_step_cn.rst
@@ -7,7 +7,7 @@ sequence_first_step
 .. py:function:: paddle.static.nn.sequence_first_step(input)
 
 .. note::
-该 API 仅支持带有 LoD 信息的 Tensor 类型的输入。
+    该 API 仅支持带有 LoD 信息的 Tensor 类型的输入。
 
 对输入的 Tensor，在最后一层 lod_level 上，选取其每个序列（sequence）的第一个时间步（time_step）的特征向量作为池化后的输出向量。
 

--- a/docs/api/paddle/static/nn/sequence_last_step_cn.rst
+++ b/docs/api/paddle/static/nn/sequence_last_step_cn.rst
@@ -8,7 +8,7 @@ sequence_last_step
 
 
 .. note::
-该 API 仅支持带有 LoD 信息的 Tensor 类型的输入。
+    该 API 仅支持带有 LoD 信息的 Tensor 类型的输入。
 
 对输入的 Tensor，在最后一层 lod_level 上，选取其每个序列（sequence）的最后一个时间步（time-step）的特征向量作为池化后的输出向量。
 


### PR DESCRIPTION
fix notes:
`docs/api/paddle/static/nn/conv2d_transpose_cn.rst`
`docs/api/paddle/static/nn/conv3d_transpose_cn.rst`
`docs/api/paddle/static/nn/embedding_cn.rst`
`docs/api/paddle/static/nn/sequence_concat_cn.rst`
`docs/api/paddle/static/nn/sequence_conv_cn.rst`
`docs/api/paddle/static/nn/sequence_enumerate_cn.rst`
`docs/api/paddle/static/nn/sequence_expand_as_cn.rst`
`docs/api/paddle/static/nn/sequence_expand_cn.rst`
`docs/api/paddle/static/nn/sequence_last_step_cn.rst`
`docs/api/paddle/static/nn/sequence_last_step_cn.rst`