### PR TITLE
[Doc Link Fix No.12] 分布式架构图片链接修复

### DIFF
--- a/docs/design/dist_train/distributed_architecture.md
+++ b/docs/design/dist_train/distributed_architecture.md
@@ -40,11 +40,11 @@ computation is only specified in Python code which sits outside of PaddlePaddle,
 
 Similar to how a compiler uses an intermediate representation (IR) so that the programmer does not need to manually optimize their code for most of the cases, we can have an intermediate representation in PaddlePaddle as well. The compiler optimizes the IR as follows:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/compiler.png"/>
+<img src="src/compiler.png"/>
 
 PaddlePaddle can support model parallelism by converting the IR so that the user no longer needs to manually perform the computation and operations in the Python component:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/paddle-compile.png"/>
+<img src="src/paddle-compile.png"/>
 
 The IR for PaddlePaddle after refactoring is called a `Block`, it specifies the computation dependency graph and the variables used in the computation.
 
@@ -60,7 +60,7 @@ For a detailed explanation, refer to this document -
 
 The revamped distributed training architecture can address the above discussed limitations. Below is the illustration of how it does so:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/distributed_architecture.png"/>
+<img src="src/distributed_architecture.png"/>
 
 The major components are: *Python API*, *Distribute Transpiler* and *Remote Executor*.
 
@@ -152,7 +152,7 @@ for data in train_reader():
 `JobDesc` object describe the distributed job resource specification to run on
 Cluster environment.
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/remote_executor.png" width="500" align="center" />
+<img src="src/remote_executor.png" width="500" align="center" />
 
 `RemoteExecutor.run` sends the `ProgramDesc` and
 [TrainingJob](https://github.com/PaddlePaddle/cloud/blob/unreleased-tpr/doc/autoscale/README.md#training-job-resource)
@@ -171,7 +171,7 @@ In the future, a more general placement algorithm should be implemented, which m
 
 The local training architecture will be the same as the distributed training architecture, the difference is that everything runs locally, and there is just one PaddlePaddle runtime:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/local_architecture.png"/>
+<img src="src/local_architecture.png"/>
 
 
 ### Training Data


### PR DESCRIPTION
## 修复内容

### 任务 12: docs/design/dist_train/distributed_architecture.md
更新 5 处失效的图片链接（原 FluidDoc 仓库已不存在）：

| # | 原链接 | 新链接 | 说明 |
|---|--------|--------|------|
| 1 | `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/compiler.png` | `src/compiler.png` | 编译器IR优化图 |
| 2 | `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/paddle-compile.png` | `src/paddle-compile.png` | Paddle编译流程图 |
| 3 | `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/distributed_architecture.png` | `src/distributed_architecture.png` | 分布式架构图 |
| 4 | `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/remote_executor.png` | `src/remote_executor.png` | 远程执行器图 |
| 5 | `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/local_architecture.png` | `src/local_architecture.png` | 本地训练架构图 |

- 404归因: FluidDoc 仓库已不存在/链接失效
- 修复方法: 图片已存在于 `docs/design/dist_train/src/` 目录，更新为相对路径引用

## 备注

- 文件中实际只有 5 处图片引用（issue 描述的 6 处可能是历史版本信息）
- 所有图片文件已验证存在于本地仓库

## 验证结果

- ✅ 所有图片文件已确认存在: `ls docs/design/dist_train/src/`
- ✅ 使用相对路径 `src/xxx.png` 正确引用同级目录下的图片

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie