### PR TITLE
解决 安装编译依赖路径不正确的问题

### DIFF
--- a/docs/install/compile/linux-compile-by-make.md
+++ b/docs/install/compile/linux-compile-by-make.md
@@ -157,7 +157,7 @@ mkdir -p /paddle/build && cd /paddle/build
 
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12
@@ -429,7 +429,7 @@ mkdir build && cd build
 
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12

--- a/docs/install/compile/linux-compile-by-make_en.md
+++ b/docs/install/compile/linux-compile-by-make_en.md
@@ -175,7 +175,7 @@ apt install patchelf
 ```
 - Install compilation dependencies
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 #### 9. Execute cmake:

--- a/docs/install/compile/linux-compile-by-ninja.md
+++ b/docs/install/compile/linux-compile-by-ninja.md
@@ -149,7 +149,7 @@ mkdir -p /paddle/build && cd /paddle/build
 #### 8. 使用以下命令安装相关依赖：
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12
 #### 9. 执行 cmake：
@@ -348,7 +348,7 @@ mkdir build && cd build
 
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12

--- a/docs/install/compile/macos-compile-make.md
+++ b/docs/install/compile/macos-compile-make.md
@@ -101,7 +101,7 @@ mkdir -p /paddle/build && cd /paddle/build
 
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12
@@ -245,7 +245,7 @@ mkdir build && cd build
 
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12

--- a/docs/install/compile/macos-compile-make_en.md
+++ b/docs/install/compile/macos-compile-make_en.md
@@ -119,7 +119,7 @@ apt install patchelf
 
 > Install compilation dependencies
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 #### 10. Execute cmake:

--- a/docs/install/compile/macos-compile-ninja.md
+++ b/docs/install/compile/macos-compile-ninja.md
@@ -82,7 +82,7 @@ mkdir -p /paddle/build && cd /paddle/build
 #### 9. 使用以下命令安装相关依赖：
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12
 #### 10. 执行 cmake：
@@ -181,7 +181,7 @@ mkdir build && cd build
 
 - 安装编译依赖
 ```
-pip3.10 install -r /paddle/requirements.txt
+pip3.10 install -r /paddle/python/requirements.txt
 ```
 
 注意：以上用 Python3.10 命令来举例，如您的 Python 版本为 3.8/3.9/3.11/3.12，请将上述命令中的 pip3.10 改成 pip3.8/pip3.9/pip3.11/pip3.12

--- a/docs/install/compile/windows-compile.md
+++ b/docs/install/compile/windows-compile.md
@@ -34,7 +34,7 @@
     * 通过 `python --version` 检查默认 python 版本是否是预期版本，因为你的计算机可能安装有多个 python，可通过修改系统环境变量的顺序来修改默认 Python 版本。
     * 安装编译依赖
         ```
-        pip3.10 install -r /paddle/requirements.txt
+        pip3.10 install -r /paddle/python/requirements.txt
         ```
 
 4. 创建编译 Paddle 的文件夹（例如 D:\workspace），进入该目录并下载源码：

--- a/docs/install/compile/windows-compile_en.md
+++ b/docs/install/compile/windows-compile_en.md
@@ -35,7 +35,7 @@ There is one compilation methods in Windows system:
 
     > Install compilation dependencies
         ```
-        pip install -r /paddle/requirements.txt
+        pip install -r /paddle/python/requirements.txt
         ```
 
     > Git can be downloaded on the [official website](https://gitforwindows.org/) and added to the environment variable.


### PR DESCRIPTION
解决 issue：https://github.com/PaddlePaddle/docs/issues/7196

（https://github.com/PaddlePaddle/docs/pull/7216 的贡献者未继续修改）