### PR TITLE
[API Compatibility] add tensor_split API alias

### DIFF
--- a/docs/api/paddle/tensor_split_cn.rst
+++ b/docs/api/paddle/tensor_split_cn.rst
@@ -21,7 +21,7 @@ tensor_split
        - **x** (Tensor) - 输入变量，数据类型为 bool、bfloat16、float16、float32、float64、uint8、int8、int32、int64 的多维 Tensor，其维度必须大于 0。
          别名： ``input``
        - **num_or_indices** (int|list|tuple) - 如果 ``num_or_indices`` 是一个整数 ``n`` ，则 ``x`` 沿 ``axis`` 拆分为 ``n`` 部分。如果 ``x`` 可被 ``n`` 整除，则每个部分都是 ``x.shape[axis]/n`` 。如果 ``x`` 不能被 ``n`` 整除，则前 ``int(x.shape[axis]%n)`` 个部分的大小将是 ``int(x.shape[axis]/n)+1`` ，其余部分的大小将是 ``int(x.shape[axis]/n)`` 。如果 ``num_or_indices`` 是整数索引的列表或元组，则在每个索引处沿 ``axis`` 分割 ``x`` 。例如， ``num_or_indices=[2, 4]`` 在 ``axis=0`` 时将沿轴 0 将 ``x`` 拆分为 ``x[：2]`` 、 ``x[2:4]`` 和 ``x[4:]`` 。
-         别名： ``indices``（类型为 list 或 tuple 时） 或 ``sections``（类型为 int 时）
+         别名： ``indices`` （类型为 list 或 tuple 时） 或 ``sections`` （类型为 int 时）
        - **axis** (int|Tensor，可选) - 整数或者形状为[]的 0-D Tensor，数据类型为 int32 或 int64。表示需要分割的维度。如果 ``axis < 0``，则划分的维度为 ``rank(x) + axis`` 。默认值为 0。
          别名： ``dim``
        - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。

--- a/docs/api/paddle/tensor_split_cn.rst
+++ b/docs/api/paddle/tensor_split_cn.rst
@@ -19,8 +19,11 @@ tensor_split
 参数
 :::::::::
        - **x** (Tensor) - 输入变量，数据类型为 bool、bfloat16、float16、float32、float64、uint8、int8、int32、int64 的多维 Tensor，其维度必须大于 0。
+         别名： ``input``
        - **num_or_indices** (int|list|tuple) - 如果 ``num_or_indices`` 是一个整数 ``n`` ，则 ``x`` 沿 ``axis`` 拆分为 ``n`` 部分。如果 ``x`` 可被 ``n`` 整除，则每个部分都是 ``x.shape[axis]/n`` 。如果 ``x`` 不能被 ``n`` 整除，则前 ``int(x.shape[axis]%n)`` 个部分的大小将是 ``int(x.shape[axis]/n)+1`` ，其余部分的大小将是 ``int(x.shape[axis]/n)`` 。如果 ``num_or_indices`` 是整数索引的列表或元组，则在每个索引处沿 ``axis`` 分割 ``x`` 。例如， ``num_or_indices=[2, 4]`` 在 ``axis=0`` 时将沿轴 0 将 ``x`` 拆分为 ``x[：2]`` 、 ``x[2:4]`` 和 ``x[4:]`` 。
+         别名： ``indices``（类型为 list 或 tuple 时） 或 ``sections``（类型为 int 时）
        - **axis** (int|Tensor，可选) - 整数或者形状为[]的 0-D Tensor，数据类型为 int32 或 int64。表示需要分割的维度。如果 ``axis < 0``，则划分的维度为 ``rank(x) + axis`` 。默认值为 0。
+         别名： ``dim``
        - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回


### PR DESCRIPTION
`tensor_split` have been updated to support parameter alias in Paddle.  https://github.com/PaddlePaddle/Paddle/pull/75042

This PR update documentation.