### PR TITLE
[API compatibility]Refine Documentation: Annotations for dtype Types

### DIFF
--- a/docs/api/paddle/Model_cn.rst
+++ b/docs/api/paddle/Model_cn.rst
@@ -263,7 +263,7 @@ summary(input_size=None, dtype=None)
 **参数**
 
     - **input_size** (tuple|InputSpec|list[tuple|InputSpec]，可选) - 输入 Tensor 的大小。如果网络只有一个输入，那么该值需要设定为 tuple 或 InputSpec。如果模型有多个输入。那么该值需要设定为 list[tuple|InputSpec]，包含每个输入的 shape 。如果该值没有设置，会将 ``self._inputs`` 作为输入。默认值：None。
-    - **dtype** (str，可选) - 输入 Tensor 的数据类型，如果没有给定，默认使用 ``float32`` 类型。默认值：None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入 Tensor 的数据类型，如果没有给定，默认使用 ``float32`` 类型。默认值：None。
 
 **返回**
 

--- a/docs/api/paddle/Tensor_cn.rst
+++ b/docs/api/paddle/Tensor_cn.rst
@@ -655,7 +655,7 @@ astype(dtype)
 将 Tensor 的类型转换为 ``dtype``，并返回一个新的 Tensor。
 
 参数：
-    - **dtype** (str) - 转换后的 dtype，支持'bool'，'float16'，'float32'，'float64'，'int8'，'int16'，
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 转换后的 dtype，支持'bool'，'float16'，'float32'，'float64'，'int8'，'int16'，
       'int32'，'int64'，'uint8'。
 
 返回：类型转换后的新的 Tensor
@@ -3431,7 +3431,7 @@ new_full(size, fill_value, \*, dtype=None, device=None, requires_grad=False, pin
     - **fill_value** (Scalar|Tensor) - 用于填充的常量值。若为 Tensor，则应为标量（0 维 Tensor）。
 
 关键字参数:
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
       若为 None，则默认与 ``self`` 的 dtype 一致。
     - **out** (Tensor，可选) - 用于保存输出结果的 Tensor，默认值为 None。
     - **device** (PlaceLike|None，可选) - 期望创建 Tensor 所在的设备。若为 None，则与 ``self`` 保持一致。
@@ -3455,7 +3455,7 @@ new_ones(size, \*, dtype=None, device=None, requires_grad=False, pin_memory=Fals
       若为列表或元组，其中元素需为整数或 0 维 Tensor。
 
 关键字参数:
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
       若为 None，则默认与 ``self`` 的 dtype 一致。
     - **out** (Tensor，可选) - 用于保存输出结果的 Tensor，默认值为 None。
     - **device** (PlaceLike|None，可选) - 期望创建 Tensor 所在的设备。若为 None，则与 ``self`` 保持一致。
@@ -3479,7 +3479,7 @@ new_zeros(size, \*, dtype=None, device=None, requires_grad=False, pin_memory=Fal
       若为列表或元组，其中元素需为整数或 0 维 Tensor。
 
 关键字参数:
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
       若为 None，则默认与 ``self`` 的 dtype 一致。
     - **out** (Tensor，可选) - 用于保存输出结果的 Tensor，默认值为 None。
     - **device** (PlaceLike|None，可选) - 期望创建 Tensor 所在的设备。若为 None，则与 ``self`` 保持一致。
@@ -3503,7 +3503,7 @@ new_empty(size, \*, dtype=None, device=None, requires_grad=False, pin_memory=Fal
       若为列表或元组，其中元素需为整数或 0 维 Tensor。
 
 关键字参数:
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，可选：``float16``、``float32``、``float64``、``int32``、``int64``、``complex64``、``complex128``。
       若为 None，则默认与 ``self`` 的 dtype 一致。
     - **out** (Tensor，可选) - 用于保存输出结果的 Tensor，默认值为 None。
     - **device** (PlaceLike|None，可选) - 期望创建 Tensor 所在的设备。若为 None，则与 ``self`` 保持一致。

--- a/docs/api/paddle/amp/auto_cast_cn.rst
+++ b/docs/api/paddle/amp/auto_cast_cn.rst
@@ -17,7 +17,7 @@ auto_cast
 - **custom_white_list** (set|list，可选) - 飞桨有默认的白名单，通常不需要设置自定义白名单。自定义白名单中的算子在计算时会被认为是数值安全的，并且对性能至关重要。如果设置了该名单，其中的算子会使用 float16/bfloat16 计算。
 - **custom_black_list** (set|list，可选) - 飞桨有默认的黑名单，可以根据模型特点设置自定义黑名单。自定义黑名单中的算子在计算时会被认为是数值危险的，它们的影响也可能会在下游算子中观察到。该名单中的算子不会转为 float16/bfloat16 计算。
 - **level** (str，可选) - 混合精度训练的优化级别，可为 ``O1`` 、``O2`` 或者 ``OD`` 模式。在 O1 级别下，在白名单中的算子将使用 float16/bfloat16 计算，在黑名单中的算子将使用 float32 计算。在 O2 级别下，模型的参数需要调用 ``decorate`` 转换为 float16/bfloat16， 如果算子的浮点型输入全是 float16/bfloat16，算子才会采用 float16/bfloat16 计算，若任意浮点型输入是 float32 类型，算子将采用 float32 计算。在 OD 级别下，飞桨默认的白名单中的算子，如卷积和矩阵乘运算使用 float16/bfloat16 计算，其他算子均使用 float32 计算。默认为 O1。
-- **dtype** (str，可选) - 使用的数据类型，可以是 float16 或 bfloat16。默认为 float16。
+- **dtype** (str|paddle.dtype|np.dtype，可选) - 使用的数据类型，可以是 float16 或 bfloat16。默认为 float16。
 - **use_promote** (bool，可选) - 当一个算子存在 float32 类型的输入时，按照 Promote to the Widest 原则，选择 float32 数据类型进行计算。仅在 AMP-O2 训练时可配置。默认为 True。
 
 

--- a/docs/api/paddle/amp/decorate_cn.rst
+++ b/docs/api/paddle/amp/decorate_cn.rst
@@ -17,7 +17,7 @@ decorate
     - **models** (Layer|list of Layer) - 网络模型。在 ``O2`` 模式下，输入的模型参数将由 float32 转为 float16 或 bfloat16。
     - **optimizers** (Optimizer|list of Optimizer，可选) - 优化器，默认值为 None，若传入优化器或由优化器组成的 list 列表，将依据 master_weight 对优化器的 master_weight 属性进行设置。
     - **level** (str，可选) - 混合精度训练模式，默认 ``O1`` 模式。
-    - **dtype** (str，可选) - 混合精度训练数据类型使用 float16 还是 bfloat16，默认为 float16 类型。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 混合精度训练数据类型使用 float16 还是 bfloat16，默认为 float16 类型。
     - **master_weight** (bool|None，可选) - 是否使用 master weight 策略。支持 master weight 策略的优化器包括 ``adam``、``adamW``、``momentum``，默认值为 None，在 ``O2`` 模式下使用 master weight 策略。
     - **save_dtype** (str|None，可选) - 网络存储类型，可为 float16、bfloat16、float32、float64。通过 ``save_dtype`` 可指定通过 ``paddle.save`` 和 ``paddle.jit.save`` 存储的网络参数数据类型。默认为 None，采用现有网络参数类型进行存储。
     - **master_grad** (bool, 可选) - 在 ``O2`` 模式下是否使用 float32 类型的权重梯度进行梯度裁剪、权重衰减、权重更新等计算。如果被启用，在反向传播结束后权重的梯度将会是 float32 类型。默认值：False，模型仅保存一份 float16 类型的权重梯度。

--- a/docs/api/paddle/arange_cn.rst
+++ b/docs/api/paddle/arange_cn.rst
@@ -15,7 +15,7 @@ arange
   - **start** (float|int|Tensor) - 区间起点（且区间包括此值）。当 ``start`` 类型是 Tensor 时，是形状为[]且数据类型为 int32、int64、float32、float64 的 0-D Tensor。如果仅指定 ``start``，而 ``end`` 为 None，则区间为[0, ``start``)。默认值为 0。
   - **end** (float|int|Tensor，可选) - 区间终点（且通常区间不包括此值）。当 ``end`` 类型是 Tensor 时，是形状为[]且数据类型为 int32、int64、float32、float64 的 0-D Tensor。默认值为 None。
   - **step** (float|int|Tensor，可选) - 均匀分割的步长。当 ``step`` 类型是 Tensor 时，是形状为[]且数据类型为 int32、int64、float32、float64 的 0-D Tensor。默认值为 1。
-  - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。当该参数值为 None 时，输出 Tensor 的数据类型为 int64。默认值为 None。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。当该参数值为 None 时，输出 Tensor 的数据类型为 int64。默认值为 None。
 
 关键字参数
 ::::::::::::

--- a/docs/api/paddle/argmax_cn.rst
+++ b/docs/api/paddle/argmax_cn.rst
@@ -13,7 +13,7 @@ argmax
     - **x** (Tensor) - 输入的多维 ``Tensor``，支持的数据类型：float16、float32、float64、int16、int32、int64、uint8。
     - **axis** (int，可选) - 指定对输入 Tensor 进行运算的轴，``axis`` 的有效范围是[-R, R），R 是输入 ``x`` 的维度个数，``axis`` 为负数时，进行计算的 ``axis`` 与 ``axis`` + R 一致。默认值为 None，将会对输入的 `x` 进行平铺展开，返回最大值的索引。
     - **keepdim** (bool，可选) - 是否在输出 Tensor 中保留减小的维度。如果 keepdim 为 True，则输出 Tensor 和 x 具有相同的维度（减少的维度除外，减少的维度的大小为 1），默认值为 False。
-    - **dtype** (np.dtype|str，可选) - 输出 Tensor 的数据类型，可选值为 int32，int64，默认值为 int64，将返回 int64 类型的结果。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，可选值为 int32，int64，默认值为 int64，将返回 int64 类型的结果。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/argmin_cn.rst
+++ b/docs/api/paddle/argmin_cn.rst
@@ -13,7 +13,7 @@ argmin
     - **x** (Tensor) - 输入的多维 ``Tensor``，支持的数据类型：float16、float32、float64、int16、int32、int64、uint8。
     - **axis** (int，可选) - 指定对输入 Tensor 进行运算的轴， ``axis`` 的有效范围是[-R, R），R 是输入 ``x`` 的维度个数， ``axis`` 为负数时，进行计算的 ``axis`` 与 ``axis`` + R 一致。默认值为 None，将会对输入的 `x` 进行平铺展开，返回最小值的索引。
     - **keepdim** (bool，可选) - 是否保留进行最小值索引操作的轴，默认值为 False。
-    - **dtype** (np.dtype|str，可选) - 输出 Tensor 的数据类型，可选值为 int32、int64，默认值为'int64'，将返回 int64 类型的结果。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，可选值为 int32、int64，默认值为'int64'，将返回 int64 类型的结果。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/audio/features/LogMelSpectrogram_cn.rst
+++ b/docs/api/paddle/audio/features/LogMelSpectrogram_cn.rst
@@ -26,7 +26,7 @@ LogMelSpectrogram
     - **ref_value** (float，可选) - 参照值，如果小于 1.0，信号的 db 会被提升，相反 db 会下降，默认值为 1.0。
     - **amin** (float，可选) - 输入的幅值的最小值，默认是 1e-10。
     - **top_db** (float，可选) - log-mel 谱的最大值(db)，默认是 None。
-    - **dtype**  (str，可选) - 输入和窗的数据类型，默认是``float32``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入和窗的数据类型，默认是``float32``。
 
 
 返回

--- a/docs/api/paddle/audio/features/MFCC_cn.rst
+++ b/docs/api/paddle/audio/features/MFCC_cn.rst
@@ -27,7 +27,7 @@ MFCC
     - **ref_value** (float，可选) - 参照值， 如果小于 1.0，信号的 db 会被提升， 相反 db 会下降， 默认值为 1.0。
     - **amin** (float，可选) - 输入的幅值的最小值，默认是 1e-10。
     - **top_db** (float，可选) - log-mel 谱的最大值(db)，默认是 None。
-    - **dtype**  (str，可选) - 输入和窗的数据类型，默认是'float32'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入和窗的数据类型，默认是'float32'。
 
 返回
 :::::::::

--- a/docs/api/paddle/audio/features/MelSpectrogram_cn.rst
+++ b/docs/api/paddle/audio/features/MelSpectrogram_cn.rst
@@ -23,7 +23,7 @@ MelSpectrogram
     - **f_max** (float，可选) - 最大频率(hz)，默认为 None。
     - **htk** (bool，可选) - 在计算 fbank 矩阵时是否用在 HTK 公式缩放，默认是 False。
     - **norm** (Union[str, float]，可选) -计算 fbank 矩阵时正则化的种类，默认是'slaney'，也可以 norm=0.5，使用 p-norm 正则化。
-    - **dtype**  (str，可选) - 输入和窗的数据类型，默认是'float32'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入和窗的数据类型，默认是'float32'。
 
 
 返回

--- a/docs/api/paddle/audio/features/Spectrogram_cn.rst
+++ b/docs/api/paddle/audio/features/Spectrogram_cn.rst
@@ -17,7 +17,7 @@ Spectrogram
     - **power**  (float，可选) - 幅度谱的指数，默认是 1.0。
     - **center**  (bool，可选) - 对输入信号填充，如果 True，那么 t 以 t*hop_length 为中心，如果为 False，则 t 以 t*hop_length 开始，默认是 True。
     - **pad_mode**  (str，可选) - 如果 center 是 True，选择填充的方式，默认值是'reflect'。
-    - **dtype**  (str，可选) - 输入和窗的数据类型，默认是'float32'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选)- 输入和窗的数据类型，默认是'float32'。
 
 
 返回

--- a/docs/api/paddle/audio/functional/compute_fbank_matrix_cn.rst
+++ b/docs/api/paddle/audio/functional/compute_fbank_matrix_cn.rst
@@ -17,7 +17,7 @@ compute_fbank_matrix
     - **f_max** (Optional[float]，可选) - 最大频率(hz)，默认是 None。
     - **htk** (bool，可选) - 是否使用 htk 缩放，默认是 False。
     - **norm** (Union[str, float]，可选) - norm 的类型，默认是``slaney``。
-    - **dtype** (str，可选) - 返回矩阵的数据类型，默认``float32``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 返回矩阵的数据类型，默认``float32``。
 
 返回
 :::::::::

--- a/docs/api/paddle/audio/functional/create_dct_cn.rst
+++ b/docs/api/paddle/audio/functional/create_dct_cn.rst
@@ -13,7 +13,7 @@ create_dct
     - **n_mfcc** (float) - mel 倒谱系数数目。
     - **n_mels** (int) - mel 的 fliterbank 数。
     - **norm** (float，可选) - 正则化类型，默认值是'ortho'。
-    - **dtype** (str，可选) - 默认'float32'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 默认'float32'。
 
 返回
 :::::::::

--- a/docs/api/paddle/audio/functional/fft_frequencies_cn.rst
+++ b/docs/api/paddle/audio/functional/fft_frequencies_cn.rst
@@ -12,7 +12,7 @@ fft_frequencies
 
     - **sr** (int) - 采样率。
     - **n_fft** (int) - fft bins 的数目。
-    - **dtype** (str，可选) - 默认'float32'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 默认'float32'。
 
 返回
 :::::::::

--- a/docs/api/paddle/audio/functional/get_window_cn.rst
+++ b/docs/api/paddle/audio/functional/get_window_cn.rst
@@ -13,7 +13,7 @@ get_window
     - **window** (str 或者 Tuple[str，float]) - 窗函数类型，或者(窗参数类型， 窗函数参数)，支持的窗函数类型'hamming'，'hann'，'gaussian'，'general_gaussian'，'exponential'，'triang'，'bohman'，'blackman'，'cosine'，'tukey'，'taylor'，'bartlett'，'kaiser'，'nuttall'。
     - **win_length** (int) - 采样点数。
     - **fftbins** (bool，可选) -  如果是 True，给出一个周期性的窗，如果是 False 给出一个对称性的窗，默认是 True。
-    - **dtype** (str，可选) - 默认'float64'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 默认'float64'。
 
 返回
 :::::::::

--- a/docs/api/paddle/audio/functional/mel_frequencies_cn.rst
+++ b/docs/api/paddle/audio/functional/mel_frequencies_cn.rst
@@ -14,7 +14,7 @@ mel_frequencies
     - **f_min** (float，可选) - 最小频率(hz)，默认 0.0。
     - **f_max** (float，可选) - 最大频率(hz)，默认 11025.0。
     - **htk** (bool，可选) - 是否使用 htk 缩放，默认 False。
-    - **dtype** (str，可选) - 默认'float32'。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 默认'float32'。
 
 返回
 :::::::::

--- a/docs/api/paddle/cast_cn.rst
+++ b/docs/api/paddle/cast_cn.rst
@@ -19,7 +19,7 @@ cast
 ::::::::::::
 
     - **x** (Tensor) - 输入多维 Tensor，支持的数据类型为：bool、float16、float32、float64、uint8、int32、int64。
-    - **dtype** (str|np.dtype) - 输出 Tensor 的数据类型。支持的数据类型为：bool、float16、float32、float64、int8、int32、int64、uint8。
+    - **dtype** (str|paddle.dtype|np.dtype) - 输出 Tensor 的数据类型。支持的数据类型为：bool、float16、float32、float64、int8、int32、int64、uint8。
 
 返回
 ::::::::::::

--- a/docs/api/paddle/create_parameter_cn.rst
+++ b/docs/api/paddle/create_parameter_cn.rst
@@ -16,7 +16,7 @@ create_parameter
 ::::::::::::
 
     - **shape** (list[int]) - 指定输出 Tensor 的形状，它可以是一个整数列表。
-    - **dtype** (str|numpy.dtype) – 初始化数据类型。可设置的字符串值有："float16"，"float32"，"float64"。
+    - **dtype** (str|paddle.dtype|np.dtype) – 初始化数据类型。可设置的字符串值有："float16"，"float32"，"float64"。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
     - **attr** (ParamAttr，可选) - 指定参数的属性对象。具体用法请参见 :ref:`cn_api_paddle_ParamAttr`。默认值为 None，表示将采用 ParamAttr 的默认方式初始化。
     - **is_bias** (bool，可选) - 当 default_initializer 为空，该值会对选择哪个默认初始化程序产生影响。如果 is_bias 为真，则使用 initializer.Constant(0.0)，否则使用 Xavier()，默认值 False。

--- a/docs/api/paddle/cummax_cn.rst
+++ b/docs/api/paddle/cummax_cn.rst
@@ -14,7 +14,7 @@ cummax
 ::::::::::
     - **x** (Tensor) - 需要进行累积最大值操作的 Tensor。
     - **axis** (int，可选) - 指明需要累积最大值的维度。-1 代表最后一维。默认：None，将输入展开为一维变量再进行累积最大值计算。
-    - **dtype** (str，可选) - 输出 Indices 的数据类型，可以是 int32、int64，默认值为 int64。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Indices 的数据类型，可以是 int32、int64，默认值为 int64。
     - **name** (str，可选) - 具体用法请参见  :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/cummin_cn.rst
+++ b/docs/api/paddle/cummin_cn.rst
@@ -14,7 +14,7 @@ cummin
 ::::::::::
     - **x** (Tensor) - 需要进行累积最小值操作的 Tensor。
     - **axis** (int，可选) - 指明需要累积最小值的维度。-1 代表最后一维。默认：None，将输入展开为一维变量再进行累积最小值计算。
-    - **dtype** (str，可选) - 输出 Indices 的数据类型，可以是 int32、int64，默认值为 int64。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Indices 的数据类型，可以是 int32、int64，默认值为 int64。
     - **name** (str，可选) - 具体用法请参见  :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
 返回
 ::::::::::

--- a/docs/api/paddle/cumprod_cn.rst
+++ b/docs/api/paddle/cumprod_cn.rst
@@ -16,7 +16,7 @@ cumprod
 :::::::::
     - **x** (Tensor) - 累乘的输入，需要进行累乘操作的 tensor。
     - **dim** (int，可选) - 指明需要累乘的维度，取值范围需在[-x.rank,x.rank)之间，其中 x.rank 表示输入 tensor x 的维度，-1 代表最后一维。
-    - **dtype** (str，可选) - 输出 tensor 的数据类型，支持 int32、int64、bfloat16、float16、float32、float64、complex64、complex128。如果指定了，那么在执行操作之前，输入的 tensor 将被转换为 dtype 类型。这对于防止数据类型溢出非常有用。默认为：None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 tensor 的数据类型，支持 int32、int64、bfloat16、float16、float32、float64、complex64、complex128。如果指定了，那么在执行操作之前，输入的 tensor 将被转换为 dtype 类型。这对于防止数据类型溢出非常有用。默认为：None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/cumsum_cn.rst
+++ b/docs/api/paddle/cumsum_cn.rst
@@ -15,7 +15,7 @@ cumsum
 :::::::::
     - **x** (Tensor) - 累加的输入，需要进行累加操作的 Tensor。
     - **axis** (int，可选) - 指明需要累加的维度。-1 代表最后一维。默认：None，将输入展开为一维变量再进行累加计算。
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，支持 int32、int64、bfloat16、float16、float32、float64、complex64、complex128。当输入 `x` 的类型是 int8/int16/int32 时，默认值是 int64；否则默认值是 None。如果不为 None，那么在执行操作之前，输入 Tensor 将被转换为 dtype。这对于防止数据类型溢出非常有用。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、bfloat16、float16、float32、float64、complex64、complex128。当输入 `x` 的类型是 int8/int16/int32 时，默认值是 int64；否则默认值是 None。如果不为 None，那么在执行操作之前，输入 Tensor 将被转换为 dtype。这对于防止数据类型溢出非常有用。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/distributed/shard_tensor_cn.rst
+++ b/docs/api/paddle/distributed/shard_tensor_cn.rst
@@ -17,7 +17,7 @@ shard_tensor
     - **data** (scalar|tuple|list|ndarray|Tensor) - 初始化 Tensor 的数据，可以是 scalar，list，tuple，numpy\.ndarray，paddle\.Tensor 类型。
     - **mesh** (paddle.distributed.ProcessMesh) - 表示进程拓扑信息的 ProcessMesh 对象。
     - **placements** (list(Placement)) - 分布式 Tensor 的切分表示列表，描述 Tensor 在 mesh 上如何切分。
-    - **dtype** (str，可选) - 创建 Tensor 的数据类型，可以是 bool、float16、float32、float64、int8、int16、int32、int64、uint8、complex64、complex128。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 创建 Tensor 的数据类型，可以是 bool、float16、float32、float64、int8、int16、int32、int64、uint8、complex64、complex128。
       默认值为 None，如果 ``data`` 为 python 浮点类型，则从 :ref:`cn_api_paddle_get_default_dtype` 获取类型，如果 ``data`` 为其他类型，则会自动推导类型。
     - **place** (CPUPlace|CUDAPinnedPlace|CUDAPlace，可选) - 创建 tensor 的设备位置，可以是 CPUPlace、CUDAPinnedPlace、CUDAPlace。默认值为 None，使用全局的 place。
     - **stop_gradient** (bool，可选) - 是否阻断 Autograd 的梯度传导。默认值为 True，此时不进行梯度传传导。

--- a/docs/api/paddle/empty_cn.rst
+++ b/docs/api/paddle/empty_cn.rst
@@ -24,7 +24,7 @@ empty
       如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor，表示一个列表。
       如果 ``shape`` 是 \*shape，则可以直接以可变参数的形式传入多个整数（例如 ``randn(2, 3)``）。
       该参数的别名为 ``size``。
-    - **dtype** (np.dtype|str，可选)- 输出变量的数据类型，可以是 bool、float16、float32、float64、int32、int64、complex64、complex128。若为 None，则输出变量的数据类型为系统全局默认类型，默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选)- 输出变量的数据类型，可以是 bool、float16、float32、float64、int32、int64、complex64、complex128。若为 None，则输出变量的数据类型为系统全局默认类型，默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/empty_like_cn.rst
+++ b/docs/api/paddle/empty_like_cn.rst
@@ -12,7 +12,7 @@ empty_like
 ::::::::::::
 
     - **x** (Tensor) – 输入 Tensor，输出 Tensor 和 x 具有相同的形状，x 的数据类型可以是 bool、float16、float32、float64、int32、int64。
-    - **dtype** （np.dtype|str，可选）- 输出变量的数据类型，可以是 bool、float16、float32、float64、int32、int64。若参数为 None，则输出变量的数据类型和输入变量相同，默认值为 None。
+    - **dtype** （str|paddle.dtype|np.dtype，可选）- 输出变量的数据类型，可以是 bool、float16、float32、float64、int32、int64。若参数为 None，则输出变量的数据类型和输入变量相同，默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/eye_cn.rst
+++ b/docs/api/paddle/eye_cn.rst
@@ -12,7 +12,7 @@ eye
 
   - **num_rows** (int|Tensor) - 生成 2-D Tensor 的行数，数据类型为非负 int32。别名：``n``。
   - **num_columns** (int|Tensor|None，可选) - 生成 2-D Tensor 的列数，数据类型为非负 int32。若为 None，则默认等于 ``num_rows``。别名：``m``。
-  - **dtype** (np.dtype|str，可选) - 返回 Tensor 的数据类型。支持 int32、int64、float16、float32、float64、complex64、complex128。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 返回 Tensor 的数据类型。支持 int32、int64、float16、float32、float64、complex64、complex128。
     默认值为 None，此时返回 Tensor 的数据类型为 float32。
   - **name** (str，可选) - 操作的名称，具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/fft/fftfreq_cn.rst
+++ b/docs/api/paddle/fft/fftfreq_cn.rst
@@ -18,7 +18,7 @@ fftfreq
 
 - **n** (int) - 窗长度（傅里叶变换点数）。
 - **d** (float，可选) - 采样间隔，采样率的倒数，默认值为 1。
-- **dtype** (str，可选) - 返回 Tensor 的数据类型，默认为
+- **dtype** (str|paddle.dtype|np.dtype，可选) - 返回 Tensor 的数据类型，默认为
   ``paddle.get_default_dtype()`` 返回的类型。
 - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/fft/rfftfreq_cn.rst
+++ b/docs/api/paddle/fft/rfftfreq_cn.rst
@@ -20,7 +20,7 @@ rfftfreq
 
 - **n** (int) - 窗长度（傅里叶变换点数）。
 - **d** (float，可选) - 采样间隔，采样率的倒数，默认值为 1。
-- **dtype** (str，可选) - 返回 Tensor 的数据类型，默认为
+- **dtype** (str|paddle.dtype|np.dtype，可选) - 返回 Tensor 的数据类型，默认为
   ``paddle.get_default_dtype()`` 返回的类型。
 - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/finfo_cn.rst
+++ b/docs/api/paddle/finfo_cn.rst
@@ -17,7 +17,7 @@ finfo
 
 参数
 :::::::::
-    - **dtype** (paddle.dtype|str) - 输入的数据类型，可以是：paddle.float16、 paddle.float32、 paddle.float64、 paddle.bfloat16、 paddle.complex64、 paddle.complex128 或这些类型的字符串形式。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入的数据类型，可以是：paddle.float16、 paddle.float32、 paddle.float64、 paddle.bfloat16、 paddle.complex64、 paddle.complex128 或这些类型的字符串形式。
     - **type** - ``dtype`` 的别名，行为完全一致。
 
 返回

--- a/docs/api/paddle/full_cn.rst
+++ b/docs/api/paddle/full_cn.rst
@@ -18,7 +18,7 @@ full
       如果 ``shape`` 是 \*shape，则可以直接以可变参数的形式传入多个整数（例如 ``randn(2, 3)``）。
       该参数的别名为 ``size``。
     - **fill_value** (bool|float|int|Tensor) - 用于初始化输出 Tensor 的常量数据的值。如果 fill_value 是一个 Tensor ，它应该是一个表示标量的 0-D Tensor。注意：该参数不可超过输出变量数据类型的表示范围。
-    - **dtype** （np.dtype|str，可选）- 输出变量的数据类型，可以是 float16、float32、float64、int32、int64。如果 dytpe 为 None，则创建的 Tensor 的数据类型为 float32。默认值为 None。
+    - **dtype** （str|paddle.dtype|np.dtype，可选）- 输出变量的数据类型，可以是 float16、float32、float64、int32、int64。如果 dytpe 为 None，则创建的 Tensor 的数据类型为 float32。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/full_like_cn.rst
+++ b/docs/api/paddle/full_like_cn.rst
@@ -13,7 +13,7 @@ full_like
 
     - **x** (Tensor) – 输入 Tensor，输出 Tensor 和 x 具有相同的形状，x 的数据类型可以是 bool、float16、float32、float64、int32、int64。
     - **fill_value** (bool|float|int) - 用于初始化输出 Tensor 的常量数据的值。注意：该参数不可超过输出变量数据类型的表示范围。
-    - **dtype** (np.dtype|str，可选) - 输出变量的数据类型。若参数为 None，则输出变量的数据类型和输入变量相同，默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出变量的数据类型。若参数为 None，则输出变量的数据类型和输入变量相同，默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/linalg/norm_cn.rst
+++ b/docs/api/paddle/linalg/norm_cn.rst
@@ -57,7 +57,7 @@ norm
       别名： ``dim``
     - **keepdim** (bool，可选) - 是否在输出的 Tensor 中保留和输入一样的维度，默认值为 False。当 :attr:`keepdim` 为 False 时，输出的 Tensor 会比输入 :attr:`input` 的维度少一些。
     - **out** (Tensor，可选) - 存储输出的 Tensor，当 ``out = None`` 时，该参数无作用。
-    - **dtype** (str|paddle.dtype，可选) - 输出的数据类型，如果指定，则执行操作时输入张量将转换为 `dtype`。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出的数据类型，如果指定，则执行操作时输入张量将转换为 `dtype`。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/linspace_cn.rst
+++ b/docs/api/paddle/linspace_cn.rst
@@ -14,7 +14,7 @@ linspace
     - **start** (int|float|Tensor) – ``start`` 是区间开始的变量，可以是一个 int、float，或是一个 shape 为[0]的 Tensor，该 Tensor 的数据类型可以是 int32，int64，float32，float64。
     - **stop** (int|float|Tensor) – ``stop`` 是区间结束的变量，可以是一个 int、float，或是一个 shape 为[0]的 Tensor，该 Tensor 的数据类型可以是 int32，int64，float32，float64。
     - **num** (int|Tensor) – ``num`` 是给定区间内需要划分的区间数，可以是一个 int，或是一个 shape 为[0]的 Tensor，该 Tensor 的数据类型需为 int32。
-    - **dtype** (np.dtype|str，可选) – 输出 Tensor 的数据类型，可以是 int32，int64，float32，float64。如果 dtype 的数据类型为 None，输出 Tensor 数据类型为 float32。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) – 输出 Tensor 的数据类型，可以是 int32，int64，float32，float64。如果 dtype 的数据类型为 None，输出 Tensor 数据类型为 float32。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/logcumsumexp_cn.rst
+++ b/docs/api/paddle/logcumsumexp_cn.rst
@@ -20,7 +20,7 @@ logcumsumexp
 :::::::::
     - **x** (Tensor) - 需要进行操作的 Tensor。
     - **axis** (int，可选) - 指明需要计算的维度。-1 代表最后一维。默认：None，将输入展开为一维变量再进行计算。
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，支持 float16、float32、float64。如果指定了，那么在执行操作之前，输入 Tensor 将被转换为 dtype。这对于防止数据类型溢出非常有用。默认为：None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float16、float32、float64。如果指定了，那么在执行操作之前，输入 Tensor 将被转换为 dtype。这对于防止数据类型溢出非常有用。默认为：None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/logspace_cn.rst
+++ b/docs/api/paddle/logspace_cn.rst
@@ -17,7 +17,7 @@ logspace
     - **stop** (int|float|Tensor) – ``stop`` 是区间结束值以 ``base`` 为底的指数，可以是一个标量，或是一个 shape 为 [] 的 0-D Tensor，该 Tensor 的数据类型可以是 float32、float64、int32 或者 int64。
     - **num** (int|Tensor) – ``num`` 是给定区间内需要划分的区间数，可以是一个整型标量，或是一个 shape 为 [] 的 0-D Tensor，该 Tensor 的数据类型需为 int32。
     - **base** (int|float|Tensor) – ``base`` 是对数函数的底数，可以是一个标量，或是一个 shape 为 [] 的 0-D Tensor，该 Tensor 的数据类型可以是 float32、float64、int32 或者 int64。
-    - **dtype** (np.dtype|str，可选) – 输出 Tensor 的数据类型，可以是 float32、float64、int32 或者 int64。如果 dtype 的数据类型为 None，输出 Tensor 数据类型为 float32。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) – 输出 Tensor 的数据类型，可以是 float32、float64、int32 或者 int64。如果 dtype 的数据类型为 None，输出 Tensor 数据类型为 float32。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 

--- a/docs/api/paddle/nansum_cn.rst
+++ b/docs/api/paddle/nansum_cn.rst
@@ -11,7 +11,7 @@ nansum
 :::::::::
     - **x** (Tensor) - 输入的 Tensor，数据类型为：bfloat16、float16、float32、float64、int32 或 int64。
     - **axis** (int|list|tuple，可选) - 求和运算的维度。如果为 None，则计算所有元素的和并返回包含单个元素的 Tensor 变量，否则必须在 :math:`[−rank(x),rank(x)]` 范围内。如果 :math:`axis [i] <0`，则维度将变为 :math:`rank+axis[i]`，默认值为 None。
-    - **dtype** (str，可选) - 输出变量的数据类型。若参数为空，则输出变量的数据类型和输入变量相同，默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出变量的数据类型。若参数为空，则输出变量的数据类型和输入变量相同，默认值为 None。
     - **keepdim** (bool) - 是否在输出 Tensor 中保留减小的维度。如 keepdim 为 True，否则结果 Tensor 的维度将比输入 Tensor 小，默认值为 False。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/nn/BatchNorm_cn.rst
+++ b/docs/api/paddle/nn/BatchNorm_cn.rst
@@ -47,7 +47,7 @@ BatchNorm
     - **epsilon** (float，可选) - 为了数值稳定加在分母上的值。默认值：1e-05。
     - **param_attr** (ParamAttr，可选) - 指定权重参数属性的对象。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_paddle_ParamAttr` 。
     - **bias_attr** (ParamAttr，可选) - 指定偏置参数属性的对象。默认值为 None，表示使用默认的偏置参数属性。具体用法请参见 :ref:`cn_api_paddle_ParamAttr` 。
-    - **dtype** (str，可选) - 指明输入 ``Tensor`` 的数据类型，可以为 float32 或 float64。默认值：float32。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 指明输入 ``Tensor`` 的数据类型，可以为 float32 或 float64。默认值：float32。
     - **data_layout** (str，可选) - 指定输入数据格式，数据格式可以为 ``"NCHW"`` 或 ``"NHWC"``，其中 N 是批大小，C 是通道数，H 是特征高度，W 是特征宽度。默认值为 ``"NCHW"``。
     - **in_place** (bool，可选) - 指示 ``batch_norm`` 的输出是否可以复用输入内存。默认值：False。
     - **moving_mean_name** (str，可选) - ``moving_mean`` 的名称，存储全局均值。如果将其设置为 None, ``batch_norm`` 将随机命名全局均值；否则，``batch_norm`` 将命名全局均值为 ``moving_mean_name``。默认值：None。

--- a/docs/api/paddle/nn/Layer_cn.rst
+++ b/docs/api/paddle/nn/Layer_cn.rst
@@ -14,7 +14,7 @@ Layer
 ::::::::::::
 
     - **name_scope** (str，可选) - 为 Layer 内部参数命名而采用的名称前缀。如果前缀为“my_layer”，在一个类名为 MyLayer 的 Layer 中，参数名为“mylayer_0.w_n”，其中 w 是参数的名称，n 为自动生成的具有唯一性的后缀。如果为 None，前缀名将为小写的类名。默认值为 None。
-    - **dtype** (str 可选) - Layer 中参数数据类型。如果设置为 str，则可以是“bool”，“float16”，“float32”，“float64”，“int8”，“int16”，“int32”，“int64”，“uint8”或“uint16”。默认值为 "float32"。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - Layer 中参数数据类型。如果设置为 str，则可以是“bool”，“float16”，“float32”，“float64”，“int8”，“int16”，“int32”，“int64”，“uint8”或“uint16”。默认值为 "float32"。
 
 **返回**
 无
@@ -148,7 +148,7 @@ create_variable(name=None, persistable=None, dtype=None)
 
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
     - **persistable** (bool，可选) - 是否为持久性变量，后续会被移出。默认值：None。
-    - **dtype** (str，可选) - Layer 中参数数据类型。如果设置为 str，则可以是“bool”，“float16”，“float32”，“float64”，“int8”，“int16”，“int32”，“int64”，“uint8”或“uint16”。默认值为 "float32" 。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - Layer 中参数数据类型。如果设置为 str，则可以是“bool”，“float16”，“float32”，“float64”，“int8”，“int16”，“int32”，“int64”，“uint8”或“uint16”。默认值为 "float32" 。
 
 **返回**
 Tensor，返回创建的 ``Tensor``
@@ -166,7 +166,7 @@ create_tensor(name=None, persistable=None, dtype=None)
 
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
     - **persistable** (bool，可选) - 是否为持久性变量，后续会被移出。默认值：None。
-    - **dtype** (str，可选) - Layer 中参数数据类型。如果设置为 str，则可以是“bool”，“float16”，“float32”，“float64”，“int8”，“int16”，“int32”，“int64”，“uint8”或“uint16”。默认值为 "float32" 。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - Layer 中参数数据类型。如果设置为 str，则可以是“bool”，“float16”，“float32”，“float64”，“int8”，“int16”，“int32”，“int64”，“uint8”或“uint16”。默认值为 "float32" 。
 
 **返回**
 Tensor，返回创建的 ``Tensor``
@@ -434,7 +434,7 @@ to(device=None, dtype=None, blocking=None)
 **参数**
 
     - **device** （str|paddle.CPUPlace()|paddle.CUDAPlace()|paddle.CUDAPinnedPlace()|paddle.XPUPlace()|None，可选) - 希望存储 Layer 的设备位置。如果为 None，设备位置和原始的 Tensor 的设备位置一致。如果设备位置是 string 类型，取值可为 ``cpu``, ``gpu:x`` and ``xpu:x``，这里的 ``x`` 是 GPUs 或者 XPUs 的编号。默认值：None。
-    - **dtype** （str|numpy.dtype|paddle.dtype|None，可选) - 数据的类型。如果为 None，数据类型和原始的 Tensor 一致。默认值：None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选)- 数据的类型。如果为 None，数据类型和原始的 Tensor 一致。默认值：None。
     - **blocking** （bool|None，可选）- 如果为 False 并且当前 Tensor 处于固定内存上，将会发生主机到设备端的异步拷贝。否则，会发生同步拷贝。如果为 None，blocking 会被设置为 True。默认为 False。
 
 **代码示例**
@@ -447,7 +447,7 @@ astype(dtype=None)
 
 **参数**
 
-    - **dtype** (str | paddle.dtype | numpy.dtype) - 转换后的 dtype，str 类型支持"bool", "bfloat16", "float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "complex64", "complex128"。
+    - **dtype** (str|paddle.dtype|np.dtype，可选)- 转换后的 dtype，str 类型支持"bool", "bfloat16", "float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "complex64", "complex128"。
 
 返回：类型转换后的 Layer
 

--- a/docs/api/paddle/nn/SpectralNorm_cn.rst
+++ b/docs/api/paddle/nn/SpectralNorm_cn.rst
@@ -33,7 +33,7 @@ SpectralNorm
     - **power_iters** (int，可选) - 将用于计算的 ``SpectralNorm`` 功率迭代次数，默认值：1。
     - **eps** (float，可选) -  ``eps`` 用于保证计算规范中的数值稳定性，分母会加上 ``eps`` 防止除零。默认值：1e-12。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
-    - **dtype** (str，可选) - 数据类型，可以为"float32"或"float64"。默认值为"float32"。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 数据类型，可以为"float32"或"float64"。默认值为"float32"。
 
 形状
 :::::::::

--- a/docs/api/paddle/nn/functional/sequence_mask_cn.rst
+++ b/docs/api/paddle/nn/functional/sequence_mask_cn.rst
@@ -37,7 +37,7 @@ sequence_mask
 :::::::::
   - **x** (Tensor) - 输入 Tensor，其元素是小于等于 ``maxlen`` 的整数，形状为 ``[d_1, d_2，…, d_n]`` 的 Tensor。
   - **maxlen** (int，可选) - 序列的最大长度。默认为空，此时 ``maxlen`` 取 ``x`` 中所有元素的最大值。
-  - **dtype** (np.dtype|core.VarDesc.VarType|str，可选) - 输出的数据类型，默认为 ``int64`` 。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出的数据类型，默认为 ``int64`` 。
   - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/nn/functional/softmax_cn.rst
+++ b/docs/api/paddle/nn/functional/softmax_cn.rst
@@ -86,7 +86,7 @@ softmax
 
     - **x** (Tensor) - 输入的 ``Tensor``，数据类型为 bfloat16 、 float16 、 float32 或 float64。
     - **axis** (int，可选) - 指定对输入 :attr:`x` 进行运算的轴。:attr:`axis` 的有效范围是 :math:`[-D, D)`，:math:`D` 是输入 :attr:`x` 的维度，:attr:`axis` 为负值时与 :math:`axis + D` 等价。默认值为 -1。
-    - **dtype** (str，可选) - 输出 `Tensor` 的数据类型，支持 bfloat16、 float16、 float32、float64。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 `Tensor` 的数据类型，支持 bfloat16、 float16、 float32、float64。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/ones_cn.rst
+++ b/docs/api/paddle/ones_cn.rst
@@ -26,7 +26,7 @@ ones
       如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor，表示一个列表。
       如果 ``shape`` 是 \*shape，则可以直接以可变参数的形式传入多个整数（例如 ``randn(2, 3)``）。
       该参数的别名为 ``size``。
-    - **dtype** (np.dtype|str，可选) - 要创建的 Tensor 的数据类型，可以为 bool、float16、float32、float64、int32 或 int64。如果 ``dtype`` 为 None，那么数据类型为 float32。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 要创建的 Tensor 的数据类型，可以为 bool、float16、float32、float64、int32 或 int64。如果 ``dtype`` 为 None，那么数据类型为 float32。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/ones_like_cn.rst
+++ b/docs/api/paddle/ones_like_cn.rst
@@ -15,7 +15,7 @@ ones_like
 ::::::::::
     - **x** (Tensor) – 输入的 Tensor，数据类型可以是 bool，float16，float32，float64，int32，int64。
     - **input** - ``x`` 的别名，行为完全一致。
-    - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 bool，float16, float32，float64，int32，int64。当该参数值为 None 时，输出 Tensor 的数据类型与 ``x`` 相同。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 bool，float16, float32，float64，int32，int64。当该参数值为 None 时，输出 Tensor 的数据类型与 ``x`` 相同。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/prod_cn.rst
+++ b/docs/api/paddle/prod_cn.rst
@@ -20,7 +20,7 @@ prod
     - **axis** (int|list|tuple，可选) - 求乘积运算的维度。如果是 None，则计算所有元素的乘积并返回包含单个元素的 Tensor，否则该参数必须在 :math:`[-x.ndim, x.ndim)` 范围内。如果 :math:`axis[i] < 0`，则维度将变为 :math:`x.ndim + axis[i]`，默认为 None。
     - **dim** - ``axis`` 的别名，行为完全一致。
     - **keepdim** (bool，可选) - 是否在输出 Tensor 中保留输入的维度。除非 keepdim 为 True，否则输出 Tensor 的维度将比输入 Tensor 小一维，默认值为 False。
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。如果指定了该参数，那么在执行操作之前，输入 Tensor 将被转换为 dtype 类型。这对于防止数据类型溢出非常有用。若参数为空，则输出变量的数据类型和输入变量相同，默认为：None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。如果指定了该参数，那么在执行操作之前，输入 Tensor 将被转换为 dtype 类型。这对于防止数据类型溢出非常有用。若参数为空，则输出变量的数据类型和输入变量相同，默认为：None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/rand_cn.rst
+++ b/docs/api/paddle/rand_cn.rst
@@ -10,7 +10,7 @@ rand
 参数
 ::::::::::
     - **shape** (list|tuple|Tensor) - 生成的随机 Tensor 的形状。如果 ``shape`` 是 list、tuple，则其中的元素可以是 int，或者是形状为[]且数据类型为 int32、int64 的 0-D Tensor。如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor。
-    - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float32、float64。当该参数值为 None 时，输出 Tensor 的数据类型为 float32。使用全局默认 dtype（详细信息请见 :ref:`get_default_dtype` ）。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float32、float64。当该参数值为 None 时，输出 Tensor 的数据类型为 float32。使用全局默认 dtype（详细信息请见 :ref:`get_default_dtype` ）。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/randint_cn.rst
+++ b/docs/api/paddle/randint_cn.rst
@@ -12,7 +12,7 @@ randint
     - **low** (int，可选) - 要生成的随机值范围的下限，``low`` 包含在范围中。当 ``high`` 为 None 时，均匀采样的区间为[0, ``low``)。默认值为 0。
     - **high** (int，可选) - 要生成的随机值范围的上限，``high`` 不包含在范围中。默认值为 None，此时范围是[0, ``low``)。
     - **shape** (list|tuple|Tensor，可选) - 生成的随机 Tensor 的形状。如果 ``shape`` 是 list、tuple，则其中的元素可以是 int，或者是形状为[]且数据类型为 int32、int64 的 0-D Tensor。如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor。默认值为[1]。
-    - **dtype** (str|np.dtype|core.VarDesc.VarType，可选) - 输出 Tensor 的数据类型，支持 int32、int64。当该参数值为 None 时， 输出 Tensor 的数据类型为 int64。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64。当该参数值为 None 时， 输出 Tensor 的数据类型为 int64。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/randint_like_cn.rst
+++ b/docs/api/paddle/randint_like_cn.rst
@@ -12,7 +12,7 @@ randint_like
     - **x** (Tensor) – 输入的多维 Tensor，数据类型可以是 bool，int32，int64，float16，float32，float64。输出 Tensor 的形状和 ``x`` 相同。如果 ``dtype`` 为 None，则输出 Tensor 的数据类型与 ``x`` 相同。
     - **low** (int，可选) - 要生成的随机值范围的下限，``low`` 包含在范围中。当 ``high`` 为 None 时，均匀采样的区间为[0, ``low``)。默认值为 0。
     - **high** (int，可选) - 要生成的随机值范围的上限，``high`` 不包含在范围中。默认值为 None，此时范围是[0, ``low``)。
-    - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 bool，int32，int64，float16，float32，float64。当该参数值为 None 时，输出 Tensor 的数据类型与输入 Tensor 的数据类型一致。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 bool，int32，int64，float16，float32，float64。当该参数值为 None 时，输出 Tensor 的数据类型与输入 Tensor 的数据类型一致。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/randn_cn.rst
+++ b/docs/api/paddle/randn_cn.rst
@@ -15,7 +15,7 @@ randn
     如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor，表示一个列表。
     如果 ``shape`` 是 \*shape，则可以直接以可变参数的形式传入多个整数（例如 ``randn(2, 3)``）。
     该参数的别名为 ``size``。
-  - **dtype** (str|np.dtype|paddle.dtype|None，可选) - 输出 Tensor 的数据类型。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型。
     支持的数据类型包括：float16、bfloat16、float32、float64、complex64、complex128。
     默认值为 None，此时使用全局默认数据类型（可参考 ``get_default_dtype`` 了解详情）。
   - **name** (str，可选) - 操作的名称，具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。

--- a/docs/api/paddle/randn_like_cn.rst
+++ b/docs/api/paddle/randn_like_cn.rst
@@ -10,7 +10,7 @@ randn_like
 参数
 ::::::::::
     - **x** (Tensor) – 输入的多维 Tensor，数据类型可以是 float16，bfloat16，float32，float64，complex64，complex128。输出 Tensor 的形状和 ``x`` 相同。如果 ``dtype`` 为 None，则输出 Tensor 的数据类型与 ``x`` 相同。
-    - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float16，bfloat16，float32，float64，complex64，complex128。当该参数值为 None 时，输出 Tensor 的数据类型与输入 Tensor 的数据类型一致。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float16，bfloat16，float32，float64，complex64，complex128。当该参数值为 None 时，输出 Tensor 的数据类型与输入 Tensor 的数据类型一致。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/randperm_cn.rst
+++ b/docs/api/paddle/randperm_cn.rst
@@ -10,7 +10,7 @@ randperm
 参数
 ::::::::::::
   - **n** (int) - 随机序列的上限（不包括在序列中），应该大于 0。
-  - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。默认值为 int64。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。默认值为 int64。
   - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/range_cn.rst
+++ b/docs/api/paddle/range_cn.rst
@@ -13,7 +13,7 @@ range
   - **start** (float|int|Tensor) - 区间起点（且区间包括此值）。当 ``start`` 类型是 Tensor 时，是形状为[]且数据类型为 int32、int64、float32、float64 的 0-D Tensor。如果仅指定 ``start``，而 ``end`` 为 None，则区间为[0, ``start``)。默认值为 0。
   - **end** (float|int|Tensor，可选) - 区间终点（且通常区间不包括此值）。当 ``end`` 类型是 Tensor 时，是形状为[]且数据类型为 int32、int64、float32、float64 的 0-D Tensor。默认值为 None。
   - **step** (float|int|Tensor，可选) - 均匀分割的步长。当 ``step`` 类型是 Tensor 时，是形状为[]且数据类型为 int32、int64、float32、float64 的 0-D Tensor。默认值为 1。
-  - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。当该参数值为 None 时，输出 Tensor 的数据类型为 int64。默认值为 None。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 int32、int64、float32、float64。当该参数值为 None 时，输出 Tensor 的数据类型为 int64。默认值为 None。
 
 关键字参数
 ::::::::::::

--- a/docs/api/paddle/sparse/sparse_coo_tensor_cn.rst
+++ b/docs/api/paddle/sparse/sparse_coo_tensor_cn.rst
@@ -23,7 +23,7 @@ sparse_coo_tensor
     - **values** (list|tuple|ndarray|Tensor) - 初始化 tensor 的数据，可以是
       list，tuple，numpy\.ndarray，paddle\.Tensor 类型。
     - **shape** (list|tuple，可选) - 稀疏 Tensor 的形状，也是 Tensor 的形状，如果没有提供，将自动推测出最小的形状。
-    - **dtype** (str|np.dtype，可选) - 创建 tensor 的数据类型，可以是 'bool' ，'float16'，'float32'，
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 创建 tensor 的数据类型，可以是 'bool' ，'float16'，'float32'，
       'float64' ，'int8'，'int16'，'int32'，'int64'，'uint8'，'complex64'，'complex128'。
       默认值为 None，如果 ``values`` 为 python 浮点类型，则从
       :ref:`cn_api_paddle_get_default_dtype` 获取类型，如果 ``values`` 为其他类型，

--- a/docs/api/paddle/sparse/sparse_csr_tensor_cn.rst
+++ b/docs/api/paddle/sparse/sparse_csr_tensor_cn.rst
@@ -27,7 +27,7 @@ sparse_csr_tensor
     - **values** (list|tuple|ndarray|Tensor) - 一维数组，存储非零元素，可以是
       list，tuple，numpy\.ndarray，paddle\.Tensor 类型。
     - **shape** (list|tuple，可选) - 稀疏 Tensor 的形状，也是 Tensor 的形状，如果没有提供，将自动推测出最小的形状。
-    - **dtype** (str|np.dtype，可选) - 创建 tensor 的数据类型，可以是 'bool' ，'float16'，'float32'，
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 创建 tensor 的数据类型，可以是 'bool' ，'float16'，'float32'，
       'float64' ，'int8'，'int16'，'int32'，'int64'，'uint8'，'complex64'，'complex128'。
       默认值为 None，如果 ``values`` 为 python 浮点类型，则从
       :ref:`cn_api_paddle_get_default_dtype` 获取类型，如果 ``values`` 为其他类型，

--- a/docs/api/paddle/sparse/sum_cn.rst
+++ b/docs/api/paddle/sparse/sum_cn.rst
@@ -17,7 +17,7 @@ sum
 :::::::::
     - **x** (Tensor) - 输入的 Tensor，数据类型为 bool、float16、float32、float64、int32 或 int64。
     - **axis** (int|list|tuple，可选) - 沿着哪些维度进行求和操作。如果为 :attr:`None`，则对 :attr:`x` 的所有元素进行求和并返回一个只有一个元素的 Tensor；否则必须在 :math:`[-rank(x), rank(x))` 范围内。如果 :math:`axis[i] < 0`，则要减少的维度是 :math:`rank + axis[i]`。
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型。默认值为 None，表示与输入 Tensor `x` 数据类型一致。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型。默认值为 None，表示与输入 Tensor `x` 数据类型一致。
     - **keepdim** (bool，可选) - 是否在输出 Tensor 中保留减少的维度。如果为 True，则结果 Tensor 的维数比 :attr:`x` 少一维，否则与 :attr:`x` 维数一致。默认值为 False。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 

--- a/docs/api/paddle/standard_normal_cn.rst
+++ b/docs/api/paddle/standard_normal_cn.rst
@@ -10,7 +10,7 @@ standard_normal
 参数
 ::::::::::
   - **shape** (list|tuple|Tensor) - 生成的随机 Tensor 的形状。如果 ``shape`` 是 list、tuple，则其中的元素可以是 int，或者是形状为[]且数据类型为 int32、int64 的 0-D Tensor。如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor。
-  - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float16、bfloat16、float32、float64、complex64、complex128。当该参数值为 None 时，输出 Tensor 的数据类型为 float32。默认值为 None。
+  - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float16、bfloat16、float32、float64、complex64、complex128。当该参数值为 None 时，输出 Tensor 的数据类型为 float32。默认值为 None。
   - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/static/InputSpec_cn.rst
+++ b/docs/api/paddle/static/InputSpec_cn.rst
@@ -13,7 +13,7 @@ InputSpec
 ::::::::::::
 
   - **shape** (tuple(integers)|list[integers])- 声明维度信息的 list 或 tuple，默认值为 None。设置为 ``None`` 或 ``-1`` 时表示维度可以是任意大小。例如，可以将可变的批尺寸（batch size）设置为 ``None`` 或 ``-1`` 。
-  - **dtype** (np.dtype|str，可选)- 数据类型，支持 bool，float16，float32，float64，int8，int16，int32，int64，uint8。默认值为 float32。
+  - **dtype** (str|paddle.dtype|np.dtype，可选)- 数据类型，支持 bool，float16，float32，float64，int8，int16，int32，int64，uint8。默认值为 float32。
   - **name** (str，可选) - 变量的名称，具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
   - **stop_gradient** (bool，可选) - 提示是否应该停止计算梯度，默认值为 False，表示不停止计算梯度。
 

--- a/docs/api/paddle/static/data_cn.rst
+++ b/docs/api/paddle/static/data_cn.rst
@@ -17,7 +17,7 @@ data
 
     - **name** (str) - 变量名，具体用法请参见 :ref:`api_guide_Name`。
     - **shape** (list|tuple)- 声明维度信息的 list 或 tuple。可以在某个维度上设置 None 或-1，以指示该维度可以是任何大小。例如，将可变 batchsize 设置为 None 或-1。
-    - **dtype** (np.dtype|str，可选)- 数据类型，支持 bool，float16，float32，float64，int8，int16，int32，int64，uint8。默认值为 None。当 ``dtype`` 为 None 时，``dtype`` 将通过 ``padle.get_default_dtype()`` 获取全局类型。
+    - **dtype** (str|paddle.dtype|np.dtype，可选)- 数据类型，支持 bool，float16，float32，float64，int8，int16，int32，int64，uint8。默认值为 None。当 ``dtype`` 为 None 时，``dtype`` 将通过 ``padle.get_default_dtype()`` 获取全局类型。
     - **lod_level** (int，可选)- DenseTensor 变量的 LoD level 数，LoD level 是 PaddlePaddle 的高级特性，一般任务中不会需要更改此默认值。默认值为 0。
 
 返回

--- a/docs/api/paddle/static/nn/embedding_cn.rst
+++ b/docs/api/paddle/static/nn/embedding_cn.rst
@@ -68,7 +68,7 @@ embedding
     - **is_distributed** (bool，可选) - 是否使用分布式的方式存储 embedding 矩阵，仅在多机分布式 cpu 训练中使用。默认为 False。
     - **padding_idx** (int|long|None，可选) - padding_idx 需在区间 ``[-vocab_size, vocab_size)``，否则不生效，``padding_idx < 0`` 时，padding_idx 会被改成``vocab_size + padding_idx``，input 中等于 padding_index 的 id 对应的 embedding 信息会被设置为 0，且这部分填充数据在训练时将不会被更新。如果为 None，不作处理，默认为 None。
     - **param_attr** (ParamAttr，可选) - 指定权重参数属性的对象。默认值为 None，表示使用默认的权重参数属性。具体用法请参见 :ref:`cn_api_paddle_ParamAttr`。此外，可以通过 ``param_attr`` 参数加载用户自定义或预训练的词向量。只需将本地词向量转为 numpy 数据格式，且保证本地词向量的 shape 和 embedding 的 ``size`` 参数一致，然后使用 :ref:`cn_api_paddle_to_tensor` 进行初始化，即可实现加载自定义或预训练的词向量。
-    - **dtype** (str，可选) - 输出 Tensor 的数据类型，数据类型必须为：float32 或 float64，默认为 float32。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，数据类型必须为：float32 或 float64，默认为 float32。
 
 返回
 ::::::::::::

--- a/docs/api/paddle/sum_cn.rst
+++ b/docs/api/paddle/sum_cn.rst
@@ -12,7 +12,7 @@ sum
 
     - **x** (Tensor) - 输入变量为多维 Tensor，支持数据类型为 bool、bfloat16、float16、float32、float64、uint8、int8、int16、int32、int64、complex64、complex128。
     - **axis** (int|list|tuple，可选) - 求和运算的维度。如果为 None，则计算所有元素的和并返回包含单个元素的 Tensor 变量，否则必须在 :math:`[−rank(x),rank(x)]` 范围内。如果 :math:`axis [i] <0`，则维度将变为 :math:`rank+axis[i]`，默认值为 None。
-    - **dtype** (str，可选) - 输出变量的数据类型。若参数为空，则输出变量的数据类型和输入变量相同，默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出变量的数据类型。若参数为空，则输出变量的数据类型和输入变量相同，默认值为 None。
     - **keepdim** (bool，可选) - 是否在输出 Tensor 中保留减小的维度。如 keepdim 为 true，否则结果 Tensor 的维度将比输入 Tensor 小，默认值为 False。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 返回

--- a/docs/api/paddle/tensor_cn.rst
+++ b/docs/api/paddle/tensor_cn.rst
@@ -34,7 +34,7 @@ tensor
 :::::::::
 
     - **data** (scalar|tuple|list|ndarray|Tensor) - 初始化 Tensor 的数据，可以是 scalar，list，tuple，numpy\.ndarray，paddle\.Tensor 类型。
-    - **dtype** (str，可选) - 创建 Tensor 的数据类型，可以是 bool、float16、float32、float64、int8、int16、int32、int64、uint8、complex64、complex128。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 创建 Tensor 的数据类型，可以是 bool、float16、float32、float64、int8、int16、int32、int64、uint8、complex64、complex128。
       默认值为 None，如果 ``data`` 为 python 浮点类型，则从 :ref:`cn_api_paddle_get_default_dtype` 获取类型，如果 ``data`` 为其他类型，则会自动推导类型。
     - **device** (CPUPlace|CUDAPinnedPlace|CUDAPlace，可选) - 创建 tensor 的设备位置，可以是 CPUPlace、CUDAPinnedPlace、CUDAPlace。默认值为 None，使用全局的 place。
     - **requires_grad** (bool，可选) - 是否阻断 Autograd 的梯度传导。默认值为 False，此时不进行梯度传传导。

--- a/docs/api/paddle/to_tensor_cn.rst
+++ b/docs/api/paddle/to_tensor_cn.rst
@@ -29,7 +29,7 @@ to_tensor
 :::::::::
 
     - **data** (scalar|tuple|list|ndarray|Tensor) - 初始化 Tensor 的数据，可以是 scalar，list，tuple，numpy\.ndarray，paddle\.Tensor 类型。
-    - **dtype** (str，可选) - 创建 Tensor 的数据类型，可以是 bool、float16、float32、float64、int8、int16、int32、int64、uint8、complex64、complex128。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 创建 Tensor 的数据类型，可以是 bool、float16、float32、float64、int8、int16、int32、int64、uint8、complex64、complex128。
       默认值为 None，如果 ``data`` 为 python 浮点类型，则从 :ref:`cn_api_paddle_get_default_dtype` 获取类型，如果 ``data`` 为其他类型，则会自动推导类型。
     - **place** (CPUPlace|CUDAPinnedPlace|CUDAPlace，可选) - 创建 tensor 的设备位置，可以是 CPUPlace、CUDAPinnedPlace、CUDAPlace。默认值为 None，使用全局的 place。
     - **device** - ``place`` 的别名，行为完全一致。

--- a/docs/api/paddle/uniform_cn.rst
+++ b/docs/api/paddle/uniform_cn.rst
@@ -22,7 +22,7 @@ uniform
 ::::::::::::
 
     - **shape** (list|tuple|Tensor) - 生成的随机 Tensor 的形状。如果 ``shape`` 是 list、tuple，则其中的元素可以是 int，或者是形状为[]且数据类型为 int32、int64 的 0-D Tensor。如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor。
-    - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float32、float64。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 float32、float64。默认值为 None。
     - **min** (float|int，可选) - 要生成的随机值范围的下限，min 包含在范围中。支持的数据类型：float、int。默认值为-1.0。
     - **max** (float|int，可选) - 要生成的随机值范围的上限，max 不包含在范围中。支持的数据类型：float、int。默认值为 1.0。
     - **seed** (int，可选) - 随机种子，用于生成样本。0 表示使用系统生成的种子。注意如果种子不为 0，该操作符每次都生成同样的随机数。支持的数据类型：int。默认为 0。

--- a/docs/api/paddle/unique_cn.rst
+++ b/docs/api/paddle/unique_cn.rst
@@ -38,7 +38,7 @@ unique
     - **return_inverse** (bool，可选) - 如果为 True，则还返回输入 Tensor 的元素对应在独有元素中的索引，该索引可用于重构输入 Tensor。
     - **return_counts** (bool，可选) - 如果为 True，则还返回每个独有元素在输入 Tensor 中的个数。
     - **axis** (int，可选) - 指定选取独有元素的轴。默认值为 None，将输入平铺为 1-D 的 Tensor 后再选取独有元素。
-    - **dtype** (np.dtype|str，可选) - 用于设置 ``index`` ， ``inverse`` 或者 ``counts`` 的类型，应该为 int32 或者 int64。默认：int64。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 用于设置 ``index`` ， ``inverse`` 或者 ``counts`` 的类型，应该为 int32 或者 int64。默认：int64。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 

--- a/docs/api/paddle/unique_consecutive_cn.rst
+++ b/docs/api/paddle/unique_consecutive_cn.rst
@@ -29,7 +29,7 @@ unique_consecutive
     - **return_counts** (bool，可选) - 如果为 True，则还返回每个连续不重复元素在输入 Tensor 中的个数。默认：False。
     - **axis** (int，可选) - 指定选取连续不重复元素的轴。默认值为 None，将输入平铺为 1-D 的 Tensor 后再选取连续不重复元素。默认：None。
     - **dim** - ``axis`` 的别名，行为完全一致。
-    - **dtype** (np.dtype|str，可选) - 用于设置 `inverse` 或者 `counts` 的类型，应该为 int32 或者 int64。默认：int64。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 用于设置 `inverse` 或者 `counts` 的类型，应该为 int32 或者 int64。默认：int64。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/zeros_cn.rst
+++ b/docs/api/paddle/zeros_cn.rst
@@ -24,7 +24,7 @@ zeros
       如果 ``shape`` 是 Tensor，则是数据类型为 int32、int64 的 1-D Tensor，表示一个列表。
       如果 ``shape`` 是 \*shape，则可以直接以可变参数的形式传入多个整数（例如 ``randn(2, 3)``）。
       该参数的别名为 ``size``。
-    - **dtype** (np.dtype|str，可选) - 输出 Tensor 的数据类型，数据类型必须为 bool、float16、float32、float64、int32 或 int64。若为 None，数据类型为 float32，默认为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，数据类型必须为 bool、float16、float32、float64、int32 或 int64。若为 None，数据类型为 float32，默认为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数

--- a/docs/api/paddle/zeros_like_cn.rst
+++ b/docs/api/paddle/zeros_like_cn.rst
@@ -11,7 +11,7 @@ zeros_like
 参数
 ::::::::::
     - **x** (Tensor) – 输入的多维 Tensor，数据类型可以是 bool，float16, float32，float64，int32，int64。输出 Tensor 的形状和 ``x`` 相同。如果 ``dtype`` 为 None，则输出 Tensor 的数据类型与 ``x`` 相同。
-    - **dtype** (str|np.dtype，可选) - 输出 Tensor 的数据类型，支持 bool，float16, float32，float64，int32，int64。当该参数值为 None 时，输出 Tensor 的数据类型与 ``x`` 相同。默认值为 None。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输出 Tensor 的数据类型，支持 bool，float16, float32，float64，int32，int64。当该参数值为 None 时，输出 Tensor 的数据类型与 ``x`` 相同。默认值为 None。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 关键字参数


### PR DESCRIPTION
规范化文档中dtye相关类型注释，目前dtype传入类型支持str,paddle.dtype,np.dtype等多种类型
相关PR：https://github.com/PaddlePaddle/Paddle/pull/74545
