### PR TITLE
[Doc Link Fix No.98] Fix docs link in page `torch.optim.Optimizer.add_param_group.md`

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.add_param_group(param_group)
 ```
 
-### [paddle.optimizer.Optimizer._add_param_group](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L2093-L2123)
+### [paddle.optimizer.Optimizer._add_param_group](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L2093-L2134)
 
 ```python
 paddle.optimizer.Optimizer._add_param_group(param_group)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.add_param_group(param_group)
 ```
 
-### [paddle.optimizer.Optimizer._add_param_group](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L2093-L2134)
+### [paddle.optimizer.Optimizer._add_param_group](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L2093-L2136)
 
 ```python
 paddle.optimizer.Optimizer._add_param_group(param_group)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.add_param_group(param_group)
 ```
 
-### [paddle.optimizer.Optimizer._add_param_group](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer)
+### [paddle.optimizer.Optimizer._add_param_group](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L2093-L2123)
 
 ```python
 paddle.optimizer.Optimizer._add_param_group(param_group)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.add_param_group.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.add_param_group(param_group)
 ```
 
-### [paddle.optimizer.Optimizer._add_param_group](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer/_add_param_group_cn.html#paddle/optimizer/Optimizer/_add_param_group_cn#cn-api-paddle-optimizer-Optimizer-_add_param_group)
+### [paddle.optimizer.Optimizer._add_param_group](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer)
 
 ```python
 paddle.optimizer.Optimizer._add_param_group(param_group)


### PR DESCRIPTION
## 修复内容

### 任务 98: `torch.optim.Optimizer.add_param_group.md`
- 原链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer/_add_param_group_cn.html#paddle/optimizer/Optimizer/_add_param_group_cn#cn-api-paddle-optimizer-Optimizer-_add_param_group
- 新链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer

## 验证结果

已手动访问更新后的链接，确认不再跳转到 docs 首页。

Related links:
- https://github.com/PaddlePaddle/docs/issues/7735
