### PR TITLE
[Doc Link Fix No.122-126] 文档链接修复

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.DEFAULT.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.DEFAULT.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.MobileNet_V2_Weights.DEFAULT
 
-### [torchvision.models.MobileNet_V2_Weights.DEFAULT](https://pytorch.org/vision/stable/models/generated/MobileNet_V2_Weights.html#torchvision.models.MobileNet_V2_Weights.DEFAULT)
+### [torchvision.models.MobileNet_V2_Weights.DEFAULT](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html#torchvision.models.MobileNet_V2_Weights)
 
 ```python
 torchvision.models.MobileNet_V2_Weights.DEFAULT

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1
 
-### [torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1](https://pytorch.org/vision/stable/models/generated/MobileNet_V2_Weights.html#torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1)
+### [torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html#torchvision.models.MobileNet_V2_Weights)
 
 ```python
 torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2
 
-### [torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v3_large.html#torchvision.models.MobileNet_V3_Large_Weights)
+### [torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html#torchvision.models.MobileNet_V2_Weights)
 
 ```python
 torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2
 
-### [torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2](https://pytorch.org/vision/stable/models/generated/MobileNet_V2_Weights.html#torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2)
+### [torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v3_large.html#torchvision.models.MobileNet_V3_Large_Weights)
 
 ```python
 torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V3_Large_Weights.DEFAULT.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V3_Large_Weights.DEFAULT.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.MobileNet_V3_Large_Weights.DEFAULT
 
-### [torchvision.models.MobileNet_V3_Large_Weights.DEFAULT](https://pytorch.org/vision/stable/models/generated/MobileNet_V3_Large_Weights.html#torchvision.models.MobileNet_V3_Large_Weights.DEFAULT)
+### [torchvision.models.MobileNet_V3_Large_Weights.DEFAULT](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v3_large.html#torchvision.models.MobileNet_V3_Large_Weights)
 
 ```python
 torchvision.models.MobileNet_V3_Large_Weights.DEFAULT

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1
 
-### [torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1](https://pytorch.org/vision/stable/models/generated/MobileNet_V3_Large_Weights.html#torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1)
+### [torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1](https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v3_large.html#torchvision.models.MobileNet_V3_Large_Weights)
 
 ```python
 torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1


### PR DESCRIPTION
## 修复内容

### 122. docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.DEFAULT.md
- 原链接: https://pytorch.org/vision/stable/models/generated/MobileNet_V2_Weights.html#torchvision.models.MobileNet_V2_Weights.DEFAULT
- 新链接: https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html#torchvision.models.MobileNet_V2_Weights

### 123. docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1.md
- 原链接: https://pytorch.org/vision/stable/models/generated/MobileNet_V2_Weights.html#torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1
- 新链接: https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html#torchvision.models.MobileNet_V2_Weights

### 124. docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2.md
- 原链接: https://pytorch.org/vision/stable/models/generated/MobileNet_V2_Weights.html#torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V2
- 新链接: https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v2.html#torchvision.models.MobileNet_V2_Weights

### 125. docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V3_Large_Weights.DEFAULT.md
- 原链接: https://pytorch.org/vision/stable/models/generated/MobileNet_V3_Large_Weights.html#torchvision.models.MobileNet_V3_Large_Weights.DEFAULT
- 新链接: https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v3_large.html#torchvision.models.MobileNet_V3_Large_Weights

### 126. docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1.md
- 原链接: https://pytorch.org/vision/stable/models/generated/MobileNet_V3_Large_Weights.html#torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1
- 新链接: https://docs.pytorch.org/vision/stable/models/generated/torchvision.models.mobilenet_v3_large.html#torchvision.models.MobileNet_V3_Large_Weights

## 备注



## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
