### PR TITLE
[Docs] Fix typos and RST markup issues in paddle.cuda API docs

### DIFF
--- a/docs/api/paddle/cuda/device_cn.rst
+++ b/docs/api/paddle/cuda/device_cn.rst
@@ -9,7 +9,7 @@ device
 
 参数
 ::::::::::::
-    - **device** (int|str|paddle.Place|None) - 设备、设备的 id 或设备的字符串名称，如 npu:x'，从中获取设备的属性。 如果设备为 None，则该设备为当前设备，默认值：None。
+    - **device** (int|str|paddle.Place|None) - 设备、设备的 id 或设备的字符串名称，如 ``npu:x``，从中获取设备的属性。如果设备为 None，则该设备为当前设备，默认值：None。
 
 
 代码示例

--- a/docs/api/paddle/cuda/manual_seed_cn.rst
+++ b/docs/api/paddle/cuda/manual_seed_cn.rst
@@ -5,7 +5,7 @@ manual_seed
 
 .. py:function:: paddle.cuda.manual_seed(seed)
 
-为当前设备置随机种子。与 :ref:`cn_api_paddle_device_manual_seed` 功能一致。
+为当前设备设置随机种子。与 :ref:`cn_api_paddle_device_manual_seed` 功能一致。
 
 参数
 ::::::::::::

--- a/docs/api/paddle/cuda/reset_peak_memory_stats_cn.rst
+++ b/docs/api/paddle/cuda/reset_peak_memory_stats_cn.rst
@@ -12,7 +12,7 @@ reset_peak_memory_stats
 
 参数
 ::::::::::::
-    - **device** (int|paddle.Place|str|None) - 设备、设备的 id 或设备的字符串名称，如 npu:x'，从中获取设备的属性。 如果设备为 None，则该设备为当前设备，默认值：None。
+    - **device** (int|paddle.Place|str|None) - 设备、设备的 id 或设备的字符串名称，如 ``npu:x``，从中获取设备的属性。如果设备为 None，则该设备为当前设备，默认值：None。
 
 代码示例
 ::::::::::::


### PR DESCRIPTION
## Changes

Fixed documentation issues found in `docs/api/paddle/cuda/` API documentation files.

### Issues Fixed

1. **`docs/api/paddle/cuda/manual_seed_cn.rst`** — Typo: missing character `设`
   - Before: `为当前设备置随机种子`
   - After: `为当前设备设置随机种子`

2. **`docs/api/paddle/cuda/device_cn.rst`** — Stray quote mark and missing RST inline code markup
   - Before: `如 npu:x',`
   - After: `如 ``npu:x``,`

3. **`docs/api/paddle/cuda/reset_peak_memory_stats_cn.rst`** — Stray quote mark and missing RST inline code markup
   - Before: `如 npu:x',`
   - After: `如 ``npu:x``,`

### Notes

- The stray quote `'` in `device_cn.rst` and `reset_peak_memory_stats_cn.rst` appears to be a copy-paste error. The correct format uses RST double-backtick markup ` ``npu:x`` ` to display inline code, consistent with how it appears in `max_memory_allocated_cn.rst`.
- The missing `设` in `manual_seed_cn.rst` is a character drop typo — the phrase `为当前设备置随机种子` is grammatically incomplete and should be `为当前设备设置随机种子`.




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22515582117)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22515582117, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22515582117 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/5