### PR TITLE
[Doc Link Fix No.31] 文档链接修复

### DIFF
--- a/docs/design/others/graph_survey.md
+++ b/docs/design/others/graph_survey.md
@@ -80,7 +80,7 @@ Attrs:
 
 The core concept of symbolic API is `Tensor`. TensorFlow defines `Tensor` in Python. Please refer to the comments in TensorFlow:
 
-A `Tensor` is a symbolic handle to one of the outputs of an `Operation`. It does not hold the values of that operation's output, but instead provides a means of computing those values in a TensorFlow [Session](https://www.tensorflow.org/api_docs/python/tf/Session).
+A `Tensor` is a symbolic handle to one of the outputs of an `Operation`. It does not hold the values of that operation's output, but instead provides a means of computing those values in a TensorFlow [Session](https://www.tensorflow.org/api_docs/python/tf/compat/v1/Session).
 
 A simple example is as follows:
 


### PR DESCRIPTION
## 修复内容

### 任务 31: docs/design/others/graph_survey.md
- 原链接: https://www.tensorflow.org/api_docs/python/tf/Session
- 新链接: https://www.tensorflow.org/api_docs/python/tf/compat/v1/Session
- 404归因: TensorFlow 官方文档结构调整

## 备注

原链接：
<img width="1470" height="762" alt="image" src="https://github.com/user-attachments/assets/8fcc5b27-91ae-41ac-a127-e715c8f6e92f" />
修复后：
<img width="1470" height="765" alt="image" src="https://github.com/user-attachments/assets/dda3bc79-522c-4146-a45d-ea06473555db" />

## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie