### PR TITLE
[Doc Link Fix No.65] 文档链接修复

### DIFF
--- a/docs/guides/flags/executor_cn.rst
+++ b/docs/guides/flags/executor_cn.rst
@@ -22,7 +22,7 @@ FLAGS_use_ngraph
 *******************************************
 (始于 1.4.0)
 
-在预测或训练过程中，可以通过该选项选择使用英特尔 `nGraph <https://github.com/NervanaSystems/ngraph>`_ 引擎。它将在英特尔 Xeon CPU 上获得很大的性能提升。
+在预测或训练过程中，可以通过该选项选择使用英特尔 `nGraph <https://github.com/openvinotoolkit/openvino>`_ 引擎。它将在英特尔 Xeon CPU 上获得很大的性能提升。
 
 取值范围
 ---------------
@@ -34,4 +34,4 @@ FLAGS_use_ngraph=True - 开启使用 nGraph 运行。
 
 注意
 -------
-英特尔 nGraph 目前仅在少数模型中支持。我们只验证了 `ResNet-50 <https://github.com/PaddlePaddle/models/blob/develop/PaddleCV/image_classification/README_ngraph.md>_ 的训练和预测。
+英特尔 nGraph 目前仅在少数模型中支持。我们只验证了 `ResNet-50 <https://github.com/PaddlePaddle/models/blob/develop/paddlecv/README.md>_ 的训练和预测。


### PR DESCRIPTION
## 修复内容

### 任务 65: docs/guides/flags/executor_cn.rst
- 原链接: https://github.com/PaddlePaddle/models/blob/develop/PaddleCV/image_classification/README_ngraph.md
- 新链接: https://github.com/PaddlePaddle/models/blob/develop/paddlecv/README.md
- 404归因: Rejected status code (this depends on your "accept" configuration): Not Found
- 原链接: https://github.com/NervanaSystems/ngraph
- 新链接: https://github.com/openvinotoolkit/openvino
- 归因: nGraph has moved to OpenVINO: https://github.com/openvinotoolkit/openvino
## 备注
1.
<img width="1851" height="518" alt="image" src="https://github.com/user-attachments/assets/fb1e0de9-a640-4b7f-8912-0f8eca1720f4" />
<img width="1823" height="956" alt="image" src="https://github.com/user-attachments/assets/26ba3093-f77b-4e3c-b1b6-d7c1ec5293ad" />
2.
<img width="1738" height="997" alt="image" src="https://github.com/user-attachments/assets/286ea356-1972-441f-902e-d0ad3c4e5402" />
<img width="1819" height="957" alt="image" src="https://github.com/user-attachments/assets/a52b3bb5-e255-4539-95ac-e10a78911f2f" />


## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie