### PR TITLE
[Doc Link Fix No.21] 文档链接修复-part

### DIFF
--- a/docs/design/mkldnn/int8/README.md
+++ b/docs/design/mkldnn/int8/README.md
@@ -87,7 +87,7 @@ Image classification models performance was measured using a single thread. The 
 
 Notes:
 
-* Performance FP32 (images/s) values come from [INT8 MKL-DNN post-training quantization](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/inference/tests/api/int8_mkldnn_quantization.md) document.
+* Performance FP32 (images/s) values come from [INT8 MKL-DNN post-training quantization](./PTQ/README.md) document.
 
 ### NLP models benchmark results
 


### PR DESCRIPTION
## 修复内容

### 任务 21: docs/design/mkldnn/int8/README.md
- 原链接: https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/inference/tests/api/int8_mkldnn_quantization.md
- 新链接: ./PTQ/README.md
- 404归因: PaddlePaddle 主仓库代码重构，`paddle/fluid/inference/tests/api/` 目录已被移除，原 INT8 MKL-DNN post-training quantization 文档内容已迁移至 docs 仓库的 `docs/design/mkldnn/int8/PTQ/README.md`

## 备注

修复后的相对链接与文件头部已有的 PTQ 链接风格保持一致（文件第3行和第34行均使用 `./PTQ/README.md`）。

## 验证结果

已手动访问所有更新后的链接，确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie

Made with [Cursor](https://cursor.com)