### PR TITLE
[Doc Link Fix No.3]Fix strided_slice_cn.rst 

### DIFF
--- a/docs/api/paddle/strided_slice_cn.rst
+++ b/docs/api/paddle/strided_slice_cn.rst
@@ -8,7 +8,7 @@ strided_slice
 
 strided_slice 算子。
 
-沿多个轴生成 ``x`` 的切片，与 numpy 类似：https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html。该 OP 使用 ``axes`` 、 ``starts`` 和 ``ends`` 属性来指定轴列表中每个轴的起点和终点位置，并使用此信息来对 ``x`` 切片。如果向 ``starts`` 或 ``ends`` 传递负值如 :math:`-i`，则表示该轴的反向第 :math:`i-1` 个位置（这里以 0 为初始位置）， ``strides`` 表示切片的步长，``strides`` 如果为负数，则按照反方向进行切片。如果传递给 ``starts`` 或 ``ends`` 的值大于 n（维度中的元素数目），则表示 n。当切片一个未知数量的维度时，建议传入 ``INT_MAX``。 ``axes`` 、 ``starts`` 和 ``ends`` 以及 ``strides`` 四个参数的元素数目必须相等。以下示例将解释切片如何工作：
+沿多个轴生成 ``x`` 的切片，与 numpy 类似：https://numpy.org/doc/stable/user/basics.indexing.html。该 OP 使用 ``axes`` 、 ``starts`` 和 ``ends`` 属性来指定轴列表中每个轴的起点和终点位置，并使用此信息来对 ``x`` 切片。如果向 ``starts`` 或 ``ends`` 传递负值如 :math:`-i`，则表示该轴的反向第 :math:`i-1` 个位置（这里以 0 为初始位置）， ``strides`` 表示切片的步长，``strides`` 如果为负数，则按照反方向进行切片。如果传递给 ``starts`` 或 ``ends`` 的值大于 n（维度中的元素数目），则表示 n。当切片一个未知数量的维度时，建议传入 ``INT_MAX``。 ``axes`` 、 ``starts`` 和 ``ends`` 以及 ``strides`` 四个参数的元素数目必须相等。以下示例将解释切片如何工作：
 
 ::
 


### PR DESCRIPTION
## 修复内容

### 任务 1: docs/api/paddle/slice_cn.rst
- 原链接: https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html%E3%80%82%E8%AF%A5 
- 新链接: https://numpy.org/doc/stable/user/basics.indexing.html
- 404归因: NumPy 官方文档结构调整


## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie