### PR TITLE
[Doc Link Fix No.44] Fix scalar_array.h link in kernel_declare_en.md

### DIFF
--- a/docs/dev_guides/custom_device_docs/custom_kernel_docs/kernel_declare_en.md
+++ b/docs/dev_guides/custom_device_docs/custom_kernel_docs/kernel_declare_en.md
@@ -42,7 +42,7 @@ Agreement：
     - `DataLayout` Please refer to [layout.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/common/layout.h)
     - `Place` Please refer to [place.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/place.h)
     - `const std::vector<int64_t>&`
-    - `const ScalarArray&` Please refer to [scalar_array.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/int_array.h)
+    - `const IntArray&` Please refer to [int_array.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/int_array.h)
     - `const std::vector<int>&`
     - `const std::string&`
     - `const std::vector<bool>&`

--- a/docs/dev_guides/custom_device_docs/custom_kernel_docs/kernel_declare_en.md
+++ b/docs/dev_guides/custom_device_docs/custom_kernel_docs/kernel_declare_en.md
@@ -42,7 +42,7 @@ Agreement：
     - `DataLayout` Please refer to [layout.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/common/layout.h)
     - `Place` Please refer to [place.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/place.h)
     - `const std::vector<int64_t>&`
-    - `const ScalarArray&` Please refer to [scalar_array.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/scalar_array.h)
+    - `const ScalarArray&` Please refer to [scalar_array.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/int_array.h)
     - `const std::vector<int>&`
     - `const std::string&`
     - `const std::vector<bool>&`


### PR DESCRIPTION
## 修复内容

### 任务 44: docs/dev_guides/custom_device_docs/custom_kernel_docs/kernel_declare_en.md
- 原链接: https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/scalar_array.h
- 新链接: https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/common/int_array.h

### 修复原因
Paddle 仓库重构后，`ScalarArray` 已重命名为 `IntArray`，对应的头文件也从 `scalar_array.h` 改为 `int_array.h`。

## 验证结果
- [x] 已验证新链接可正常访问 (HTTP 200)
- [x] 已验证原链接失效 (HTTP 404)

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie