### PR TITLE
Update link-check workflow triggers

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,10 +1,7 @@
 name: Link Checker
 
 on:
-  repository_dispatch:
   workflow_dispatch:
-  schedule:
-    - cron: "00 18 * * 0"
 
 jobs:
   linkChecker:


### PR DESCRIPTION
Removed repository_dispatch trigger and schedule for the link checker workflow.