### PR TITLE
[Docs] Fix punctuation standards in 3 Chinese API docs

### DIFF
--- a/docs/api/paddle/distributed/stream/alltoall_single_cn.rst
+++ b/docs/api/paddle/distributed/stream/alltoall_single_cn.rst
@@ -15,10 +15,10 @@ alltoall_single
 
 参数
 :::::::::
-    - **out_tensor** (Tensor): 用于保存操作结果的 tensor，数据类型必须与输入的 tensor 保持一致。
-    - **in_tensor** (Tensor): 输入的 tensor。支持的数据类型包括：float16、float32、float64、int32、int64、int8、uint8、bool、bfloat16。
-    - **out_split_sizes** (List[int]，可选): 对 out_tensor 的 dim[0] 进行切分的大小。默认为 None，即 out_tensor 将均匀地聚合各个进程的数据（需要确保 out_tensor 的大小能够被组中的进程数整除）。
-    - **in_split_sizes** (List[int]，可选): 对 in_tensor 的 dim[0] 进行切分的大小。默认为 None，即将 in_tensor 均匀地分发到各个进程中（需要确保 in_tensor 的大小能够被组中的进程数整除）。
+    - **out_tensor** (Tensor) - 用于保存操作结果的 tensor，数据类型必须与输入的 tensor 保持一致。
+    - **in_tensor** (Tensor) - 输入的 tensor。支持的数据类型包括：float16、float32、float64、int32、int64、int8、uint8、bool、bfloat16。
+    - **out_split_sizes** (List[int]，可选) - 对 out_tensor 的 dim[0] 进行切分的大小。默认为 None，即 out_tensor 将均匀地聚合各个进程的数据（需要确保 out_tensor 的大小能够被组中的进程数整除）。
+    - **in_split_sizes** (List[int]，可选) - 对 in_tensor 的 dim[0] 进行切分的大小。默认为 None，即将 in_tensor 均匀地分发到各个进程中（需要确保 in_tensor 的大小能够被组中的进程数整除）。
     - **group** (Group，可选) - 执行该操作的进程组实例（通过 ``new_group`` 创建）。默认为 None，即使用全局默认进程组。
     - **sync_op** (bool，可选) - 该操作是否为同步操作。默认为 True，即同步操作。
     - **use_calc_stream** (bool，可选) - 该操作是否在计算流上进行。默认为 False，即不在计算流上进行。该参数旨在提高同步操作的性能，请确保在充分了解其含义的情况下调整该参数的值。

--- a/docs/api/paddle/incubate/nn/FusedDropoutAdd_cn.rst
+++ b/docs/api/paddle/incubate/nn/FusedDropoutAdd_cn.rst
@@ -9,26 +9,26 @@ FusedDropoutAdd
 
 参数
 :::::::::
-    - **p** (float|int, 可选): 将单位设置为零的概率。默认值: 0.5
-    - **mode** (str, 可选): ['upscale_in_train'(默认) | 'downscale_in_infer']
+    - **p** (float|int，可选) - 将单位设置为零的概率。默认值：0.5
+    - **mode** (str，可选) - ['upscale_in_train'（默认）| 'downscale_in_infer']
 
-               1. upscale_in_train (默认), 在训练时放大输出
+               1. upscale_in_train（默认），在训练时放大输出
 
                   - train: :math:`out = x \times \frac{mask}{(1.0 - p)} + y`
                   - inference: :math:`out = x + y`
 
-               2. downscale_in_infer, 在推理时缩小输出
+               2. downscale_in_infer，在推理时缩小输出
 
                   - train: :math:`out = x \times mask + y`
                   - inference: :math:`out = x \times (1.0 - p) + y`
-    - **name** (str, 可选): 操作的名称, 默认值为 None. 有关更多信息请参阅 :ref:`api_guide_Name`.
+    - **name** (str，可选) - 操作的名称，默认值为 None。有关更多信息请参阅 :ref:`api_guide_Name`。
 
 
 形状
 :::::::::
-        - x: N-D 张量.
-        - y: N-D 张量.
-        - output: N-D 张量, 和 `x` 形状相同.
+        - x: N-D 张量。
+        - y: N-D 张量。
+        - output: N-D 张量，和 `x` 形状相同。
 
 
 代码示例

--- a/docs/api/paddle/incubate/nn/functional/fused_dropout_add_cn.rst
+++ b/docs/api/paddle/incubate/nn/functional/fused_dropout_add_cn.rst
@@ -9,23 +9,23 @@ fused_dropout_add
 
 参数
 :::::::::
-    - **x** (Tensor): 输入张量。数据类型为 bfloat16, float16, float32 或 float64.
-    - **y** (Tensor): 输入张量，数据类型为 bfloat16, float16, float32 或 float64.
-    - **p** (float|int, 可选): 将单位设置为零的概率。默认值: 0.5。
-    - **training** (bool, 可选): 标记是否为训练阶段。默认值: True。
-    - **mode** (str, 可选): ['upscale_in_train'(默认) | 'downscale_in_infer'].
+    - **x** (Tensor) - 输入张量。数据类型为 bfloat16、float16、float32 或 float64。
+    - **y** (Tensor) - 输入张量，数据类型为 bfloat16、float16、float32 或 float64。
+    - **p** (float|int，可选) - 将单位设置为零的概率。默认值：0.5。
+    - **training** (bool，可选) - 标记是否为训练阶段。默认值：True。
+    - **mode** (str，可选) - ['upscale_in_train'（默认）| 'downscale_in_infer']。
 
-            1. upscale_in_train (默认), 在训练时放大输出
+            1. upscale_in_train（默认），在训练时放大输出
 
                 - 训练: :math:`out = x \times \frac{mask}{(1.0 - dropout\_prob)} + y`
                 - 推理: :math:`out = x + y`
 
-            2. downscale_in_infer, 在推理时缩小输出
+            2. downscale_in_infer，在推理时缩小输出
 
                 - 训练: :math:`out = input \times mask + y`
                 - 推理: :math:`out = input \times (1.0 - dropout\_prob) + y`
 
-    - **name** (str, 可选): 操作的名称, 默认值: None。有关更多信息, 请参阅 :ref:`api_guide_Name`.
+    - **name** (str，可选) - 操作的名称，默认值：None。有关更多信息，请参阅 :ref:`api_guide_Name`。
 
 
 返回


### PR DESCRIPTION
## Summary

Fixed documentation standard violations in 3 Chinese API documentation files.

## Changes

### Issue: English punctuation used in Chinese API documentation

The following files used English punctuation where Chinese punctuation is required by the documentation standards:

1. **`docs/api/paddle/distributed/stream/alltoall_single_cn.rst`**
   - Changed English colon `(Tensor): description` → `(Tensor) - description` for 4 parameters
   - Mixed separators (some params used `:`, others ` - `) made the file inconsistent

2. **`docs/api/paddle/incubate/nn/FusedDropoutAdd_cn.rst`**
   - Changed English colon separator `: ` → ` - ` in parameter descriptions
   - Changed English comma `,` → `,` in type annotations like `(float|int, 可选)` → `(float|int,可选)`
   - Changed English period `.` → `。` in shape descriptions  
   - Changed English parentheses in descriptive text `(默认)` → `(默认)`
   - Changed `默认值: 0.5` → `默认值:0.5`

3. **`docs/api/paddle/incubate/nn/functional/fused_dropout_add_cn.rst`**
   - Changed English colon separator `: ` → ` - ` in all parameter descriptions
   - Changed English comma `,` → `,` in type annotations
   - Changed English comma-separated data types to use Chinese enumeration mark `、`
   - Changed English period `.` → `。` at end of descriptions

## Standards Compliance

These changes follow the documentation standards that specify:
- Chinese documents should avoid English punctuation marks (commas, periods, colons, etc.)
- Parameter separator format should use ` - ` (dash) not `: ` (colon)
- Type annotations in Chinese context should use Chinese comma `,`




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22521407183)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22521407183, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22521407183 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/14