### PR TITLE
[Docathon][Add Inplace CN Doc No.9] Create cauchy__cn.rst,Update Overview_cn.rst

### DIFF
--- a/docs/api/paddle/Overview_cn.rst
+++ b/docs/api/paddle/Overview_cn.rst
@@ -194,6 +194,7 @@ tensor 数学操作原位（inplace）版本
     " :ref:`paddle.baddbmm_ <cn_api_paddle_baddbmm_>` ", "Inplace 版本的 baddbmm API，对输入 input 采用 Inplace 策略"
     " :ref:`paddle.bernoulli_ <cn_api_paddle_bernoulli_>` ", "Inplace 版本的 bernoulli API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.bitwise_xor_ <cn_api_paddle_bitwise_xor_>` ", "Inplace 版本的 bitwise_xor API，对输入 x 采用 Inplace 策略"
+    " :ref:`paddle.cauchy_ <cn_api_paddle_cauchy_>` ", "Inplace 版本的 cauchy API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.tanh_ <cn_api_paddle_tanh_>` ", "Inplace 版本的 tanh API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.erf_ <cn_api_paddle_erf_>` ", "Inplace 版本的 erf API，对输入 x 采用 Inplace 策略"
     " :ref:`paddle.erfinv_ <cn_api_paddle_erfinv_>` ", "Inplace 版本的 erfinv API，对输入 x 采用 Inplace 策略"

--- a/docs/api/paddle/cauchy__cn.rst
+++ b/docs/api/paddle/cauchy__cn.rst
@@ -3,21 +3,16 @@
 cauchy\_
 ------------------------------
 
-.. py:function::   paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric =
-   1, name: str | None = None) →
-   paddle.Tensor[`source <https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/tensor/creation.py#L3215>`__]
+.. py:function:: paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric = 1, name: str | None = None)
 
 使用 Cauchy 分布中的数字填充张量。
 
 参数
 :::::::::
-   -  **x** (Tensor) – 将被填充的张量，数据类型为 float32 或 float64。
-   -  **loc** (scalar, optional) – 分布峰值的位置。数据类型为 float32 或
-      float64。
-   -  **scale** (scalar, optional) – 半高宽（HWHM）。数据类型为 float32 或
-      float64。必须为正值。
-   -  **name** (str|None, optional) –
-      具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+   -  **x** (Tensor) - 将被填充的张量，数据类型为 float32 或 float64。
+   -  **loc** (scalar, optional) - 分布峰值的位置。数据类型为 float32 或 float64。
+   -  **scale** (scalar, optional) - 半高宽(HWHM)。数据类型为 float32 或 float64。必须为正值。
+   -  **name** (str|None, optional) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 ..
 

--- a/docs/api/paddle/cauchy__cn.rst
+++ b/docs/api/paddle/cauchy__cn.rst
@@ -4,7 +4,7 @@ cauchy\_
 ------------------------------
 
 .. py:function::   paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric =
-   1, name: str \| None = None) →
+   1, name: str | None = None) →
    paddle.Tensor[`source <https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/tensor/creation.py#L3215>`__]
 
 使用 Cauchy 分布中的数字填充张量。

--- a/docs/api/paddle/cauchy__cn.rst
+++ b/docs/api/paddle/cauchy__cn.rst
@@ -1,0 +1,35 @@
+.. _cn_api_paddle_cauchy_:
+
+cauchy\_
+------------------------------
+
+.. py:function::   paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric =
+   1, name: str \| None = None) →
+   paddle.Tensor[`source <https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/tensor/creation.py#L3215>`__]
+
+使用 Cauchy 分布中的数字填充张量。
+
+参数
+:::::::::
+   -  **x** (Tensor) – 将被填充的张量，数据类型为 float32 或 float64。
+   -  **loc** (scalar, optional) – 分布峰值的位置。数据类型为 float32 或
+      float64。
+   -  **scale** (scalar, optional) – 半高宽（HWHM）。数据类型为 float32 或
+      float64。必须为正值。
+   -  **name** (str|None, optional) –
+      具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+
+..
+
+返回
+:::::::::
+使用 Cauchy 分布中的数字填充的输入张量。
+
+返回类型
+:::::::::
+Tensor
+
+代码示例
+:::::::::
+
+COPY-FROM: paddle.cauchy_

--- a/docs/api/paddle/cauchy__cn.rst
+++ b/docs/api/paddle/cauchy__cn.rst
@@ -5,24 +5,21 @@ cauchy\_
 
 .. py:function:: paddle.cauchy_(x: paddle.Tensor, loc: Numeric = 0, scale: Numeric = 1, name: str | None = None)
 
-使用 Cauchy 分布中的数字填充张量。
+使用柯西分布(Cauchy distribution)随机数就地(Inplace)填充输入张量 x 。
 
 参数
 :::::::::
    -  **x** (Tensor) - 将被填充的张量，数据类型为 float32 或 float64。
-   -  **loc** (scalar, optional) - 分布峰值的位置。数据类型为 float32 或 float64。
-   -  **scale** (scalar, optional) - 半高宽(HWHM)。数据类型为 float32 或 float64。必须为正值。
-   -  **name** (str|None, optional) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+   -  **loc** (scalar, 可选) - 分布峰值的位置。数据类型为 float32 或 float64。
+   -  **scale** (scalar, 可选) - 半高宽(HWHM)。数据类型为 float32 或 float64。必须为正值。
+   -  **name** (str|None, 可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 ..
 
 返回
 :::::::::
-使用 Cauchy 分布中的数字填充的输入张量。
+输出 Tensor, 使用 Cauchy 分布中的数字填充的输入张量。
 
-返回类型
-:::::::::
-Tensor
 
 代码示例
 :::::::::


### PR DESCRIPTION

【Docathon】补充缺失的中文 API 文档（Inplace 类）
No.9 paddle.cauchy_ 的中文文档补充

增加：
新增cauchy__cn.rst中文文档

修改：
Overview_cn.rst中新增cauchy_相关信息（在“tensor 数学操作原位（inplace）版本”标题下）

issue：https://github.com/PaddlePaddle/docs/issues/7090
英文文档链接：https://www.paddlepaddle.org.cn/documentation/docs/en/3.0-beta/api/paddle/cauchy__en.html
@sunzhongkai588