### PR TITLE
Task 43: 修正rnnt_loss_cn.rst的出现的文档错误

### DIFF
--- a/docs/api/paddle/nn/functional/rnnt_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/rnnt_loss_cn.rst
@@ -16,7 +16,7 @@ rnnt_loss
     - **label_lengths** (Tensor) - 每个标签序列的长度，它应该有形状 [batch_size] 和 dtype int64。
     - **blank** (int，可选) - RNN-T loss 的空白标签索引，处于半开放区间 [0,B)。数据类型必须为 int32。默认值为 0。
     - **fastemit_lambda** (float，默认 0.001) - FastEmit 的正则化参数(https://arxiv.org/pdf/2010.11148.pdf)。
-    - **reduction** (str，可选) - 表示如何平均损失，候选是 ``'none'``|``'mean'``|``'sum'`` 。如果 ::attr:`reduction` 是 ``'mean'``，输出将是损失的总和并除以 batch_size;如果 :attr:`reduction` 是 ``'sum'``，返回损失的总和;如果 :attr:`reduction` 为 ``'none'``，则不应用 reduction。默认是 ``'mean'``。
+    - **reduction** (str，可选) - 表示如何平均损失，候选是 ``'none'`` | ``'mean'`` | ``'sum'`` 。如果 :attr:`reduction` 是 ``'mean'``，输出将是损失的总和并除以 batch_size;如果 :attr:`reduction` 是 ``'sum'``，返回损失的总和;如果 :attr:`reduction` 为 ``'none'``，则不应用 reduction。默认是 ``'mean'``。
     - **name** (str，可选) - 操作名称，默认为 None。
 
 返回


### PR DESCRIPTION
对应 Issue #7435（第43个任务）
本次修改修正了 docs/api/paddle/nn/functional/rnnt_loss_cn.rst 文档中的表述错误，具体为调整了出现”相关的语句，使其符合文档规范且语义清晰。