### PR TITLE
[Doc Link Fix No.99] Fix docs link in page `torch.optim.Optimizer.load_state_dict.md`

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.load_state_dict(state_dict)
 ```
 
-### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer.load_state_dict)
+### [paddle.optimizer.Optimizer.load_state_dict](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L445-L519)
 
 ```python
 paddle.optimizer.Optimizer.load_state_dict(state_dict)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.load_state_dict(state_dict)
 ```
 
-### [paddle.optimizer.Optimizer.load_state_dict](https://github.com/PaddlePaddle/Paddle/blob/7763841cacc6f3235e97c0cacd0a7381860e044c/python/paddle/optimizer/optimizer.py#L445-L519)
+### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/optimizer/Optimizer_en.html#set_state_dict)
 
 ```python
 paddle.optimizer.Optimizer.load_state_dict(state_dict)

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.optim.Optimizer.load_state_dict.md
@@ -6,7 +6,7 @@
 torch.optim.Optimizer.load_state_dict(state_dict)
 ```
 
-### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer/load_state_dict_cn.html#paddle/optimizer/Optimizer/load_state_dict_cn#cn-api-paddle-optimizer-Optimizer-load_state_dict)
+### [paddle.optimizer.Optimizer.load_state_dict](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer.load_state_dict)
 
 ```python
 paddle.optimizer.Optimizer.load_state_dict(state_dict)


### PR DESCRIPTION
## 修复内容

### 任务 99: `torch.optim.Optimizer.load_state_dict.md`
- 原链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer/load_state_dict_cn.html#paddle/optimizer/Optimizer/load_state_dict_cn#cn-api-paddle-optimizer-Optimizer-load_state_dict
- 新链接: https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/optimizer/Optimizer_cn.html#paddle.optimizer.Optimizer.load_state_dict

## 验证结果

已手动检查更新后的链接格式与同目录已合并修复（state_dict）一致，避免跳转到文档首页。

Related links:
- https://github.com/PaddlePaddle/docs/issues/7735
