### PR TITLE
fix: update macOS compilation docs for Apple Silicon compatibility

### DIFF
--- a/docs/install/compile/macos-compile-make.md
+++ b/docs/install/compile/macos-compile-make.md
@@ -4,17 +4,19 @@
 
 * **macOS 版本 10.x/11.x/12.x/13.x/14.x/15.x (64 bit) (不支持 GPU 版本)**
 * **Python 版本 3.9/3.10/3.11/3.12/3.13 (64 bit)**
+* **注意：Docker 编译方式仅支持 x86_64 架构，生成的 x86_64 whl 包无法在 Apple Silicon (M系列芯片) Mac 上安装**
 
 ## 选择 CPU/GPU
 
 * 目前仅支持在 macOS 环境下编译安装 CPU 版本的 PaddlePaddle
 
 ## 安装步骤
-在 macOS 系统下有 2 种编译方式，推荐使用 Docker 编译。
-Docker 环境中已预装好编译 Paddle 需要的各种依赖，相较本机编译环境更简单。
+在 macOS 系统下有 2 种编译方式：
 
-* [Docker 源码编译](#compile_from_docker)
-* [本机源码编译](#compile_from_host)
+* [Docker 源码编译](#compile_from_docker) - 仅适用于 Intel Mac (x86_64)
+* [本机源码编译](#compile_from_host) - 推荐用于 Apple Silicon Mac (ARM64)
+
+**注意：** Docker 编译方式仅支持 x86_64 架构，生成的 x86_64 whl 包无法在 Apple Silicon (M系列芯片) Mac 上安装。如果您使用的是 Apple Silicon Mac，请使用本机编译方式。
 
 <a name="mac_docker"></a>
 ### <span id="compile_from_docker">**使用 Docker 编译**</span>
@@ -149,6 +151,8 @@ pip3.10 install -U [whl 包的名字]
 
 **请严格按照以下指令顺序执行**
 
+**重要提示：** 如果您使用的是 Apple Silicon (M系列芯片) Mac，请确保使用本机编译方式，并在 cmake 命令中添加 `-DWITH_ARM=ON` 参数。
+
 #### 1. 检查您的计算机和操作系统是否符合我们支持的编译标准：
 ```
 uname -m
@@ -258,7 +262,7 @@ pip3.10 install -r /paddle/python/requirements.txt
 
     ```
     cmake .. -DPY_VERSION=3.10 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
-    -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF
+    -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF -DWITH_ARM=ON
     ```
 
 >`-DPY_VERSION=3.10`请修改为安装环境的 Python 版本

--- a/docs/install/compile/macos-compile-make_en.md
+++ b/docs/install/compile/macos-compile-make_en.md
@@ -4,17 +4,19 @@
 
 * **macOS version 10.x/11.x/12.x/13.x/14.x/15.x (64 bit) (not support GPU version)**
 * **Python version 3.9/3.10/3.11/3.12/3.13 (64 bit)**
+* **Note: Docker compilation only supports x86_64 architecture, generated x86_64 whl packages cannot be installed on Apple Silicon (M-series chip) Macs**
 
 ## Choose CPU/GPU
 
 * Currently, only PaddlePaddle for CPU is supported.
 
 ## Installation steps
-There are two compilation methods in macOS system. It's recommended to use Docker to compile.
-The dependencies required for compiling Paddle are pre-installed in the Docker environment, which is simpler than the native compiling environment.
+There are two compilation methods in macOS system:
 
-* [Compile with Docker](#compile_from_docker)
-* [Local compilation](#compile_from_host)
+* [Compile with Docker](#compile_from_docker) - Only for Intel Mac (x86_64)
+* [Local compilation](#compile_from_host) - Recommended for Apple Silicon Mac (ARM64)
+
+**Note:** Docker compilation only supports x86_64 architecture, generated x86_64 whl packages cannot be installed on Apple Silicon (M-series chip) Macs. If you are using an Apple Silicon Mac, please use local compilation.
 
 <a name="mac_docker"></a>
 ### <span id="compile_from_docker">**Compile with Docker**</span>
@@ -169,6 +171,8 @@ We used Python3.10 command as an example above, if the version of your Python is
 
 **Please strictly follow the order of the following instructions**
 
+**Important:** If you are using an Apple Silicon (M-series chip) Mac, please ensure you use local compilation and add the `-DWITH_ARM=ON` parameter to the cmake command.
+
 #### 1. Check that your computer and operating system meet our supported compilation standards: `uname -m` and view the system version `about this Mac`. And install [OpenCV](https://opencv.org/releases.html) in advance.
 
 #### 2. Install python and pip:
@@ -268,7 +272,7 @@ mkdir build && cd build
 
     ```
     cmake .. -DPY_VERSION=3.10 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
-    -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF
+    -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF -DWITH_ARM=ON
     ```
 
 - ``-DPY_VERSION=3.10`` Please change to the Python version of the installation environment.

--- a/docs/install/compile/macos-compile-ninja.md
+++ b/docs/install/compile/macos-compile-ninja.md
@@ -4,17 +4,19 @@
 
 * **macOS 版本 10.x/11.x/12.x/13.x/14.x/15.x (64 bit) (不支持 GPU 版本)**
 * **Python 版本 3.9/3.10/3.11/3.12/3.13 (64 bit)**
+* **注意：Docker 编译方式仅支持 x86_64 架构，生成的 x86_64 whl 包无法在 Apple Silicon (M系列芯片) Mac 上安装**
 
 ## 选择 CPU/GPU
 
 * 目前仅支持在 macOS 环境下编译安装 CPU 版本的 PaddlePaddle
 
 ## 安装步骤
-在 macOS 系统下有 2 种编译方式，推荐使用 Docker 编译。
-Docker 环境中已预装好编译 Paddle 需要的各种依赖，相较本机编译环境更简单。
+在 macOS 系统下有 2 种编译方式：
 
-* [Docker 源码编译](#compile_from_docker)
-* [本机源码编译](#compile_from_host)
+* [Docker 源码编译](#compile_from_docker) - 仅适用于 Intel Mac (x86_64)
+* [本机源码编译](#compile_from_host) - 推荐用于 Apple Silicon Mac (ARM64)
+
+**注意：** Docker 编译方式仅支持 x86_64 架构，生成的 x86_64 whl 包无法在 Apple Silicon (M系列芯片) Mac 上安装。如果您使用的是 Apple Silicon Mac，请使用本机编译方式。
 
 <a name="mac_docker"></a>
 ### <span id="compile_from_docker">**使用 Docker 编译**</span>
@@ -112,6 +114,8 @@ pip3.10 install -U [whl 包的名字]
 <br/><br/>
 ### <span id="compile_from_host">**本机编译**</span>
 **请严格按照以下指令顺序执行**
+
+**重要提示：** 如果您使用的是 Apple Silicon (M系列芯片) Mac，请确保使用本机编译方式，并在 cmake 命令中添加 `-DWITH_ARM=ON` 参数。
 #### 1. 检查您的计算机和操作系统是否符合我们支持的编译标准：
 ```
 uname -m
@@ -190,7 +194,7 @@ pip3.10 install -r /paddle/python/requirements.txt
 *  对于需要编译**CPU 版本 PaddlePaddle**的用户：
     ```
     cmake .. -GNinja -DPY_VERSION=3.10 -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS} \
-    -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF
+    -DPYTHON_LIBRARY=${PYTHON_LIBRARY} -DWITH_GPU=OFF -DWITH_ARM=ON
     ```
 >`-DPY_VERSION=3.10`请修改为安装环境的 Python 版本
 #### 10. 使用以下命令来编译：


### PR DESCRIPTION
- Add Apple Silicon warnings for Docker compilation limitations
- Add -DWITH_ARM=ON flag to cmake commands for ARM64 compilation
- Clarify Docker generates x86_64 packages that cannot be installed on Apple Silicon
- Update both make and ninja compilation methods
- Update both Chinese and English documentation versions