### PR TITLE
[Docs] Fix typos and English punctuation in Chinese API docs

### DIFF
--- a/docs/api/paddle/distributed/QueueDataset_cn.rst
+++ b/docs/api/paddle/distributed/QueueDataset_cn.rst
@@ -9,7 +9,7 @@ QueueDataset
 
 
 
-QueueyDataset 是流式处理数据使用 Dataset 类。与 InmemoryDataset 继承自同一父类，用于单机训练，不支持分布式大规模参数服务器相关配置和 shuffle。此类由 paddle.distributed.QueueDataset 直接创建。
+QueueDataset 是流式处理数据使用 Dataset 类。与 InMemoryDataset 继承自同一父类，用于单机训练，不支持分布式大规模参数服务器相关配置和 shuffle。此类由 paddle.distributed.QueueDataset 直接创建。
 
 代码示例
 ::::::::::::

--- a/docs/api/paddle/distributed/to_static_cn.rst
+++ b/docs/api/paddle/distributed/to_static_cn.rst
@@ -5,7 +5,7 @@ to_static
 
 .. py:function:: paddle.distributed.to_static(layer, loader, loss=None, optimizer=None, strategy=None)
 
-将带有分布式切分信息的动态图 ``layer`` 转换为静态图分布式模型, 可在静态图模式下进行分布式训练；同时将动态图下所使用的数据迭代器 ``loader`` 转换为静态图分布式训练所使用的数据迭代器。
+将带有分布式切分信息的动态图 ``layer`` 转换为静态图分布式模型，可在静态图模式下进行分布式训练；同时将动态图下所使用的数据迭代器 ``loader`` 转换为静态图分布式训练所使用的数据迭代器。
 
 ``paddle.distributed.to_static`` 返回 ``DistModel`` 实例和 ``DistributedDataLoader`` 实例。 ``DistModel`` 实例包含了转换后的静态图模型，同时提供了训练、评估和预测的接口。 ``DistributedDataLoader`` 实例用于在静态图分布式训练中加载数据。
 

--- a/docs/api/paddle/frexp_cn.rst
+++ b/docs/api/paddle/frexp_cn.rst
@@ -6,7 +6,7 @@ frexp
 .. py:function:: paddle.frexp(x, name)
 
 
-用于把一个浮点数分解为尾数和指数的函数, 返回一个尾数 Tensor 和一个指数 Tensor
+用于把一个浮点数分解为尾数和指数的函数，返回一个尾数 Tensor 和一个指数 Tensor
 
 参数
 ::::::::::


### PR DESCRIPTION
## Summary

Fixed documentation compliance issues in 3 API doc files found during automated documentation standards check.

## Changes

### 1. `docs/api/paddle/distributed/QueueDataset_cn.rst`
- Fixed typo: `QueueyDataset` → `QueueDataset` (class name misspelling)
- Fixed class name: `InmemoryDataset` → `InMemoryDataset` (incorrect capitalization)

### 2. `docs/api/paddle/distributed/to_static_cn.rst`
- Fixed punctuation: replaced English comma `, ` with Chinese comma `,` in Chinese prose (line 8)

### 3. `docs/api/paddle/frexp_cn.rst`
- Fixed punctuation: replaced English comma `, ` with Chinese comma `,` in Chinese prose (line 9)

## Standards Reference

Per the documentation standards:
- 中文文档中尽量避免使用英文标点符号,均应使用中文标点符号
- Class and API names must be spelled correctly and consistently




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22521095147)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22521095147, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22521095147 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/12