### PR TITLE
[Doc Link Fix No.91] Fix docs link in page `torch.cpu.current_device.md`

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.cpu.current_device.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.cpu.current_device.md
@@ -6,7 +6,7 @@
 torch.cpu.current_device()
 ```
 
-### [paddle.get_device](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/get_device_cn.html#paddle/get_device_cn#cn-api-paddle-get_device)
+### [paddle.get_device](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/device/get_device_cn.html)
 
 ```python
 paddle.get_device()


### PR DESCRIPTION
## 📝 PR 描述

修复 torch.cpu.current_device.md 中的失效 Paddle API 链接。

### 修复内容

- 将旧的 develop 路径链接改为稳定版 API 文档链接
- 旧链接：`https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/get_device_cn.html#paddle/get_device_cn#cn-api-paddle-get_device`
- 新链接：`https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/get_device_cn.html`

### 关联 Issue

#7735

## ✅ 检查清单

- [x] 我已阅读 [贡献指南](https://github.com/PaddlePaddle/docs/blob/main/docs/guides/development/contribution_cn.rst)
- [x] 本次 PR 文档预览已通过
- [x] 本次 PR 已通过所有 CI 检查（或有合理的 CI 失败原因）
- [x] 我已确认没有其他人正在修复相同的问题

---

**注意**：此 PR 仅修复一处失效链接。

## 📋 相关文档

- [Paddle get_device API 文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/get_device_cn.html)
