### PR TITLE
[Docathon][Fix Doc Format No.44] Fix spacing format for UtilBase_cn

### DIFF
--- a/docs/api/paddle/distributed/fleet/UtilBase_cn.rst
+++ b/docs/api/paddle/distributed/fleet/UtilBase_cn.rst
@@ -16,11 +16,11 @@ all_reduce(input, mode="sum", comm_world="worker")
 
     - **input** (list|tuple|numpy.array) – 归约操作的输入。
     - **mode** (str) - 归约操作的模式，包含求和，取最大值和取最小值，默认为求和归约。
-    - **comm_world** (str) - 归约操作的通信集合，包含：server 集合(``server``)，worker 集合(``worker``)及所有节点集合(``all``)，默认为 worker 集合。
+    - **comm_world** (str) - 归约操作的通信集合，包含：server 集合 (``server``)，worker 集合 (``worker``) 及所有节点集合 (``all``)，默认为 worker 集合。
 
 **返回**
 
-Numpy.array|None：一个和``input``形状一致的 numpy 数组或 None。
+Numpy.array|None：一个和 ``input`` 形状一致的 numpy 数组或 None。
 
 **代码示例**
 
@@ -32,7 +32,7 @@ barrier(comm_world="worker")
 
 **参数**
 
-   - **comm_world** (str) - 阻塞操作的通信集合，包含：server 集合(``server``)，worker 集合(``worker``)及所有节点集合(``all``)，默认为 worker 集合。
+   - **comm_world** (str) - 阻塞操作的通信集合，包含：server 集合 (``server``)，worker 集合 (``worker``) 及所有节点集合 (``all``)，默认为 worker 集合。
 
 **代码示例**
 
@@ -45,7 +45,7 @@ all_gather(input, comm_world="worker")
 **参数**
 
    - **input** (int|float) - 聚合操作的输入。
-   - **comm_world** (str) - 聚合操作的通信集合，包含：server 集合(``server``)，worker 集合(``worker``)及所有节点集合(``all``)，默认为 worker 集合。
+   - **comm_world** (str) - 聚合操作的通信集合，包含：server 集合 (``server``)，worker 集合 (``worker``) 及所有节点集合 (``all``)，默认为 worker 集合。
 
 **返回**
 

--- a/docs/api/paddle/distributed/fleet/UtilBase_cn.rst
+++ b/docs/api/paddle/distributed/fleet/UtilBase_cn.rst
@@ -9,7 +9,7 @@ UtilBase
 方法
 ::::::::::::
 all_reduce(input, mode="sum", comm_world="worker")
-'''''''''
+''''''''''''''''''''''''''''''''''''''''''''''''''
 在指定的通信集合间进行归约操作，并将归约结果返回给集合中每个实例。
 
 **参数**
@@ -27,7 +27,7 @@ Numpy.array|None：一个和 ``input`` 形状一致的 numpy 数组或 None。
 COPY-FROM: paddle.distributed.fleet.UtilBase.all_reduce
 
 barrier(comm_world="worker")
-'''''''''
+''''''''''''''''''''''''''''
 在指定的通信集合间进行阻塞操作，以实现集合间进度同步。
 
 **参数**
@@ -39,7 +39,7 @@ barrier(comm_world="worker")
 COPY-FROM: paddle.distributed.fleet.UtilBase.barrier
 
 all_gather(input, comm_world="worker")
-'''''''''
+''''''''''''''''''''''''''''''''''''''''
 在指定的通信集合间进行聚合操作，并将聚合的结果返回给集合中每个实例。
 
 **参数**
@@ -56,7 +56,7 @@ all_gather(input, comm_world="worker")
 COPY-FROM: paddle.distributed.fleet.UtilBase.all_gather
 
 get_file_shard(files)
-'''''''''
+'''''''''''''''''''''
 在数据并行的分布式训练中，获取属于当前训练节点的文件列表。
 
 .. code-block:: text
@@ -77,8 +77,7 @@ get_file_shard(files)
 COPY-FROM: paddle.distributed.fleet.UtilBase.get_file_shard
 
 print_on_rank(message, rank_id)
-'''''''''
-
+'''''''''''''''''''''''''''''''''
 在编号为 `rank_id` 的节点上打印指定信息。
 
 **参数**


### PR DESCRIPTION
- Fix incorrect spacing format in `UtilBase_cn.rst`.
- Add spaces around ``.

Related issue: #7435
@Echo-Nie @sunzhongkai588