### PR TITLE
[BIT] Fix fused_linear, fused_multi_head_attention doc

### DIFF
--- a/docs/api/paddle/incubate/nn/functional/fused_linear_cn.rst
+++ b/docs/api/paddle/incubate/nn/functional/fused_linear_cn.rst
@@ -12,6 +12,7 @@ fused_linear
   - **x** (Tensor) – 需要进行乘法运算的输入 Tensor。
   - **weight** (Tensor) – 需要进行乘法运算的权重 Tensor，它的阶数必须为 2。
   - **bias** (Tensor, 可选) – 输入的偏置 Tensor。如果为 None ，则不执行偏置加法。否则，将偏置加到矩阵乘法的结果上。默认值为 None。
+  - **trans_x** (bool, 可选) - 是否在乘法之前转置输入 Tensor。默认值：False。
   - **transpose_weight** (bool, 可选) - 是否在乘法之前转置权重。默认值：False。
   - **name** (str, 可选) - 如需详细信息，请参阅 :ref:`api_guide_Name` 。一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/incubate/nn/functional/fused_multi_head_attention_cn.rst
+++ b/docs/api/paddle/incubate/nn/functional/fused_multi_head_attention_cn.rst
@@ -16,27 +16,30 @@ fused_multi_head_attention 算子目前只支持在 GPU 下运行，其包含的
 .. code-block:: ipython
 
     # pseudocode
+    residual = x
     if pre_layer_norm:
-      out = layer_norm(x)
-      out = linear(out) + qkv) + bias
+        out = layer_norm(x)
     else:
-      out = linear(x) + bias
+        out = x
+    out = matmul(out, qkv_weight) + qkv_bias
     out = transpose(out, perm=[2, 0, 3, 1, 4])
     # extract q, k and v from out.
-    q = out[0:1,::]
+    q = out[0:1,::] * (head_dim ** -0.5)
     k = out[1:2,::]
     v = out[2:3,::]
-    out = q * k^t
+    out = matmul(q, k, transpose_y=True)
     out = attn_mask + out
     out = softmax(out)
     out = dropout(out)
-    out = out * v
+    out = matmul(out, v)
     out = transpose(out, perm=[0, 2, 1, 3])
-    out = out_linear(out)
-    if pre_layer_norm:
-        out = x + dropout(linear_bias + out)
+    out = linear(out, bias=None)
+    if add_residual:
+        out = residual + dropout(out + linear_bias)
     else:
-        out = layer_norm(x + dropout(linear_bias + out))
+        out = dropout(out + linear_bias)
+    if not pre_layer_norm:
+        out = layer_norm(out)
 
 
 值得注意的是，该 API 中，q, k, v 的 weight 被统一存储在一个权重 Tensor 中，形状为 `[3, num_heads, head_dim, embed_dim]` ,


### PR DESCRIPTION
## paddle.incubate.nn.functional.fused_linear

缺少 trans_x 的参数描述，为其补充。

## paddle.incubate.nn.functional.fused_multi_head_attention

原来文档的有一行是这样的

```python
out = linear(out) + qkv) + bias
```

看上去多打了 `qkv)`，并且原来的描述里缺少了 qkv 的矩阵乘法，发现源码[文档](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/incubate/nn/functional/fused_transformer.py#L544)的伪码描述更好，但是源码文档里算完 attention score 后的线性层相关行为描述为

```python
out = linear(out)
if add_residual:
    out = residual + dropout(out)
else:
    out = dropout(out)
# ...
```

和 kernel 实现不一致，在 [paddle/phi/kernels/fusion/gpu/fused_attention_kernel.cu](https://github.com/PaddlePaddle/Paddle/blob/release/3.1/paddle/phi/kernels/fusion/gpu/fused_attention_kernel.cu#L319-L362) 中为了采用融合算子 fused_dropout_layernorm_helper.ResidualDropoutBias 和 fused_dropout_layernorm_helper.LayernormResidualDropoutBias，linear 是无偏的，将偏置放到了融合算子的参数里，所以改为

```python
out = linear(out, bias=None)
if add_residual:
    out = residual + dropout(out + linear_bias)
else:
    out = dropout(out + linear_bias)
```

更符合算子的实现。