### PR TITLE
[Doc Link Fix No.16] Fix rnn.md

### DIFF
--- a/docs/design/dynamic_rnn/rnn.md
+++ b/docs/design/dynamic_rnn/rnn.md
@@ -5,7 +5,7 @@ This document describes the RNN (Recurrent Neural Network) operator and how it i
 ## RNN Algorithm Implementation
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn.jpg"/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn.jpg"/>
 </p>
 
 The above diagram shows an RNN unrolled into a full network.
@@ -22,7 +22,7 @@ There are several important concepts here:
 There could be local variables defined in each step-net.  PaddlePaddle runtime realizes these variables in *step-scopes* which are created for each step.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn.png"/><br/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn.png"/><br/>
 Figure 2 illustrates the RNN's data flow
 </p>
 
@@ -93,7 +93,7 @@ For example, we could have a 2-level RNN, where the top level corresponds to par
 The following figure illustrates feeding in text into the lower level, one sentence at a step, and the feeding in step outputs to the top level. The final top level output is about the whole text.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn.png"/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn.png"/>
 </p>
 
 ```python
@@ -149,5 +149,5 @@ If the `output_all_steps` is set to False, it will only output the final time st
 
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn_2level_data.png"/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn_2level_data.png"/>
 </p>

--- a/docs/design/dynamic_rnn/rnn.md
+++ b/docs/design/dynamic_rnn/rnn.md
@@ -5,7 +5,7 @@ This document describes the RNN (Recurrent Neural Network) operator and how it i
 ## RNN Algorithm Implementation
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn.jpg"/>
+<img src="../../images/rnn.jpg"/>
 </p>
 
 The above diagram shows an RNN unrolled into a full network.
@@ -22,7 +22,7 @@ There are several important concepts here:
 There could be local variables defined in each step-net.  PaddlePaddle runtime realizes these variables in *step-scopes* which are created for each step.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn.png"/><br/>
+<img src="../../images/rnn.png"/><br/>
 Figure 2 illustrates the RNN's data flow
 </p>
 
@@ -93,7 +93,7 @@ For example, we could have a 2-level RNN, where the top level corresponds to par
 The following figure illustrates feeding in text into the lower level, one sentence at a step, and the feeding in step outputs to the top level. The final top level output is about the whole text.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn.png"/>
+<img src="../../images/rnn.png"/>
 </p>
 
 ```python
@@ -149,5 +149,5 @@ If the `output_all_steps` is set to False, it will only output the final time st
 
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/develop/docs/images/rnn_2level_data.png"/>
+<img src="../../images/rnn_2level_data.png"/>
 </p>


### PR DESCRIPTION
## 修复内容

### 任务 1: docs/design/dynamic_rnn/rnn.md
- 原链接: 
- https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn.jpg
- https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn.png
- https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/rnn_2level_data.png
- 新链接: 
- ../../images/rnn.jpg
- ../../images/rnn.png
- ../../images/rnn_2level_data.png


## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问,md文件中的图片正确加载

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
