### PR TITLE
[Docathon][Fix Doc Format No.5]

### DIFF
--- a/docs/api/paddle/tensor_split_cn.rst
+++ b/docs/api/paddle/tensor_split_cn.rst
@@ -67,7 +67,7 @@ COPY-FROM: paddle.tensor_split:tensor-split-example-4
 代码示例 5
 :::::::::::
 
-COPY-FROM: paddle.tensor_split:tensor-split-example-5
+COPY-FROM: paddle.tensor_split:tensor-spilt-example-5
 
 .. image:: ../../images/api_legend/tensor_split/tensor_split-6.png
    :alt: 图例-5


### PR DESCRIPTION
PR types
others

PR changes
Docs

Description
1. 第5个代码示例，是因为split单词拼错了，英文网页是spilt，中文网页是split， 我查了下英文网页的html中的代码示例的div的id，是tensor-spilt-example-5，这里可以发现是spilt这个错误拼写。

英文网页的对应代码示例的html代码如下：
<img width="1836" height="742" alt="Safari浏览器 2025-09-23 19 16 55" src="https://github.com/user-attachments/assets/db163fd3-43d3-40a1-8880-779f668b9a08" />

活动 issue : https://github.com/PaddlePaddle/docs/issues/7435 [Docathon] 中文文档格式日常修复
@Echo-Nie @wanglezz
