### PR TITLE
[Docs] Fix Chinese punctuation compliance in paddle.hub API docs

### DIFF
--- a/docs/api/paddle/hub/help_cn.rst
+++ b/docs/api/paddle/hub/help_cn.rst
@@ -15,7 +15,7 @@ help
     - **repo_dir** (str) - repo 地址，支持 git 地址形式和 local 地址。git 地址由 repo 拥有者/repo 名字:repo 分支组成，实例：PaddlePaddle/PaddleClas:develop；local 地址为 repo 的本地路径。
     - **model** (str) - 模型的名字。
     - **source** (str，可选) - 指定 repo 托管的位置，支持 github、gitee 和 local，默认值：github。
-    - **force_reload** (bool，可选) - 指定是否强制拉取，默认值: False。
+    - **force_reload** (bool，可选) - 指定是否强制拉取，默认值：False。
 
 返回
 :::::::::

--- a/docs/api/paddle/hub/list_cn.rst
+++ b/docs/api/paddle/hub/list_cn.rst
@@ -14,7 +14,7 @@ list
 
     - **repo_dir** (str) - repo 地址，支持 git 地址形式和 local 地址。git 地址由 repo 拥有者/repo 名字:repo 分支组成，实例：PaddlePaddle/PaddleClas:develop；local 地址为 repo 的本地路径。
     - **source** (str，可选) - 指定 repo 托管的位置，支持 github、gitee 和 local，默认值：github。
-    - **force_reload** (bool，可选) - 指定是否强制拉取，默认值: False。
+    - **force_reload** (bool，可选) - 指定是否强制拉取，默认值：False。
 
 
 返回

--- a/docs/api/paddle/hub/load_cn.rst
+++ b/docs/api/paddle/hub/load_cn.rst
@@ -12,9 +12,9 @@ load
 :::::::::
 
     - **repo_dir** (str) - repo 地址，支持 git 地址形式和 local 地址。git 地址由 repo 拥有者/repo 名字:repo 分支组成，实例：PaddlePaddle/PaddleClas:develop；local 地址为 repo 的本地路径。
-    - **model** (str)- 模型的名字。
+    - **model** (str) - 模型的名字。
     - **source** (str，可选) - 指定 repo 托管的位置，支持 github、gitee 和 local，默认值：github。
-    - **force_reload** (bool，可选)  - 指定是否强制拉取，默认值: False。
+    - **force_reload** (bool，可选) - 指定是否强制拉取，默认值：False。
     - **\*\*kwargs** (any，可选) - 模型参数。
 
 返回


### PR DESCRIPTION
## Summary

Fixed documentation compliance issues in `paddle.hub` API docs where English colons (`:`) were incorrectly used in Chinese-language parameter descriptions instead of Chinese colons (`:`).

Per the repository's documentation standards, Chinese documents should use Chinese punctuation throughout. The `默认值: False` pattern violates this standard and should be `默认值:False`.

## Changes

### `docs/api/paddle/hub/help_cn.rst`
- Fixed English colon in default value description: `默认值: False` → `默认值:False`

### `docs/api/paddle/hub/list_cn.rst`
- Fixed English colon in default value description: `默认值: False` → `默认值:False`

### `docs/api/paddle/hub/load_cn.rst`
- Fixed English colon in default value description: `默认值: False` → `默认值:False`
- Fixed missing space after parameter type: `**model** (str)-` → `**model** (str) -`
- Fixed double space before dash: `(bool,可选)  -` → `(bool,可选) -`

## Standards Reference

From `.github/copilot-instructions.md`:
> 中文文档中尽量避免使用英文标点符号,如逗号、句号、引号等,均应使用中文标点符号




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22523490614)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22523490614, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22523490614 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/19