### PR TITLE
增加了inplace类cauchy_方法的中文文档

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -254,6 +254,7 @@ tensor 数学操作原位（inplace）版本
     " :ref:`paddle.nan_to_num_ <cn_api_paddle_nan_to_num_>` ", "Inplace 版本的 nan_to_num API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.i0_ <cn_api_paddle_i0_>` ", "Inplace 版本的 i0 API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.lcm_ <cn_api_paddle_lcm_>` ", "Inplace 版本的 lcm API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.cauchy_ <cn_api_paddle_cauchy_>` ", 对现有张量``x``进行原地修改,将所有元素替换为从柯西分布中随机采样的数值。
 
 
 

--- a/docs/api/paddle/cauchy__cn.rst
+++ b/docs/api/paddle/cauchy__cn.rst
@@ -1,0 +1,27 @@
+.. _cn_api_paddle_cauchy_:
+
+cauchy_
+-------------------------------
+
+.. py:function::paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric = 1, name: str | None = None)
+
+
+
+对现有张量``x``进行原地修改,将所有元素替换为从柯西分布中随机采样的数值。
+
+参数
+::::::::::::
+
+    - **x** (Tensor) - 输入的 Tensor，支持的数据类型为：float32、float64。
+    - **loc** (scalar|可选) - 分布峰值的位置参数，数据类型为 float32 或 float64。
+    - **scale** (scalar|可选) - 分布的尺度参数，数据类型为 float32 或 float64。
+    - **name** (str|可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+
+返回
+::::::::::::
+Tensor，对输入的张量``x`` 直接进行了修改，数据类型与输入时相同。
+
+代码示例
+::::::::::::
+
+COPY-FROM: paddle.cauchy_

--- a/docs/api/paddle/cauchy__cn.rst
+++ b/docs/api/paddle/cauchy__cn.rst
@@ -1,9 +1,9 @@
 .. _cn_api_paddle_cauchy_:
 
-cauchy_
+cauchy\_
 -------------------------------
 
-.. py:function::paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric = 1, name: str | None = None)
+.. py:function:: paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric = 1, name: str | None = None)
 
 
 


### PR DESCRIPTION
@sunzhongkai588
新增cauchy_.rst中文文档，同时在Overview_cn.rst中新增cauchy_相关信息（在“tensor 数学操作原位（inplace）版本”标题下）
issue：https://github.com/PaddlePaddle/docs/issues/7090
英文文档链接：https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/cauchy__en.html