### PR TITLE
[Docs] Fix missing spaces between Chinese and English in device API docs

### DIFF
--- a/docs/api/paddle/device/cuda/Event_cn.rst
+++ b/docs/api/paddle/device/cuda/Event_cn.rst
@@ -11,7 +11,7 @@ CUDA event 的句柄。
 ::::::::::::
 
     - **enable_timing** (bool，可选) - Event 是否需要统计时间。默认值为 False。
-    - **blocking** (bool，可选) - wait()函数是否被阻塞。默认值为 False。
+    - **blocking** (bool，可选) - wait() 函数是否被阻塞。默认值为 False。
     - **interprocess** (bool，可选) - Event 是否能在进程间共享。默认值为 False。
 
 返回

--- a/docs/api/paddle/device/get_rng_state_cn.rst
+++ b/docs/api/paddle/device/get_rng_state_cn.rst
@@ -11,7 +11,7 @@ get_rng_state
 :::::::::
 - **device** (DeviceLike, 可选) - 要获取 RNG 状态的设备:
 
-  - 如果不指定，则使用当前默认设备(由 paddle.framework._current_expected_place_()返回)
+  - 如果不指定，则使用当前默认设备(由 paddle.framework._current_expected_place_() 返回)
   - 可以是设备对象、整数设备 ID 或设备字符串
 
 返回

--- a/docs/api/paddle/device/is_compiled_with_rocm_cn.rst
+++ b/docs/api/paddle/device/is_compiled_with_rocm_cn.rst
@@ -8,11 +8,11 @@ is_compiled_with_rocm
 
 
 
-检查 ``whl`` 包是否可以被用来在 AMD 或海光 GPU(ROCm)上运行模型。
+检查 ``whl`` 包是否可以被用来在 AMD 或海光 GPU(ROCm) 上运行模型。
 
 返回
 ::::::::::::
-bool，支持 GPU(ROCm)则为 True，否则为 False。
+bool，支持 GPU(ROCm) 则为 True，否则为 False。
 
 代码示例
 ::::::::::::


### PR DESCRIPTION
Fix violations of the documentation standard requiring spaces between Chinese characters and English/ASCII text (including closing parentheses) in 3 device API documentation files.

## Changes

- **`docs/api/paddle/device/cuda/Event_cn.rst`**: `wait()函数` → `wait() 函数`
- **`docs/api/paddle/device/is_compiled_with_rocm_cn.rst`**: `GPU(ROCm)上` → `GPU(ROCm) 上`; `GPU(ROCm)则` → `GPU(ROCm) 则`
- **`docs/api/paddle/device/get_rng_state_cn.rst`**: `_current_expected_place_()返回` → `_current_expected_place_() 返回`

## Standard Reference

Per the documentation guidelines in `.github/copilot-instructions.md`:

> 中英文之间(语法层面)需要使用空格分隔

All cases above had English/ASCII characters (closing parentheses of function calls) directly adjacent to Chinese characters without a space.




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22516080705)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22516080705, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22516080705 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/6