### PR TITLE
docs: update PyTorch documentation links (tasks #75-79)

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Flatten.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Flatten.md
@@ -1,5 +1,5 @@
 ## [ 仅参数名不一致 ]torch.nn.Flatten
-### [torch.nn.Flatten](https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Flatten.html)
+### [torch.nn.Flatten](https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html)
 ```python
 torch.nn.Flatten(start_dim=1,
                 end_dim=-1)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md
@@ -1,5 +1,5 @@
 ## [ 仅参数名不一致 ]torch.nn.Unflatten
-### [torch.nn.Unflatten](https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Unflatten.html)
+### [torch.nn.Unflatten](https://pytorch.org/docs/stable/generated/torch.nn.Unflatten.html)
 ```python
 torch.nn.Unflatten(dim, unflattened_size)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/composite_implement/torch.cuda.set_per_process_memory_fraction.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/composite_implement/torch.cuda.set_per_process_memory_fraction.md
@@ -1,5 +1,5 @@
 ## [ 组合替代实现 ]torch.cuda.set_per_process_memory_fraction
-### [torch.cuda.set_per_process_memory_fraction](https://docs.pytorch.org/docs/stable/generated/torch.cuda.memory.set_per_process_memory_fraction.html)
+### [torch.cuda.set_per_process_memory_fraction](https://pytorch.org/docs/stable/generated/torch.cuda.set_per_process_memory_fraction.html)
 ```python
 torch.cuda.set_per_process_memory_fraction(fraction, device=None)
 ```

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/output_args_type_diff/torch.Tensor.ge_.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/output_args_type_diff/torch.Tensor.ge_.md
@@ -1,5 +1,5 @@
 ## [ 返回参数类型不一致 ]torch.Tensor.ge_
-### [torch.Tensor.ge\_](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.ge_.html#torch.Tensor.ge_)
+### [torch.Tensor.ge\_](https://pytorch.org/docs/stable/generated/torch.Tensor.ge_.html#torch.Tensor.ge_)
 ```python
 torch.Tensor.ge_(other)
 ```


### PR DESCRIPTION
## Summary
更新 PyTorch 文档链接格式：`docs.pytorch.org` → `pytorch.org/docs`

### 涉及任务
- ✅ #75 `torch.nn.Flatten` - 链接已更新
- ✅ #76 `torch.nn.Unflatten` - 链接已更新  
- ✅ #77 `torch.cuda.set_per_process_memory_fraction` - 链接已更新
- ℹ️ #78 `torch.inference_mode` - 已使用新格式，无需修改
- ✅ #79 `torch.Tensor.ge_` - 链接已更新

### 修改文件
- `docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Flatten.md`
- `docs/guides/model_convert/convert_from_pytorch/api_difference/args_name_diff/torch.nn.Unflatten.md`
- `docs/guides/model_convert/convert_from_pytorch/api_difference/composite_implement/torch.cuda.set_per_process_memory_fraction.md`
- `docs/guides/model_convert/convert_from_pytorch/api_difference/output_args_type_diff/torch.Tensor.ge_.md`

## Related Issue
Refs #7735 (快乐开源任务 #75-#79)