### PR TITLE
[API Compatibility] Update fill_diagonal_ alias docs

### DIFF
--- a/docs/api/paddle/Tensor__upper_cn.rst
+++ b/docs/api/paddle/Tensor__upper_cn.rst
@@ -1560,7 +1560,7 @@ fill_diagonal_(x, value, offset=0, wrap=False, name=None)
 
 参数：
     - **x** (Tensor) - 需要修改对角线元素值的原始 Tensor。
-    - **value** (float) - 以输入 value 值修改原始 Tensor 对角线元素。
+    - **value** (float) - 以输入 value 值修改原始 Tensor 对角线元素。别名 ``fill_value``。
     - **offset** (int，可选) - 所选取对角线相对原始主对角线位置的偏移量，正向右上方偏移，负向左下方偏移，默认为 0。
     - **wrap** (bool，可选) - 对于 2 维 Tensor，height>width 时是否循环填充，默认为 False。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
@@ -1573,6 +1573,10 @@ fill_diagonal_(x, value, offset=0, wrap=False, name=None)
         import paddle
         x = paddle.ones((4, 3))
         x.fill_diagonal_(2)
+        print(x.tolist())   #[[2.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 2.0], [1.0, 1.0, 1.0]]
+
+        x = paddle.ones((4, 3))
+        x.fill_diagonal_(fill_value=2)
         print(x.tolist())   #[[2.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 2.0], [1.0, 1.0, 1.0]]
 
         x = paddle.ones((7, 3))

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/paddle_more_args/torch.Tensor.fill_diagonal_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/paddle_more_args/torch.Tensor.fill_diagonal_.md
@@ -16,6 +16,6 @@ paddle.Tensor.fill_diagonal_(value, offset=0, wrap=False, name=None)
 | PyTorch    | PaddlePaddle | 备注                                                                                                                         |
 | ---------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | fill_value | value        | Paddle 支持 ``fill_value`` 作为 ``value`` 的别名。                                                                            |
-| -          | offset       | 所选取对角线相对原始主对角线位置的偏移量，正向右上方偏移，负向左下方偏移，默认为 0。PyTorch 无此参数， Paddle 保持默认即可。 |
+| -          | offset       | 所选取对角线相对原始主对角线位置的偏移量，正向右上方偏移，负向左下方偏移，默认为 0。PyTorch 无此参数，Paddle 保持默认即可。 |
 | wrap       | wrap         | 对于 2 维 Tensor，height>width 时是否循环填充，默认为 False。                                                                |
 | -          | name         | 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。                                                            |

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/paddle_more_args/torch.Tensor.fill_diagonal_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/paddle_more_args/torch.Tensor.fill_diagonal_.md
@@ -9,12 +9,13 @@ torch.Tensor.fill_diagonal_(fill_value, wrap=False)
 paddle.Tensor.fill_diagonal_(value, offset=0, wrap=False, name=None)
 ```
 
-两者功能一致且参数用法一致，paddle 参数更多，具体如下：
+两者功能一致且参数用法一致，Paddle 支持 ``fill_value`` 作为 ``value`` 的别名，并额外提供 ``offset`` 和 ``name`` 参数，具体如下：
 
 ### 参数映射
 
 | PyTorch    | PaddlePaddle | 备注                                                                                                                         |
 | ---------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| fill_value | value        | 以输入 value 值修改原始 Tensor 对角线元素，仅参数名不一致。                                                                    |
+| fill_value | value        | Paddle 支持 ``fill_value`` 作为 ``value`` 的别名。                                                                            |
 | -          | offset       | 所选取对角线相对原始主对角线位置的偏移量，正向右上方偏移，负向左下方偏移，默认为 0。PyTorch 无此参数， Paddle 保持默认即可。 |
 | wrap       | wrap         | 对于 2 维 Tensor，height>width 时是否循环填充，默认为 False。                                                                |
+| -          | name         | 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。                                                            |


### PR DESCRIPTION
### PR Category
  Documentation

  ### PR Types
  Documentation

  ### Description
  - Add `fill_value` alias note for `paddle.Tensor.fill_diagonal_` in Tensor CN docs.
  - Update the PyTorch difference doc to reflect the alias support and keep extra args description.