### PR TITLE
[Doc Link Fix No.108、109、110、111、112] 文档链接修复

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.AlexNet_Weights.DEFAULT.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.AlexNet_Weights.DEFAULT.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.AlexNet_Weights.DEFAULT
 
-### [torchvision.models.AlexNet_Weights.DEFAULT](https://pytorch.org/vision/stable/models/generated/AlexNet_Weights.html#torchvision.models.AlexNet_Weights.DEFAULT)
+### [torchvision.models.AlexNet_Weights.DEFAULT](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.alexnet.html#torchvision.models.AlexNet_Weights)
 
 ```python
 torchvision.models.AlexNet_Weights.DEFAULT

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.AlexNet_Weights.IMAGENET1K_V1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.AlexNet_Weights.IMAGENET1K_V1.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.AlexNet_Weights.IMAGENET1K_V1
 
-### [torchvision.models.AlexNet_Weights.IMAGENET1K_V1](https://pytorch.org/vision/stable/models/generated/AlexNet_Weights.html#torchvision.models.AlexNet_Weights.IMAGENET1K_V1)
+### [torchvision.models.AlexNet_Weights.IMAGENET1K_V1](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.alexnet.html#torchvision.models.AlexNet_Weights)
 
 ```python
 torchvision.models.AlexNet_Weights.IMAGENET1K_V1

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet121_Weights.DEFAULT.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet121_Weights.DEFAULT.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.DenseNet121_Weights.DEFAULT
 
-### [torchvision.models.DenseNet121_Weights.DEFAULT](https://pytorch.org/vision/stable/models/generated/DenseNet121_Weights.html#torchvision.models.DenseNet121_Weights.DEFAULT)
+### [torchvision.models.DenseNet121_Weights.DEFAULT](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.densenet121.html#torchvision.models.DenseNet121_Weights)
 
 ```python
 torchvision.models.DenseNet121_Weights.DEFAULT

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet121_Weights.IMAGENET1K_V1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet121_Weights.IMAGENET1K_V1.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.DenseNet121_Weights.IMAGENET1K_V1
 
-### [torchvision.models.DenseNet121_Weights.IMAGENET1K_V1](https://pytorch.org/vision/stable/models/generated/DenseNet121_Weights.html#torchvision.models.DenseNet121_Weights.IMAGENET1K_V1)
+### [torchvision.models.DenseNet121_Weights.IMAGENET1K_V1](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.densenet121.html#torchvision.models.DenseNet121_Weights)
 
 ```python
 torchvision.models.DenseNet121_Weights.IMAGENET1K_V1

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet161_Weights.DEFAULT.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet161_Weights.DEFAULT.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.DenseNet161_Weights.DEFAULT
 
-### [torchvision.models.DenseNet161_Weights.DEFAULT](https://pytorch.org/vision/stable/models/generated/DenseNet161_Weights.html#torchvision.models.DenseNet161_Weights.DEFAULT)
+### [torchvision.models.DenseNet161_Weights.DEFAULT](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.densenet161.html#torchvision.models.DenseNet161_Weights)
 
 ```python
 torchvision.models.DenseNet161_Weights.DEFAULT


### PR DESCRIPTION
## 修复内容

### 任务 1：docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.AlexNet_Weights.DEFAULT.md
- 原链接：https://pytorch.org/vision/stable/models/generated/AlexNet_Weights.html#torchvision.models.AlexNet_Weights.DEFAULT
- 新链接： https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.alexnet.html#torchvision.models.AlexNet_Weights
- 404归因： PyTorch 官方文档重构，原有深度链接失效，权重详情已整合至模型主页。

### 任务 2：docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.AlexNet_Weights.IMAGENET1K_V1.md
- 原链接： https://pytorch.org/vision/stable/models/generated/AlexNet_Weights.html#torchvision.models.AlexNet_Weights.IMAGENET1K_V1
- 新链接:：https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.alexnet.html#torchvision.models.AlexNet_Weights
- 404归因： PyTorch 官方文档重构，权重信息已移至模型主页。

### 任务 3： docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet121_Weights.DEFAULT.md
- 原链接:：https://pytorch.org/vision/stable/models/generated/DenseNet121_Weights.html#torchvision.models.DenseNet121_Weights.DEFAULT
- 新链接： https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.densenet121.html#torchvision.models.DenseNet121_Weights
- 404归因: PyTorch 官方文档结构调整，权重详情整合。

### 任务 4: docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet121_Weights.IMAGENET1K_V1.md
- 原链接： https://pytorch.org/vision/stable/models/generated/DenseNet121_Weights.html#torchvision.models.DenseNet121_Weights.IMAGENET1K_V1
- 新链接：https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.densenet121.html#torchvision.models.DenseNet121_Weights
- 404归因：PyTorch 官方文档结构调整。
### 任务 5：docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.DenseNet161_Weights.DEFAULT.md
- 原链接： https://pytorch.org/vision/stable/models/generated/DenseNet161_Weights.html#torchvision.models.DenseNet161_Weights.DEFAULT
- 新链接:：https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.densenet161.html#torchvision.models.DenseNet161_Weights
- 404归因： PyTorch 官方文档结构调整。

## 备注
本次修复具体涉及以下内容的链接更新：

- 更新 AlexNet_Weights.DEFAULT 调用差异文档链接

- 更新 AlexNet_Weights.IMAGENET1K_V1 调用差异文档链接

- 更新 DenseNet121_Weights.DEFAULT 调用差异文档链接

- 更新 DenseNet121_Weights.IMAGENET1K_V1 调用差异文档链接

- 更新 DenseNet161_Weights.DEFAULT 调用差异文档链接
- 修复前：
<img width="1816" height="922" alt="image" src="https://github.com/user-attachments/assets/6ad3c958-e3e2-49a6-b075-5ce1a98532cb" />

- 修复后
<img width="2535" height="946" alt="image" src="https://github.com/user-attachments/assets/5fb21b4b-f0d1-4489-b404-8c21f4e906bd" />


## 验证结果
已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie