### PR TITLE
[Doc Link Fix No.100] Fix docs link in page `torch.optim.Optimizer.state_dict.md`

### DIFF
--- a/docs/api/paddle/optimizer/Optimizer_cn.rst
+++ b/docs/api/paddle/optimizer/Optimizer_cn.rst
@@ -124,6 +124,53 @@ set_lr_scheduler(scheduler)
 
 COPY-FROM: paddle.optimizer.Optimizer.set_lr_scheduler
 
+state_dict()
+'''''''''
+
+获取优化器的状态字典信息。包含优化器使用的所有 Tensor。对于 Adam 优化器，包含 beta1、beta2、momentum 等。如果使用了 LRScheduler，状态字典中还会包含 global_step。如果优化器从未被调用过（minimize 函数），则状态字典为空。
+
+**返回**
+
+dict[str, Tensor]，包含优化器使用的所有 Tensor 的字典。
+
+**代码示例**
+
+COPY-FROM: paddle.optimizer.Optimizer.state_dict
+
+set_state_dict(state_dict)
+'''''''''
+
+加载优化器的状态字典。对于 Adam 优化器，包含 beta1、beta2、momentum 等。如果使用了 LRScheduler，global_step 也将被更新。
+
+**参数**
+
+    - **state_dict** (dict) - 包含优化器所需的所有 Tensor 的字典。
+
+**返回**
+
+无。
+
+**代码示例**
+
+COPY-FROM: paddle.optimizer.Optimizer.set_state_dict
+
+load_state_dict(state_dict)
+'''''''''
+
+加载优化器的状态字典。对于 Adam 优化器，包含 beta1、beta2、momentum 等。如果使用了 LRScheduler，global_step 也将被更新。
+
+**参数**
+
+    - **state_dict** (dict) - 包含优化器所需的所有 Tensor 的字典。
+
+**返回**
+
+无。
+
+**代码示例**
+
+COPY-FROM: paddle.optimizer.Optimizer.load_state_dict
+
 get_lr()
 '''''''''
 

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.load_state_dict(state_dict)
 ```
 
-### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/optimizer/Optimizer_en.html#set_state_dict)
+### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/optimizer/Optimizer_cn.html#load-state-dict-state-dict)
 
 ```python
 paddle.optimizer.Optimizer.load_state_dict(state_dict)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.state_dict.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.state_dict()
 ```
 
-### [paddle.optimizer.Optimizer.state_dict](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/optimizer/Optimizer_en.html#state_dict)
+### [paddle.optimizer.Optimizer.state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/optimizer/Optimizer_cn.html#state-dict)
 
 ```python
 paddle.optimizer.Optimizer.state_dict()

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.state_dict.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.state_dict()
 ```
 
-### [paddle.optimizer.Optimizer.state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer/state_dict_cn.html#paddle/optimizer/Optimizer/state_dict_cn#cn-api-paddle-optimizer-Optimizer-state_dict)
+### [paddle.optimizer.Optimizer.state_dict](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/optimizer/Optimizer_en.html#state_dict)
 
 ```python
 paddle.optimizer.Optimizer.state_dict()


### PR DESCRIPTION
## 修复内容

### 任务 100: torch.optim.Optimizer.state_dict.md
- 原链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer/state_dict_cn.html#paddle/optimizer/Optimizer/state_dict_cn#cn-api-paddle-optimizer-Optimizer-state_dict
- 新链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer.state_dict

## 补充的中文文档

本 PR 补充了以下 API 的中文文档（翻译自英文文档）：

### Optimizer.state_dict()
- 英文文档: https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/optimizer/Optimizer_en.html#state-dict

### Optimizer.set_state_dict()
- 英文文档: https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/optimizer/Optimizer_en.html#set-state-dict

### Optimizer.load_state_dict()
- 英文文档: https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/optimizer/Optimizer_en.html#load-state-dict

## 验证结果

已手动访问更新后的链接，确认不再重定向到 docs 首页。

Related links:
- https://github.com/PaddlePaddle/docs/issues/7735