### PR TITLE
[Doc Link Fix No.76、77] 文档链接修复

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md
@@ -1,5 +1,5 @@
 ## [ 仅参数名不一致 ]torch.nn.Unflatten
-### [torch.nn.Unflatten](https://pytorch.org/docs/stable/generated/torch.nn.Unflatten.html?highlight=torch+nn+unflatten#torch.nn.Unflatten)
+### [torch.nn.Unflatten](https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Unflatten.html)
 ```python
 torch.nn.Unflatten(dim, unflattened_size)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/composite_implement/torch.cuda.set_per_process_memory_fraction.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/composite_implement/torch.cuda.set_per_process_memory_fraction.md
@@ -1,5 +1,5 @@
 ## [ 组合替代实现 ]torch.cuda.set_per_process_memory_fraction
-### [torch.cuda.set_per_process_memory_fraction](https://pytorch.org/docs/stable/generated/torch.cuda.set_per_process_memory_fraction.html)
+### [torch.cuda.set_per_process_memory_fraction](https://docs.pytorch.org/docs/stable/generated/torch.cuda.memory.set_per_process_memory_fraction.html)
 ```python
 torch.cuda.set_per_process_memory_fraction(fraction, device=None)
 ```


### PR DESCRIPTION
## 修复内容：

1. docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md
2. docs/guides/model_convert/convert_from_pytorch/api_difference/composite_implement/torch.cuda.set_per_process_memory_fraction.md

### 任务 76 & 77: docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md

- 原链接: 
    - https://docs.pytorch.org/docs/stable/generated/torch.nn.Unflatten.html?highlight=torch+nn+unflatten#torch.nn.Unflatten
    - https://docs.pytorch.org/docs/stable/generated/torch.cuda.set_per_process_memory_fraction.html

- 新链接: 
    - https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Unflatten.html
    - https://docs.pytorch.org/docs/stable/generated/torch.cuda.memory.set_per_process_memory_fraction.html
- 404归因: Pytorch 官方文档结构调整

## 备注

以将失效链接替换为有效链接：
- Unflatten页面：
<img width="2155" height="1244" alt="屏幕截图 2026-02-16 172116" src="https://github.com/user-attachments/assets/ef7abe42-880c-4067-8b95-60a97b8cf088" />

- set-per-process-fraction页面：
<img width="2154" height="1187" alt="屏幕截图 2026-02-16 180720" src="https://github.com/user-attachments/assets/0a768171-00b2-4859-b86c-02ec6ade0a88" />


## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie