### PR TITLE
[Doc Link Fix No.14] Fix broken links in multi_cpu.md

### DIFF
--- a/docs/design/dist_train/multi_cpu.md
+++ b/docs/design/dist_train/multi_cpu.md
@@ -8,11 +8,11 @@ Op graph to a multi-CPU Op graph, and run `ParallelDo` Op to run the graph.
 
 ## Transpiler
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/single-thread@3x.png" width="300">
+<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/a69a584b0c5be42bb75bec5966ac1faf385a5b36/doc/fluid/images/single-thread%403x.png" width="300">
 
 After converted:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/multi-threads@3x.png" width="1000">
+<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/a69a584b0c5be42bb75bec5966ac1faf385a5b36/doc/fluid/images/multi-threads%403x.png" width="1000">
 
 ## Implement
 


### PR DESCRIPTION
## 修复内容

### 任务 14: docs/design/dist_train/multi_cpu.md

- 原链接 1: https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/single-thread@3x.png
- 新链接 1: https://raw.githubusercontent.com/PaddlePaddle/Paddle/a69a584b0c5be42bb75bec5966ac1faf385a5b36/doc/fluid/images/single-thread%403x.png

- 原链接 2: https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/multi-threads@3x.png
- 新链接 2: https://raw.githubusercontent.com/PaddlePaddle/Paddle/a69a584b0c5be42bb75bec5966ac1faf385a5b36/doc/fluid/images/multi-threads%403x.png

## 备注

原链接指向 develop 分支的 doc/fluid/images 目录下的图片，但该目录在 commit 4c4fad7a 中已被删除。因此使用该文件最后存在的 commit a69a584b0 的 permalink 链接进行修复。

## 验证结果

已手动访问所有更新后的链接，确认所有链接可正常访问。

- https://github.com/PaddlePaddle/docs/issues/7735

@SigureMo @HZ1ovo @Echo-Nie