### PR TITLE
[Doc Link Fix No.75] Fix broken link for torch.nn.Flatten (Task 75)

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Flatten.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Flatten.md
@@ -1,5 +1,5 @@
 ## [ 仅参数名不一致 ]torch.nn.Flatten
-### [torch.nn.Flatten](https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html?highlight=nn+flatten#torch.nn.Flatten)
+### [torch.nn.Flatten](https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Flatten.html)
 ```python
 torch.nn.Flatten(start_dim=1,
                 end_dim=-1)


### PR DESCRIPTION
## 修复内容
  ### 任务 75: docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Flatten.md
  - 原链接：https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html
  - 新链接：https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Flatten.html
  - 404归因：PyTorch 官方文档域名从 pytorch.org 迁移到 docs.pytorch.org
