### PR TITLE
[Doc Link Fix No.7] 文档链接修复

### DIFF
--- a/docs/api_guides/low_level/optimizer_en.rst
+++ b/docs/api_guides/low_level/optimizer_en.rst
@@ -5,7 +5,7 @@ Optimizer
 ###########
 
 Neural network in essence is a `Optimization problem <https://en.wikipedia.org/wiki/Optimization_problem>`_ .
-With `forward computing and back propagation <https://zh.wikipedia.org/zh-hans/backpropagation_algorithm>`_ ,
+With `forward computing and back propagation <https://zh.wikipedia.org/wiki/%E5%8F%8D%E5%90%91%E4%BC%A0%E6%92%AD%E7%AE%97%E6%B3%95>`_ ,
 :code:`Optimizer` use back-propagation gradients to optimize parameters in a neural network.
 
 

--- a/docs/api_guides/low_level/optimizer_en.rst
+++ b/docs/api_guides/low_level/optimizer_en.rst
@@ -5,7 +5,7 @@ Optimizer
 ###########
 
 Neural network in essence is a `Optimization problem <https://en.wikipedia.org/wiki/Optimization_problem>`_ .
-With `forward computing and back propagation <https://zh.wikipedia.org/wiki/%E5%8F%8D%E5%90%91%E4%BC%A0%E6%92%AD%E7%AE%97%E6%B3%95>`_ ,
+With `forward computing and back propagation <https://en.wikipedia.org/wiki/Backpropagation>`_ ,
 :code:`Optimizer` use back-propagation gradients to optimize parameters in a neural network.
 
 


### PR DESCRIPTION
## 修复内容

### 任务 7: docs/api_guides/low_level/optimizer_en.rst
- 原链接: https://zh.wikipedia.org/zh-hans/backpropagation_algorithm
- 新链接: https://zh.wikipedia.org/wiki/%E5%8F%8D%E5%90%91%E4%BC%A0%E6%92%AD%E7%AE%97%E6%B3%95

## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
