### PR TITLE
[Doc Link Fix No.1,4,5] 文档链接修复-part

### DIFF
--- a/CONTRIBUTING_cn.md
+++ b/CONTRIBUTING_cn.md
@@ -30,7 +30,7 @@ API 文档是飞桨框架的 API 文档，包含了飞桨框架 API 的说明介
 
 ### 应用实践
 
-这部分内容分为源代码与官网文档两部分，源代码的部分以 notebook 的形式，存放在 [book/paddle2.0_docs](https://github.com/PaddlePaddle/book/tree/develop/paddle2.0_docs) 目录下，你可以提交你的 notebook 格式的源码于该目录中；在你的 notebook 文件被合入后，我们会将其转为 ipynb 文件，存储在 [docs/practices](https://github.com/PaddlePaddle/docs/tree/develop/docs/practices) 中，然后呈现到官网。具体信息请参考：[[Call for Contribution] Tutorials for PaddlePaddle 2.0](https://github.com/PaddlePaddle/book/issues/905)。
+这部分内容存放于 [docs/practices](https://github.com/PaddlePaddle/docs/tree/develop/docs/practices) 目录下。我们非常欢迎你提交基于飞桨框架的实践案例（以 `.ipynb` notebook 格式），包括但不限于计算机视觉、自然语言处理、推荐系统等方向。提交后会直接呈现在[官网文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/practices/index_cn.html)中。具体贡献方式请参考[文档贡献指南](https://github.com/PaddlePaddle/docs/wiki/%E6%96%87%E6%A1%A3%E8%B4%A1%E7%8C%AE%E6%8C%87%E5%8D%97)。
 
 ### API 文档
 

--- a/CONTRIBUTING_cn.md
+++ b/CONTRIBUTING_cn.md
@@ -30,7 +30,7 @@ API 文档是飞桨框架的 API 文档，包含了飞桨框架 API 的说明介
 
 ### 应用实践
 
-这部分内容存放于 [docs/practices](https://github.com/PaddlePaddle/docs/tree/develop/docs/practices) 目录下。我们非常欢迎你提交基于飞桨框架的实践案例（以 `.ipynb` notebook 格式），包括但不限于计算机视觉、自然语言处理、推荐系统等方向。提交后会直接呈现在[官网文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/practices/index_cn.html)中。具体贡献方式请参考[文档贡献指南](https://github.com/PaddlePaddle/docs/wiki/%E6%96%87%E6%A1%A3%E8%B4%A1%E7%8C%AE%E6%8C%87%E5%8D%97)。
+这部分内容存放于 [docs/practices](https://github.com/PaddlePaddle/docs/tree/develop/docs/practices) 目录下。我们非常欢迎你提交基于飞桨框架的实践案例（以 `.ipynb` notebook 格式），包括但不限于计算机视觉、自然语言处理、推荐系统等方向。提交后会呈现在官方文档的[应用实践](https://www.paddlepaddle.org.cn/documentation/docs/zh/practices/index_cn.html)中。具体贡献方式请参考[文档贡献指南](https://www.paddlepaddle.org.cn/documentation/docs/zh/dev_guides/docs_contributing_guides_cn.html)。
 
 ### API 文档
 

--- a/CONTRIBUTING_cn.md
+++ b/CONTRIBUTING_cn.md
@@ -30,7 +30,7 @@ API 文档是飞桨框架的 API 文档，包含了飞桨框架 API 的说明介
 
 ### 应用实践
 
-这部分内容分为源代码与官网文档两部分，源代码的部分以 notebook 的形式，存放在 [book/paddle2.0_docs](https://github.com/PaddlePaddle/book/tree/develop/paddle2.0_docs) 目录下，你可以提交你的 notebook 格式的源码于该目录中；在你的 notebook 文件被合入后，我们会将其转为 md 文件，存储在 [docs/docs/tutorial](https://github.com/PaddlePaddle/docs/tree/develop/docs/tutorial) 中，然后呈现到官网。具体信息请参考：[[Call for Contribution] Tutorials for PaddlePaddle 2.0](https://github.com/PaddlePaddle/book/issues/905)。
+这部分内容分为源代码与官网文档两部分，源代码的部分以 notebook 的形式，存放在 [book/paddle2.0_docs](https://github.com/PaddlePaddle/book/tree/develop/paddle2.0_docs) 目录下，你可以提交你的 notebook 格式的源码于该目录中；在你的 notebook 文件被合入后，我们会将其转为 ipynb 文件，存储在 [docs/practices](https://github.com/PaddlePaddle/docs/tree/develop/docs/practices) 中，然后呈现到官网。具体信息请参考：[[Call for Contribution] Tutorials for PaddlePaddle 2.0](https://github.com/PaddlePaddle/book/issues/905)。
 
 ### API 文档
 

--- a/docs/api/paddle/strided_slice_cn.rst
+++ b/docs/api/paddle/strided_slice_cn.rst
@@ -8,7 +8,7 @@ strided_slice
 
 strided_slice 算子。
 
-沿多个轴生成 ``x`` 的切片，与 numpy 类似：https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html。该 OP 使用 ``axes`` 、 ``starts`` 和 ``ends`` 属性来指定轴列表中每个轴的起点和终点位置，并使用此信息来对 ``x`` 切片。如果向 ``starts`` 或 ``ends`` 传递负值如 :math:`-i`，则表示该轴的反向第 :math:`i-1` 个位置（这里以 0 为初始位置）， ``strides`` 表示切片的步长，``strides`` 如果为负数，则按照反方向进行切片。如果传递给 ``starts`` 或 ``ends`` 的值大于 n（维度中的元素数目），则表示 n。当切片一个未知数量的维度时，建议传入 ``INT_MAX``。 ``axes`` 、 ``starts`` 和 ``ends`` 以及 ``strides`` 四个参数的元素数目必须相等。以下示例将解释切片如何工作：
+沿多个轴生成 ``x`` 的切片，与 numpy 类似：https://numpy.org/doc/stable/user/basics.indexing.html。该 OP 使用 ``axes`` 、 ``starts`` 和 ``ends`` 属性来指定轴列表中每个轴的起点和终点位置，并使用此信息来对 ``x`` 切片。如果向 ``starts`` 或 ``ends`` 传递负值如 :math:`-i`，则表示该轴的反向第 :math:`i-1` 个位置（这里以 0 为初始位置）， ``strides`` 表示切片的步长，``strides`` 如果为负数，则按照反方向进行切片。如果传递给 ``starts`` 或 ``ends`` 的值大于 n（维度中的元素数目），则表示 n。当切片一个未知数量的维度时，建议传入 ``INT_MAX``。 ``axes`` 、 ``starts`` 和 ``ends`` 以及 ``strides`` 四个参数的元素数目必须相等。以下示例将解释切片如何工作：
 
 ::
 

--- a/docs/api/paddle/text/Conll05st_cn.rst
+++ b/docs/api/paddle/text/Conll05st_cn.rst
@@ -6,8 +6,7 @@ Conll05st
 .. py:class:: paddle.text.Conll05st(data_file=None, word_dict_file=None, verb_dict_file=None, target_dict_file=None, emb_file=None, download=True)
 
 
-该类是对 `Conll05st <https://www.cs.upc.edu/~srlconll/soft.html>`_
-测试数据集的实现。
+该类是对 Conll05st 测试数据集的实现，相关介绍可参阅：https://aclanthology.org/W05-0620.pdf
 
 .. note::
     只支持自动下载公共的 Conll05st 测试数据集。

--- a/docs/api/paddle/text/Imdb_cn.rst
+++ b/docs/api/paddle/text/Imdb_cn.rst
@@ -6,7 +6,7 @@ Imdb
 .. py:class:: paddle.text.Imdb(data_file=None, mode='train', cutoff=150, download=True)
 
 
-该类是对 `IMDB <https://www.imdb.com/interfaces/>`_ 测试数据集的实现。
+该类是对 `IMDB <https://datasets.imdbws.com/>`_ 测试数据集的实现。
 
 参数
 :::::::::


### PR DESCRIPTION
## 修复内容

### 任务 1: CONTRIBUTING_cn.md
- 原链接: https://github.com/PaddlePaddle/docs/tree/develop/docs/tutorial 
- 新链接: (https://github.com/PaddlePaddle/docs/tree/develop/docs/practices

### 任务 4: docs/api/paddle/text/Conll05st_cn.rst
- 原链接: （被删除）https://www.cs.upc.edu/~srlconll/soft.html
- 新链接: 该类是对 Conll05st 测试数据集的实现，相关介绍可参阅：https://aclanthology.org/W05-0620.pdf

## 备注
⚠️ 任务  docs/api/paddle/text/Imdb_cn.rst 未录入开源任务中，额外修复
- 原链接: https://www.imdb.com/interfaces/
- 新链接:https://datasets.imdbws.com/

## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
