### PR TITLE
[CI] Stop link check run on push event, and add reStructureText check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,9 +1,10 @@
 name: Link Checker
 
 on:
+  repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: "00 18 * * 0"
-  workflow_dispatch:
 
 jobs:
   linkChecker:
@@ -17,7 +18,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-            args: --verbose --no-progress --max-redirects 8 './**/*.md'
+            args: --verbose --no-progress --max-redirects 8 './**/*.md' './**/*.rst'
             format: markdown
             fail: false
             output: lychee/results.md

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,13 +1,9 @@
 name: Link Checker
 
 on:
-  repository_dispatch:
-  push:
-    branches:
-      - develop
-  workflow_dispatch:
   schedule:
     - cron: "00 18 * * 0"
+  workflow_dispatch:
 
 jobs:
   linkChecker:


### PR DESCRIPTION
- 每周日18:00触发 Link Checker
- 检查 `.md` 和 `.rst` 的死链问题

前置PR： https://github.com/PaddlePaddle/docs/pull/7486

@sunzhongkai588 @luotao1 