### PR TITLE
[Docathon] supplement activation

### DIFF
--- a/docs/api_guides/low_level/layers/activations.rst
+++ b/docs/api_guides/low_level/layers/activations.rst
@@ -8,18 +8,29 @@
 
 PaddlePaddle 对大部分的激活函数进行了支持，其中有:
 
+* :ref:`cn_api_paddle_nn_functional_celu`
 * :ref:`cn_api_paddle_nn_functional_elu`
 * :ref:`cn_api_paddle_exp`
-* :ref:`cn_api_paddle_nn_functional_hardsigmoid`
+* :ref:`cn_api_paddle_nn_functional_glu`
+* :ref:`cn_api_paddle_nn_functional_gumbel_softmax`
 * :ref:`cn_api_paddle_nn_functional_hardshrink`
+* :ref:`cn_api_paddle_nn_functional_hardsigmoid`
+* :ref:`cn_api_paddle_nn_functional_hardswish`
+* :ref:`cn_api_paddle_nn_functional_hardtanh`
 * :ref:`cn_api_paddle_nn_functional_leaky_relu`
 * :ref:`cn_api_paddle_nn_functional_log_sigmoid`
+* :ref:`cn_api_paddle_nn_functional_log_softmax`
 * :ref:`cn_api_paddle_nn_functional_maxout`
+* :ref:`cn_api_paddle_nn_functional_mish`
 * :ref:`cn_api_paddle_pow`
 * :ref:`cn_api_paddle_nn_functional_prelu`
 * :ref:`cn_api_paddle_nn_functional_relu`
 * :ref:`cn_api_paddle_nn_functional_relu6`
+* :ref:`cn_api_paddle_nn_functional_rrelu`
+* :ref:`cn_api_paddle_nn_functional_selu`
 * :ref:`cn_api_paddle_nn_functional_sigmoid`
+* :ref:`cn_api_paddle_nn_functional_silu`
+* :ref:`cn_api_paddle_nn_functional_softmax`
 * :ref:`cn_api_paddle_nn_functional_softplus`
 * :ref:`cn_api_paddle_nn_functional_softshrink`
 * :ref:`cn_api_paddle_nn_functional_softsign`

--- a/docs/api_guides/low_level/layers/activations_en.rst
+++ b/docs/api_guides/low_level/layers/activations_en.rst
@@ -8,18 +8,29 @@ The activation function incorporates non-linearity properties into the neural ne
 
 PaddlePaddle supports most of the activation functions, including:
 
+* :ref:`api_paddle_nn_functional_celu`
 * :ref:`api_paddle_nn_functional_elu`
 * :ref:`api_paddle_exp`
-* :ref:`api_paddle_nn_functional_hardsigmoid`
+* :ref:`api_paddle_nn_functional_glu`
+* :ref:`api_paddle_nn_functional_gumbel_softmax`
 * :ref:`api_paddle_nn_functional_hardshrink`
+* :ref:`api_paddle_nn_functional_hardsigmoid`
+* :ref:`api_paddle_nn_functional_hardswish`
+* :ref:`api_paddle_nn_functional_hardtanh`
 * :ref:`api_paddle_nn_functional_leaky_relu`
 * :ref:`api_paddle_nn_functional_log_sigmoid`
+* :ref:`api_paddle_nn_functional_log_softmax`
 * :ref:`api_paddle_nn_functional_maxout`
+* :ref:`api_paddle_nn_functional_mish`
 * :ref:`api_paddle_pow`
 * :ref:`api_paddle_nn_functional_prelu`
 * :ref:`api_paddle_nn_functional_relu`
 * :ref:`api_paddle_nn_functional_relu6`
+* :ref:`api_paddle_nn_functional_rrelu`
+* :ref:`api_paddle_nn_functional_selu`
 * :ref:`api_paddle_tensor_sigmoid`
+* :ref:`api_paddle_nn_functional_silu`
+* :ref:`api_paddle_nn_functional_softmax`
 * :ref:`api_paddle_nn_functional_softplus`
 * :ref:`api_paddle_nn_functional_softshrink`
 * :ref:`api_paddle_nn_functional_softsign`


### PR DESCRIPTION
## Description
该PR是针对上一个PR的补充：#7297
将主框架中的 `activation.rst` 中的激活函数列表，和源码[activation源码](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/nn/functional/activation.py)进行对齐。目前develop分支中的 `activation.py` 中的激活函数比之前多了很多，而且均能使用：

![image](https://github.com/user-attachments/assets/92095e99-2841-48f4-9b2a-b03a1c832b7b)

### 文档 `docs/api_guides/low_level/layers/activations.rst` 中缺失以下函数：
```
* :ref:`cn_api_paddle_nn_functional_celu`
* :ref:`cn_api_paddle_nn_functional_glu`
* :ref:`cn_api_paddle_nn_functional_gumbel_softmax`
* :ref:`cn_api_paddle_nn_functional_hardsigmoid`
* :ref:`cn_api_paddle_nn_functional_hardswish`
* :ref:`cn_api_paddle_nn_functional_hardtanh`
* :ref:`cn_api_paddle_nn_functional_log_softmax`
* :ref:`cn_api_paddle_nn_functional_mish`
* :ref:`cn_api_paddle_nn_functional_rrelu`
* :ref:`cn_api_paddle_nn_functional_selu`
* :ref:`cn_api_paddle_nn_functional_silu`
* :ref:`cn_api_paddle_nn_functional_softmax`
```

### Inplace版本
另外还有 Inplace版本的，但是Inplace版本的好像不该放在这里面吧？所以就没有添加
```
elu_
leaky_relu_
relu_
softmax_
thresholded_relu_
```

activation源代码链接：https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/nn/functional/activation.py

@DrRyanHuang @sunzhongkai588 @luotao1 