### PR TITLE
修复Exponential文档 issue#7475

### DIFF
--- a/docs/api/paddle/distribution/Exponential_cn.rst
+++ b/docs/api/paddle/distribution/Exponential_cn.rst
@@ -87,7 +87,7 @@ entropy()
 
     - Tensor: 信息熵。
 
-cdf(k)
+cdf(value)
 '''''''''
 指数分布的累积分布函数。
 
@@ -109,7 +109,7 @@ cdf(k)
 
     - Tensor: value 对应的累积分布。
 
-icdf(k)
+icdf(value)
 '''''''''
 指数分布的逆累积分布函数。
 
@@ -121,7 +121,8 @@ icdf(k)
 
 .. math::
 
-    icdf(x; \theta) = -\frac{ 1 }{ \theta } ln(1 + x), (x \ge 0)
+    icdf(x; \theta) = -\frac{ 1 }{ \theta } ln(1 - x), (0 < x < 1)
+
 
 上面的数学公式中：
 
@@ -138,7 +139,7 @@ kl_divergence(other)
 
 **参数**
 
-    - **other** (Geometric) - Exponential 的实例。
+    - **other** (Exponential) - Exponential 的实例。
 
 **返回**
 


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/docs/issues/7475

### 文档链接&描述 Document Links & Description

Exponential的api添加PR：https://github.com/PaddlePaddle/docs/pull/6413
API源码：https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/distribution/exponential.py
预览文档：[preview-Exponential-API文档](http://preview-pr-7477.paddle-docs-preview.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distribution/Exponential_cn.html)


### 问题1：ICDF(k)
<img width="1735" height="701" alt="Image" src="https://github.com/user-attachments/assets/5bdff764-c1cf-453f-a36d-4f976d9cc49a" />


**应该写成：** $icdf(p; θ) = -\frac{1}{θ} \ln(1 - p), \quad 0 < p < 1 $



### 问题2：kl_divergence

<img width="1468" height="372" alt="Image" src="https://github.com/user-attachments/assets/fc2bf68f-d13b-4108-b17e-ec1cd737251a" />

这里改写成Exponential 


### 问题3：cdf和icdf中的 `k和value`

<img width="1527" height="1112" alt="Image" src="https://github.com/user-attachments/assets/22995650-efd6-4257-b359-63d5b53cbdde" />

统一改成 ：`value`