### PR TITLE
[Doc Link Fix No.89]

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.backends.cuda.is_built.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.backends.cuda.is_built.md
@@ -1,6 +1,6 @@
 ## [ 仅 API 调用方式不一致 ]torch.backends.cuda.is_built
 
-### [torch.backends.cuda.is\_built](https://docs.pytorch.org/docs/stable/backends.html#torch.backends.cuda.is_built)
+### [torch.backends.cuda.is\_built](https://pytorch.org/docs/stable/backends.html#torch.backends.cuda.is_built)
 
 ```python
 torch.backends.cuda.is_built()


### PR DESCRIPTION
## 修复内容

### 任务 89: docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.backends.cuda.is_built.md
- 原链接: https://docs.pytorch.org/docs/stable/backends.html#torch.backends.cuda.is_built
- 新链接: https://pytorch.org/docs/stable/backends.html#torch.backends.cuda.is_built

## 验证结果

已手动访问更新后的链接，确认可正常访问。

- https://github.com/PaddlePaddle/docs/issues/7735

@SigureMo @HZ1ovo @Echo-Nie