### PR TITLE
[Doc Link Fix No.27] Fix framework.proto link in operator_kernel_type.md

### DIFF
--- a/docs/design/multi_devices/operator_kernel_type.md
+++ b/docs/design/multi_devices/operator_kernel_type.md
@@ -61,7 +61,7 @@ If we want to support new library, a new enumerator need to be added to `Library
 ### DataType
 
 
-`DataType` is defined in [framework.proto](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/framework/framework.proto). Currently, int32/int64/fp32/fp64 are supported.
+`DataType` is defined in [framework.proto](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/core/framework/framework.proto). Currently, int32/int64/fp32/fp64 are supported.
 
 ### Layout
 


### PR DESCRIPTION
## 修复内容

### 任务 27: docs/design/multi_devices/operator_kernel_type.md
- 原链接: https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/framework/framework.proto
- 新链接: https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/core/framework/framework.proto

### 修复原因
Paddle 仓库重构后，`framework.proto` 文件已从 `paddle/framework/` 迁移到 `paddle/phi/core/framework/` 目录。

## 验证结果
- [x] 已验证新链接可正常访问 (HTTP 200)
- [x] 已验证原链接失效 (HTTP 404)

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie