### PR TITLE
[Doc Link Fix No.15] Fix broken image links in parameter_server.md

### DIFF
--- a/docs/design/dist_train/parameter_server.md
+++ b/docs/design/dist_train/parameter_server.md
@@ -41,11 +41,11 @@ We will need these OPs: *Send*, *Recv*, *Enqueue*, *Dequeue*.
 Below is an example of converting the user defined graph to the
 subgraphs for the trainer and the parameter server:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/local-graph.png" width="300"/>
+<img src="src/local-graph.png" width="300"/>
 
 After converting:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/dist-graph.png" width="700"/>
+<img src="src/dist-graph.png" width="700"/>
 
 1. The parameter variable W and its optimizer program are placed on the parameter server.
 1. Operators are added to the program.
@@ -69,7 +69,7 @@ In Fluid, we introduce [SelectedRows](https://github.com/PaddlePaddle/docs/blob/
 non-zero gradient data. So when we do parameter optimization both locally and remotely,
 we only need to send those non-zero rows to the optimizer operators:
 
-<img src="https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/sparse_update.png" width="700" />
+<img src="src/sparse_update.png" width="700" />
 ### Benefits
 
 - Model parallelism becomes easier to implement: it is an extension to


### PR DESCRIPTION
## 修复内容

### 任务 15: docs/design/dist_train/parameter_server.md
- 原链接: `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/local-graph.png`
- 新链接: `src/local-graph.png`

- 原链接: `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/dist-graph.png`
- 新链接: `src/dist-graph.png`

- 原链接: `https://raw.githubusercontent.com/PaddlePaddle/FluidDoc/develop/doc/fluid/images/sparse_update.png`
- 新链接: `src/sparse_update.png`

## 备注

The images already exist in the `docs/design/dist_train/src/` directory, so the links are updated to use relative paths.

## 验证结果

已确认所有图片文件存在于 `docs/design/dist_train/src/` 目录下，链接可正常访问。

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
