### PR TITLE
[Docathon][Fix Doc Format No.37、38] fix while_loop_cn & affine_grid_cn

### DIFF
--- a/docs/api/paddle/nn/functional/affine_grid_cn.rst
+++ b/docs/api/paddle/nn/functional/affine_grid_cn.rst
@@ -18,7 +18,7 @@ affine_grid
 
 返回
 ::::::::::::
- Tensor。Shape 为 ``[N, H, W, 2]`` 的 4-D Tensor 或``[N, D, H, W, 3]``的 5-D Tensor，表示仿射变换前后的坐标的映射关系。输出为 4-D Tensor 时，N、H、W 分别为仿射变换中输出 feature map 的 batch size、高和宽，输出为 5D Tensor 时，N、D、H、W 分别为仿射变换中输出 feature map 的 batch size、深度、高和宽。数据类型与 ``theta`` 一致。
+ Tensor。Shape 为 ``[N, H, W, 2]`` 的 4-D Tensor 或 ``[N, D, H, W, 3]`` 的 5-D Tensor，表示仿射变换前后的坐标的映射关系。输出为 4-D Tensor 时，N、H、W 分别为仿射变换中输出 feature map 的 batch size、高和宽，输出为 5D Tensor 时，N、D、H、W 分别为仿射变换中输出 feature map 的 batch size、深度、高和宽。数据类型与 ``theta`` 一致。
 
 
 代码示例

--- a/docs/api/paddle/static/nn/while_loop_cn.rst
+++ b/docs/api/paddle/static/nn/while_loop_cn.rst
@@ -16,7 +16,7 @@ ____________________________________
 :::::::::
 
     - **cond** (callable) - 返回 boolean 类型 Tensor 的可调用函数，用以判断循环是否继续执行。``cond`` 的参数和 ``loop_vars`` 相对应。
-    - **body** (callable) - 循环执行的结构体。其返回一个包含 tensor 或 DenseTensorArray 的列表或元组，且这些 tensor 或 DenseTensorArray 的长度，结构，类型和 ``loop_vars`` 中的相同。且``body`` 的参数与 ``loop_vars`` 相对应。
+    - **body** (callable) - 循环执行的结构体。其返回一个包含 tensor 或 DenseTensorArray 的列表或元组，且这些 tensor 或 DenseTensorArray 的长度，结构，类型和 ``loop_vars`` 中的相同。且 ``body`` 的参数与 ``loop_vars`` 相对应。
     - **loop_vars** (list|tuple) - 包含 tensor 或 DenseTensorArray 的列表或是元组，将其传入至 ``cond`` 和 ``body`` 中，得到循环条件和输出值。
     - **is_test** (bool，可选) - 用于表明是否在测试阶段执行，默认值为 False。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。


### PR DESCRIPTION
修改了docs/api/paddle/nn/functional/affine_grid_cn.rst与docs/api/paddle/static/nn/while_loop_cn.rst，修复如下渲染问题。检查后其余部分渲染无错误。
<img width="310" height="129" alt="image" src="https://github.com/user-attachments/assets/7ced33e5-9086-47c0-aa61-134b98340326" />
<img width="270" height="130" alt="image" src="https://github.com/user-attachments/assets/5d8138f3-81a0-40e8-9722-6c73597daa00" />

#7435 
@Echo-Nie @sunzhongkai588 