### PR TITLE
[Docathon][Fix Doc Format No.41、44-46] fix dropout_cn，UtilBase_cn，LogMelSpectrogram_cn，compute_fbank_matrix_cn

### DIFF
--- a/docs/api/paddle/audio/features/LogMelSpectrogram_cn.rst
+++ b/docs/api/paddle/audio/features/LogMelSpectrogram_cn.rst
@@ -14,7 +14,7 @@ LogMelSpectrogram
     - **n_fft** (int，可选) - 离散傅里叶变换中频率窗大小，默认 512。
     - **hop_length**  (int，可选) - 帧移，默认 512。
     - **win_length**  (int，可选) - 短时 FFT 的窗长，默认为 None。
-    - **window**  (str，可选) - 窗函数名，支持的窗函数类型'hamming'，'hann'，'gaussian'，'general_gaussian'，'exponential'，'triang'，'bohman'，'blackman'，'cosine'，'tukey'，'taylor'，'bartlett'，'kaiser'，'nuttall'，默认``hann``。
+    - **window**  (str，可选) - 窗函数名，支持的窗函数类型'hamming'，'hann'，'gaussian'，'general_gaussian'，'exponential'，'triang'，'bohman'，'blackman'，'cosine'，'tukey'，'taylor'，'bartlett'，'kaiser'，'nuttall'，默认 ``hann`` 。
     - **power**  (float，可选) - 幅度谱的指数，默认是 2.0。
     - **center**  (bool，可选) - 对输入信号填充，如果 True，那么 t 以 t*hop_length 为中心，如果为 False，则 t 以 t*hop_length 开始，默认是 True。
     - **pad_mode**  (str，可选) - 如果 center 是 True，选择填充的方式，默认值是'reflect'。
@@ -22,11 +22,11 @@ LogMelSpectrogram
     - **f_min** (float，可选) - 最小频率(hz)，默认 50.0。
     - **f_max** (float，可选) - 最大频率(hz)，默认为 None。
     - **htk** (bool，可选) - 在计算 fbank 矩阵时是否用在 HTK 公式缩放，默认是 False。
-    - **norm** (Union[str，float]，可选) - 计算 fbank 矩阵时正则化的种类，默认是``slaney``，你也可以 norm=0.5，使用 p-norm 正则化。
+    - **norm** (Union[str，float]，可选) - 计算 fbank 矩阵时正则化的种类，默认是 ``slaney`` ，你也可以 norm=0.5，使用 p-norm 正则化。
     - **ref_value** (float，可选) - 参照值，如果小于 1.0，信号的 db 会被提升，相反 db 会下降，默认值为 1.0。
     - **amin** (float，可选) - 输入的幅值的最小值，默认是 1e-10。
     - **top_db** (float，可选) - log-mel 谱的最大值(db)，默认是 None。
-    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入和窗的数据类型，默认是``float32``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 输入和窗的数据类型，默认是 ``float32`` 。
 
 
 返回

--- a/docs/api/paddle/audio/functional/compute_fbank_matrix_cn.rst
+++ b/docs/api/paddle/audio/functional/compute_fbank_matrix_cn.rst
@@ -16,13 +16,13 @@ compute_fbank_matrix
     - **f_min** (float，可选) - 最小频率(hz)，默认是 0.0。
     - **f_max** (Optional[float]，可选) - 最大频率(hz)，默认是 None。
     - **htk** (bool，可选) - 是否使用 htk 缩放，默认是 False。
-    - **norm** (Union[str, float]，可选) - norm 的类型，默认是``slaney``。
-    - **dtype** (str|paddle.dtype|np.dtype，可选) - 返回矩阵的数据类型，默认``float32``。
+    - **norm** (Union[str, float]，可选) - norm 的类型，默认是 ``slaney``。
+    - **dtype** (str|paddle.dtype|np.dtype，可选) - 返回矩阵的数据类型，默认 ``float32`` 。
 
 返回
 :::::::::
 
-``paddle.Tensor``，Tensor shape (n_mels, n_fft//2 + 1)。
+ ``paddle.Tensor`` ，Tensor shape (n_mels, n_fft//2 + 1)。
 
 代码示例
 :::::::::

--- a/docs/api/paddle/distributed/fleet/UtilBase_cn.rst
+++ b/docs/api/paddle/distributed/fleet/UtilBase_cn.rst
@@ -16,11 +16,11 @@ all_reduce(input, mode="sum", comm_world="worker")
 
     - **input** (list|tuple|numpy.array) – 归约操作的输入。
     - **mode** (str) - 归约操作的模式，包含求和，取最大值和取最小值，默认为求和归约。
-    - **comm_world** (str) - 归约操作的通信集合，包含：server 集合(``server``)，worker 集合(``worker``)及所有节点集合(``all``)，默认为 worker 集合。
+    - **comm_world** (str) - 归约操作的通信集合，包含：server 集合( ``server`` )，worker 集合( ``worker`` )及所有节点集合( ``all`` )，默认为 worker 集合。
 
 **返回**
 
-Numpy.array|None：一个和``input``形状一致的 numpy 数组或 None。
+Numpy.array|None：一个和 ``input`` 形状一致的 numpy 数组或 None。
 
 **代码示例**
 
@@ -32,7 +32,7 @@ barrier(comm_world="worker")
 
 **参数**
 
-   - **comm_world** (str) - 阻塞操作的通信集合，包含：server 集合(``server``)，worker 集合(``worker``)及所有节点集合(``all``)，默认为 worker 集合。
+   - **comm_world** (str) - 阻塞操作的通信集合，包含：server 集合( ``server`` )，worker 集合( ``worker`` )及所有节点集合( ``all`` )，默认为 worker 集合。
 
 **代码示例**
 
@@ -45,7 +45,7 @@ all_gather(input, comm_world="worker")
 **参数**
 
    - **input** (int|float) - 聚合操作的输入。
-   - **comm_world** (str) - 聚合操作的通信集合，包含：server 集合(``server``)，worker 集合(``worker``)及所有节点集合(``all``)，默认为 worker 集合。
+   - **comm_world** (str) - 聚合操作的通信集合，包含：server 集合( ``server`` )，worker 集合( ``worker`` )及所有节点集合( ``all`` )，默认为 worker 集合。
 
 **返回**
 

--- a/docs/api/paddle/nn/functional/dropout_cn.rst
+++ b/docs/api/paddle/nn/functional/dropout_cn.rst
@@ -50,7 +50,7 @@ axis 参数的默认值为 None。当 ``axis=None`` 时，dropout 的功能为�
    将输入 x 和生成的 mask 点积，就得到了随机丢弃部分元素之后的结果：
    [[0 2 0]
     [4 0 6]]
-   假定 dropout 的概率使用默认值，即 ``p=0.5``，若 mode 参数使用默认值，即 ``mode='upscale_in_train'`` ，
+   假定 dropout 的概率使用默认值，即 ``p=0.5`` ，若 mode 参数使用默认值，即 ``mode='upscale_in_train'`` ，
    则在训练阶段，最终增大后的结果为：
    [[0 4 0 ]
     [8 0 12]]
@@ -70,8 +70,8 @@ axis 参数的默认值为 None。当 ``axis=None`` 时，dropout 的功能为�
 
  -  axis 应设置为：``[0, 1, ... , ndim(x)-1]`` 的子集（ndim(x) 为输入 x 的维度），例如：
 
-   - 若 x 的维度为 2，参数 axis 可能的取值有 4 种：``None``, ``[0]``, ``[1]``, ``[0,1]``
-   - 若 x 的维度为 3，参数 axis 可能的取值有 8 种：``None``, ``[0]``, ``[1]``, ``[2]``, ``[0,1]``, ``[0,2]``, ``[1,2]``, ``[0,1,2]``
+   - 若 x 的维度为 2，参数 axis 可能的取值有 4 种： ``None`` , ``[0]`` , ``[1]`` , ``[0,1]``
+   - 若 x 的维度为 3，参数 axis 可能的取值有 8 种： ``None`` , ``[0]`` , ``[1]`` , ``[2]`` , ``[0,1]`` , ``[0,2]`` , ``[1,2]``, ``[0,1,2]``
 
  -  下面以维度为 2 的输入 Tensor 展示 axis 参数的用法：
 
@@ -80,7 +80,7 @@ axis 参数的默认值为 None。当 ``axis=None`` 时，dropout 的功能为�
    假定 x 是形状为 2*3 的 2 维 Tensor:
    [[1 2 3]
     [4 5 6]]
-   (1) 若 ``axis=[0]``，则表示只在第 0 个维度做 dropout。这时生成 mask 的形状为 2*1。
+   (1) 若 ``axis=[0]`` ，则表示只在第 0 个维度做 dropout。这时生成 mask 的形状为 2*1。
      例如，我们可能会得到这样的 mask:
      [[1]
       [0]]
@@ -92,7 +92,7 @@ axis 参数的默认值为 None。当 ``axis=None`` 时，dropout 的功能为�
       [0 0 0]]
      之后依据其它参数的设置，得到最终的输出结果。
 
-   (2) 若 ``axis=[1]``，则表示只在第 1 个维度做 dropout。这时生成的 mask 形状为 1*3。
+   (2) 若 ``axis=[1]`` ，则表示只在第 1 个维度做 dropout。这时生成的 mask 形状为 1*3。
      例如，我们可能会得到这样的 mask:
      [[1 0 1]]
      这个 1*3 的 mask 在和 x 做点积的时候，会首先广播成一个 2*3 的矩阵：
@@ -101,9 +101,9 @@ axis 参数的默认值为 None。当 ``axis=None`` 时，dropout 的功能为�
      点积所得结果为：
      [[1 0 3]
       [4 0 6]]
-   (3) 若 ``axis=[0, 1]``，则表示在第 0 维和第 1 维上做 dropout。此时与默认设置 ``axis=None`` 的作用一致。
+   (3) 若 ``axis=[0, 1]`` ，则表示在第 0 维和第 1 维上做 dropout。此时与默认设置 ``axis=None`` 的作用一致。
 
-若输入 x 为 4 维 Tensor，形状为 `NCHW`，其中 N 是批尺寸，C 是通道数，H 是特征高度，W 是特征宽度，当设置 ``axis=[0,1]`` 时，则只会在通道 `N` 和 `C` 上做 dropout，通道 `H` 和 `W` 的元素是绑定在一起的，即：``paddle.nn.functional.dropout(x, p, axis=[0,1])``，此时对 4 维 Tensor 中的某个 2 维特征图（形状为 `HW`），或者全部置 0，或者全部保留，这便是 dropout2d 的实现。详情参考 :ref:`cn_api_paddle_nn_functional_dropout2d` 。
+若输入 x 为 4 维 Tensor，形状为 `NCHW`，其中 N 是批尺寸，C 是通道数，H 是特征高度，W 是特征宽度，当设置 ``axis=[0,1]`` 时，则只会在通道 `N` 和 `C` 上做 dropout，通道 `H` 和 `W` 的元素是绑定在一起的，即：``paddle.nn.functional.dropout(x, p, axis=[0,1])`` ，此时对 4 维 Tensor 中的某个 2 维特征图（形状为 `HW`），或者全部置 0，或者全部保留，这便是 dropout2d 的实现。详情参考 :ref:`cn_api_paddle_nn_functional_dropout2d` 。
 
 类似的，若输入 x 为 5 维 Tensor，形状为 `NCDHW`，其中 D 是特征深度，当设置 ``axis=[0,1]`` 时，便可实现 dropout3d。详情参考 :ref:`cn_api_paddle_nn_functional_dropout3d` 。
 


### PR DESCRIPTION
PR types
Others (Fixing Work)

PR changes
Docs

Description
fix dropout_cn，UtilBase_cn，LogMelSpectrogram_cn，compute_fbank_matrix_cn四个文档，增加缺少的空格
活动issue链接：https://github.com/PaddlePaddle/docs/issues/7435
@Echo-Nie @sunzhongkai588