### PR TITLE
[Docs] Use `pycon` as syntax highlight marker

### DIFF
--- a/ci_scripts/check_api_cn.sh
+++ b/ci_scripts/check_api_cn.sh
@@ -15,7 +15,7 @@ function filter_cn_api_files() {
     local __resultvar=$2
     local need_check_files=""
     for file in `echo $git_files`;do
-        grep 'code-block:: python' ../docs/$file > /dev/null
+        grep -E 'code-block:: (python|pycon)' ../docs/$file > /dev/null
         if [ $? -eq 0 ] ;then
             api_file=`echo $file | sed 's#api/##g'`
             grep -w "${api_file}" ${DIR_PATH}/api_white_list.txt > /dev/null

--- a/docs/api/copy_codes_from_en_doc.py
+++ b/docs/api/copy_codes_from_en_doc.py
@@ -105,7 +105,7 @@ def extract_code_blocks_from_docstr(docstr, google_style=True):
 
     lastlineindex = len(docstr_list) - 1
 
-    cb_start_pat = re.compile(r"code-block::\s*python")
+    cb_start_pat = re.compile(r"code-block::\s*(python|python-console|pycon)")
     cb_param_pat = re.compile(r"^\s*:(\w+):\s*(\S*)\s*$")
 
     cb_info = {}
@@ -261,7 +261,7 @@ def instert_codes_into_cn_rst_if_need(cnrstfilename):
         cb_new = []
         indent = cf_info["indent"]
         cb_new.append("")  # insert a empty line in the frontend
-        cb_new.append(" " * indent + ".. code-block:: python")
+        cb_new.append(" " * indent + ".. code-block:: python-console")
         if cf_info["cb_name"]:
             cb_new.append(" " * (indent + 3) + ":name: " + cf_info["cb_name"])
         cb_new.append("")

--- a/docs/api/copy_codes_from_en_doc.py
+++ b/docs/api/copy_codes_from_en_doc.py
@@ -261,7 +261,7 @@ def instert_codes_into_cn_rst_if_need(cnrstfilename):
         cb_new = []
         indent = cf_info["indent"]
         cb_new.append("")  # insert a empty line in the frontend
-        cb_new.append(" " * indent + ".. code-block:: python-console")
+        cb_new.append(" " * indent + ".. code-block:: pycon")
         if cf_info["cb_name"]:
             cb_new.append(" " * (indent + 3) + ":name: " + cf_info["cb_name"])
         cb_new.append("")

--- a/docs/api/extract_api_from_docs.py
+++ b/docs/api/extract_api_from_docs.py
@@ -55,7 +55,9 @@ def extract_code_blocks_from_rst(docstr):
     ds_list = docstr.expandtabs(tabsize=4).split("\n")
     lastlineindex = len(ds_list) - 1
     cb_started = False
-    cb_start_pat = re.compile(r"((code)|(code-block))::\s*i?python[23]?")
+    cb_start_pat = re.compile(
+        r"((code)|(code-block))::\s*i?(python|python-console|pycon)"
+    )
     cb_cur = []
     cb_cur_indent = -1
     for lineno, linecont in enumerate(ds_list):

--- a/docs/api/paddle/device/memory_allocated_cn.rst
+++ b/docs/api/paddle/device/memory_allocated_cn.rst
@@ -22,7 +22,7 @@ memory_allocated
 
 代码示例
 ::::::::::::
-.. code-block:: python-console
+.. code-block:: pycon
 
     >>> import paddle
     >>> paddle.device.memory_allocated('npu:0')

--- a/docs/api/paddle/device/memory_allocated_cn.rst
+++ b/docs/api/paddle/device/memory_allocated_cn.rst
@@ -22,7 +22,7 @@ memory_allocated
 
 代码示例
 ::::::::::::
-.. code-block:: python
+.. code-block:: python-console
 
     >>> import paddle
     >>> paddle.device.memory_allocated('npu:0')

--- a/docs/api/paddle/device/memory_reserved_cn.rst
+++ b/docs/api/paddle/device/memory_reserved_cn.rst
@@ -19,7 +19,7 @@ memory_reserved
 
 代码示例
 ::::::::::::
-.. code-block:: python-console
+.. code-block:: pycon
 
     >>> import paddle
     >>> paddle.device.memory_reserved('npu:0')

--- a/docs/api/paddle/device/memory_reserved_cn.rst
+++ b/docs/api/paddle/device/memory_reserved_cn.rst
@@ -19,7 +19,7 @@ memory_reserved
 
 代码示例
 ::::::::::::
-.. code-block:: python
+.. code-block:: python-console
 
     >>> import paddle
     >>> paddle.device.memory_reserved('npu:0')

--- a/docs/api/paddle/device/reset_max_memory_allocated_cn.rst
+++ b/docs/api/paddle/device/reset_max_memory_allocated_cn.rst
@@ -19,7 +19,7 @@ reset_max_memory_allocated
 
 代码示例
 ::::::::::::
-.. code-block:: python-console
+.. code-block:: pycon
 
     >>> import paddle
     >>> paddle.device.reset_max_memory_allocated('npu:0')

--- a/docs/api/paddle/device/reset_max_memory_allocated_cn.rst
+++ b/docs/api/paddle/device/reset_max_memory_allocated_cn.rst
@@ -19,7 +19,7 @@ reset_max_memory_allocated
 
 代码示例
 ::::::::::::
-.. code-block:: python
+.. code-block:: python-console
 
     >>> import paddle
     >>> paddle.device.reset_max_memory_allocated('npu:0')

--- a/docs/api/paddle/device/reset_max_memory_reserved_cn.rst
+++ b/docs/api/paddle/device/reset_max_memory_reserved_cn.rst
@@ -19,7 +19,7 @@ reset_max_memory_reserved
 
 代码示例
 ::::::::::::
-.. code-block:: python
+.. code-block:: python-console
 
     >>> import paddle
     >>> paddle.device.reset_max_memory_reserved('npu:0')

--- a/docs/api/paddle/device/reset_max_memory_reserved_cn.rst
+++ b/docs/api/paddle/device/reset_max_memory_reserved_cn.rst
@@ -19,7 +19,7 @@ reset_max_memory_reserved
 
 代码示例
 ::::::::::::
-.. code-block:: python-console
+.. code-block:: pycon
 
     >>> import paddle
     >>> paddle.device.reset_max_memory_reserved('npu:0')

--- a/docs/dev_guides/api_contributing_guides/api_docs_guidelines_cn.md
+++ b/docs/dev_guides/api_contributing_guides/api_docs_guidelines_cn.md
@@ -52,7 +52,7 @@
             N-D Tensor. A location into which the result is stored. It’s dimension equals with :attr:`x`.
 
         Examples:
-            .. code-block:: python-console
+            .. code-block:: pycon
 
                 >>> import paddle
 
@@ -305,7 +305,7 @@ API 抛出异常部分，由于历史原因写在文档中，建议在源码的 
 def api():
     """
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             示例代码位置
 
@@ -318,12 +318,12 @@ def api():
 def api():
     """
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
             :name: example-1
 
             示例代码位置
 
-        .. code-block:: python-console
+        .. code-block:: pycon
             :name: example-2
 
             示例代码位置 (存在多个示例代码)
@@ -336,7 +336,7 @@ def api():
 def multiply(x, y, axis=-1, name=None):
     """
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/docs/dev_guides/api_contributing_guides/api_docs_guidelines_cn.md
+++ b/docs/dev_guides/api_contributing_guides/api_docs_guidelines_cn.md
@@ -52,7 +52,7 @@
             N-D Tensor. A location into which the result is stored. It’s dimension equals with :attr:`x`.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: python-console
 
                 >>> import paddle
 
@@ -305,7 +305,7 @@ API 抛出异常部分，由于历史原因写在文档中，建议在源码的 
 def api():
     """
     Examples:
-        .. code-block:: python
+        .. code-block:: python-console
 
             示例代码位置
 
@@ -318,12 +318,12 @@ def api():
 def api():
     """
     Examples:
-        .. code-block:: python
+        .. code-block:: python-console
             :name: example-1
 
             示例代码位置
 
-        .. code-block:: python
+        .. code-block:: python-console
             :name: example-2
 
             示例代码位置 (存在多个示例代码)
@@ -336,7 +336,7 @@ def api():
 def multiply(x, y, axis=-1, name=None):
     """
     Examples:
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> import paddle
 

--- a/docs/dev_guides/api_contributing_guides/new_cpp_op_cn.md
+++ b/docs/dev_guides/api_contributing_guides/new_cpp_op_cn.md
@@ -818,7 +818,7 @@ def trace(
         Tensor: the output data type is the same as input data type.
 
     Examples:
-        .. code-block:: python-console
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/docs/dev_guides/api_contributing_guides/new_cpp_op_cn.md
+++ b/docs/dev_guides/api_contributing_guides/new_cpp_op_cn.md
@@ -818,7 +818,7 @@ def trace(
         Tensor: the output data type is the same as input data type.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> import paddle
 


### PR DESCRIPTION
Follow PaddlePaddle/Paddle#76542，使用 `pycon` 作为更加合理的 syntax highlight marker

cc. @megemini @ooooo-create 