### PR TITLE
[Doc Link Fix No.32] 文档链接修复

### DIFF
--- a/docs/design/others/parameters_in_cpp.md
+++ b/docs/design/others/parameters_in_cpp.md
@@ -1,6 +1,6 @@
 # Design Doc: The C++ Class `Parameters`
 
-`Parameters` is a concept we designed in PaddlePaddle V2 API. `Parameters` is a container of parameters, which makes PaddlePaddle capable of  sharing parameter between topologies. We described usages of `Parameter` in [api.md](./api.md).
+`Parameters` is a concept we designed in PaddlePaddle V2 API. `Parameters` is a container of parameters, which makes PaddlePaddle capable of  sharing parameter between topologies. We described usages of `Parameter` in [api.md](../motivation/api.md).
 
 We used Python to implement Parameters when designing V2 API before. There are several defects for the current implementation:
 * We just use `memcpy` to share Parameters between topologies, but this is very inefficient.


### PR DESCRIPTION
## 修复内容

### 任务 32: docs/design/others/parameters_in_cpp.md
- 原链接: ./api.md
- 新链接: ../motivation/api.md
- 404归因: PaddlePaddle 官方文档结构调整

## 备注

修复前：
<img width="1470" height="763" alt="image" src="https://github.com/user-attachments/assets/ea0a1f05-6c0a-4d00-a6a3-894e0260e9c3" />
修复后：
<img width="1470" height="763" alt="image" src="https://github.com/user-attachments/assets/b3039113-e2ba-4038-a889-7febfc0bb7a7" />

## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie