### PR TITLE
[Doc Link Fix No.2]Fix slice_cn.rst-part

### DIFF
--- a/docs/api/paddle/slice_cn.rst
+++ b/docs/api/paddle/slice_cn.rst
@@ -8,7 +8,7 @@ slice
 
 
 
-沿多个轴生成 ``input`` 的切片。与 numpy 类似：https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html 该 OP 使用 ``axes`` 、 ``starts`` 和 ``ends`` 属性来指定轴列表中每个轴的起点和终点位置，并使用此信息来对 ``input`` 切片。如果向 ``starts`` 或 ``ends`` 传递负值如 :math:`-i`，则表示该轴的反向第 :math:`i-1` 个位置（这里以 0 为初始位置）。如果传递给 ``starts`` 或 ``end`` 的值大于 n（维度中的元素数目），则表示 n。当切片一个未知数量的维度时，建议传入 ``INT_MAX``。 ``axes`` 、 ``starts`` 和 ``ends`` 三个参数的元素数目必须相等。以下示例将解释切片如何工作：
+沿多个轴生成 ``input`` 的切片。与 numpy 类似：https://numpy.org/doc/stable/user/basics.indexing.html。该 OP 使用 ``axes`` 、 ``starts`` 和 ``ends`` 属性来指定轴列表中每个轴的起点和终点位置，并使用此信息来对 ``input`` 切片。如果向 ``starts`` 或 ``ends`` 传递负值如 :math:`-i`，则表示该轴的反向第 :math:`i-1` 个位置（这里以 0 为初始位置）。如果传递给 ``starts`` 或 ``end`` 的值大于 n（维度中的元素数目），则表示 n。当切片一个未知数量的维度时，建议传入 ``INT_MAX``。 ``axes`` 、 ``starts`` 和 ``ends`` 三个参数的元素数目必须相等。以下示例将解释切片如何工作：
 
 ::
 


### PR DESCRIPTION
## 修复内容
### 任务1：docs/api/paddle/slice_cn.rst
- 原链接：
  - https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
  - https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/slice_cn.html
- 新链接：https://numpy.org/doc/stable/user/basics.indexing.html
- 404归因：NumPy 官方文档结构调整

## 备注
1、以下为新发现404链接，已做修改https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/slice_cn.html
<img width="868" height="607" alt="image" src="https://github.com/user-attachments/assets/7ef231cb-397f-4f6e-8143-6a3af3b3cbbe" />

2、解决过程
Change https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html to https://numpy.org/doc/stable/user/basics.indexing.html, which is a stable page and same as origin link.

Origin page in 1.18 version:
<img width="1538" height="864" alt="image" src="https://github.com/user-attachments/assets/39c27832-5fad-4fe5-a92c-89bf26b0f64c" />

Stable page:
<img width="1882" height="867" alt="image" src="https://github.com/user-attachments/assets/82d30eda-2ec2-4e95-8edd-84f4bf146db5" />
## 验证结果
已手动访问所有更新后的链接，确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie 