### PR TITLE
[Fix Doc] Fix broken link (.pdf) for TripletMarginLoss_cn, TripletMarginWithDistanceLoss_cn, triplet_margin_loss_cn, triplet_margin_with_distance_loss_cn, nce_cn

### DIFF
--- a/docs/api/paddle/nn/TripletMarginLoss_cn.rst
+++ b/docs/api/paddle/nn/TripletMarginLoss_cn.rst
@@ -19,7 +19,7 @@ TripletMarginLoss
     d(x_i, y_i) = \left\lVert {\bf x}_i - {\bf y}_i \right\rVert_p
 
 
-``p`` 为距离函数的范数。``margin`` 为（input，positive）与（input，negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://www.bmva.org/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
+``p`` 为距离函数的范数。``margin`` 为（input，positive）与（input，negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://bmva-archive.org.uk/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
 
 参数
 :::::::::

--- a/docs/api/paddle/nn/TripletMarginWithDistanceLoss_cn.rst
+++ b/docs/api/paddle/nn/TripletMarginWithDistanceLoss_cn.rst
@@ -20,7 +20,7 @@ TripletMarginWithDistanceLoss
     d(x_i, y_i) = \left\lVert {\bf x}_i - {\bf y}_i \right\rVert_2
 
 
-``margin`` 为（input,positive）与（input,negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）的值换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://www.bmva.org/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
+``margin`` 为（input,positive）与（input,negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）的值换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://bmva-archive.org.uk/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
 
 
 

--- a/docs/api/paddle/nn/functional/triplet_margin_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/triplet_margin_loss_cn.rst
@@ -20,7 +20,7 @@ triplet_margin_loss
 
 
 
-``p`` 为距离函数的范数。``margin`` 为（input，positive）与（input，negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://www.bmva.org/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
+``p`` 为距离函数的范数。``margin`` 为（input，positive）与（input，negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://bmva-archive.org.uk/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
 
 参数
 :::::::::

--- a/docs/api/paddle/nn/functional/triplet_margin_with_distance_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/triplet_margin_with_distance_loss_cn.rst
@@ -20,7 +20,7 @@ triplet_margin_with_distance_loss
     d(x_i, y_i) = \left\lVert {\bf x}_i - {\bf y}_i \right\rVert_2
 
 
-``margin`` 为（input,positive）与（input,negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）的值换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://www.bmva.org/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
+``margin`` 为（input,positive）与（input,negative）的距离间隔，``swap`` 为 True 时，会比较（input，negative）和（positive，negative）的大小，并将（input，negative）的值换为其中较小的值，内容详见论文 `Learning shallow convolutional feature descriptors with triplet losses <http://bmva-archive.org.uk/bmvc/2016/papers/paper119/paper119.pdf>`_ 。
 
 
 参数

--- a/docs/api/paddle/static/nn/nce_cn.rst
+++ b/docs/api/paddle/static/nn/nce_cn.rst
@@ -12,7 +12,7 @@ nce
 计算并返回噪音对比估计损失值（ noise-contrastive estimation training loss）。该层默认使用均匀分布进行抽样。
 
 论文参考：`Noise-contrastive estimation: A new estimation principle for unnormalized statistical models
-<http://www.jmlr.org/proceedings/papers/v9/gutmann10a/gutmann10a.pdf>`_
+<http://proceedings.mlr.press/v9/gutmann10a/gutmann10a.pdf>`_
 
 
 参数


### PR DESCRIPTION
### PR types
others

### PR changes
Docs

### Description
- Change pdf file origin for the paper _Learning shallow convolutional feature descriptors with triplet losses_ in `TripletMarginLoss_cn`, `TripletMarginWithDistanceLoss_cn`, `triplet_margin_loss_cn`, `triplet_margin_with_distance_loss_cn`
- Change pdf file origin for the paper _Noise-contrastive estimation: A new estimation principle for unnormalized statistical models_ in `nce_cn`

ℹ️After checking, there are no broken pdf file links remaining in the repo.