### PR TITLE
[Doc Link Fix No.23] 文档链接修复

### DIFF
--- a/docs/design/modules/optimizer.md
+++ b/docs/design/modules/optimizer.md
@@ -32,7 +32,7 @@ In this design, we propose a high-level API that automatically derives the optim
     cost = layer.mse(hidden, labels)
     ```
 
-    The above code snippet will create forward operators in [Block](https://github.com/PaddlePaddle/Paddle/blob/develop/doc/design/block.md).
+    The above code snippet will create forward operators in [Block](https://github.com/PaddlePaddle/docs/blob/develop/docs/design/concepts/block.md).
 
 
 2. Users create a certain kind of Optimizer with some argument.


### PR DESCRIPTION
## 修复内容

### 任务 23: docs/design/modules/optimizer.md
- 原链接: https://github.com/PaddlePaddle/Paddle/blob/develop/doc/design/block.md
- 新链接: https://github.com/PaddlePaddle/docs/blob/develop/docs/design/concepts/block.md
- 404归因: 
  - 仓库名称错误（Paddle → docs）
  - 目录结构调整（doc → docs）
  - 文件位置迁移（design/block.md → docs/design/concepts/block.md）

## 备注

![404链接](https://github.com/xcq-code/image/raw/main/0.png) ![修改后链接](https://github.com/xcq-code/image/raw/main/1.png) `optimizer.md` `block.md` 没有单独的中文版本，中英文索引均引用同一个英文文件，因此无需在 Paddle repo 提交。 ![index_cn.rst 引用 optimizer.md](https://github.com/xcq-code/image/raw/main/2.png) ![index_en.rst 引用 optimizer.md](https://github.com/xcq-code/image/raw/main/3.png) ![index_cn.rst 引用 block.md](https://github.com/xcq-code/image/raw/main/4.png) ![index_en.rst 引用 block.md](https://github.com/xcq-code/image/raw/main/5.png)


## 验证结果

已手动访问所有更新后的链接，确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie