### PR TITLE
[Doc Link Fix No.29] 文档链接修复

### DIFF
--- a/docs/design/network/sequence_decoder.md
+++ b/docs/design/network/sequence_decoder.md
@@ -198,7 +198,7 @@ Packing the `selected_generation_scores` will get a `DenseTensor`, and each tail
 
 ## LoD and shape changes during decoding
 <p align="center">
-  <img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/LOD-and-shape-changes-during-decoding.jpg"/>
+  <img src="https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/network/images/LOD-and-shape-changes-during-decoding.jpg"/>
 </p>
 
 According to the image above, the only phase that changes the LoD is beam search.


### PR DESCRIPTION
## 修复内容

### 任务 29: docs/design/network/sequence_decoder.md
- 原链接: https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/LOD-and-shape-changes-during-decoding.jpg
- 新链接: https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/network/images/LOD-and-shape-changes-during-decoding.jpg
- 404归因: 图片已移动至 docs 中的 docs/design/network/images/LOD-and-shape-changes-during-decoding.jpg

## 备注

修复前：

<img width="1072" height="221" alt="QQ_1771654914061" src="https://github.com/user-attachments/assets/82bd861f-3d2a-463a-bd3c-0e2d3f944563" />

修复后：

<img width="1203" height="749" alt="QQ_1771654931388" src="https://github.com/user-attachments/assets/6be5fe1b-29a6-4e06-afb1-4f50bc37c0f1" />


## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie