### PR TITLE
[Doc Link Fix No.97] Fix docs link in page `torch.is_inference.md`

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.is_inference.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.is_inference.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torch.is_inference
 
-### [torch.is_inference](https://pytorch.org/docs/stable/generated/torch.is_inference.html)
+### [torch.is_inference](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.is_inference.html)
 
 ```python
 torch.is_inference(input)


### PR DESCRIPTION
### Description
Fix one broken link in:
- `docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.is_inference.md`

Updated the PyTorch reference from a 404 page to the current valid API doc page.

### Related links
- Task issue: #7735
- Verified old link (404): `https://pytorch.org/docs/stable/generated/torch.is_inference.html`
- New link (200): `https://docs.pytorch.org/docs/stable/generated/torch.Tensor.is_inference.html`
