### PR TITLE
[CI] Use tsinghua index when install deps

### DIFF
--- a/ci_scripts/hooks/pre-doc-compile.sh
+++ b/ci_scripts/hooks/pre-doc-compile.sh
@@ -96,7 +96,7 @@ download_file "${ATTRIBUTE_MAPPING_URL}" "${TOOLS_DIR}/attribute_mapping.json"
 
 echo "INFO: All API mapping files successfully downloaded"
 
-python -m pip install loguru sphobjinv
+python -m pip install loguru sphobjinv -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # Run the remaining scripts with failure handling
 echo "INFO: Running get_api_difference_info.py"


### PR DESCRIPTION
安装依赖时显式使用清华源以避免 Paddle docs preview 默认使用的百度源无法找到 loguru 等依赖而挂掉

https://github.com/PaddlePaddle/Paddle/actions/runs/21470690511/job/61892395250?pr=77493

<img width="1117" height="392" alt="image" src="https://github.com/user-attachments/assets/162033f1-9415-47e7-830c-8a885f99b234" />

@LittleHeroZZZX #7701 又把 CI 搞挂了……

cc @ooooo-create @swgu98 