### PR TITLE
[CodeStyle] Fix missing spaces between English and Chinese in API docs

### DIFF
--- a/docs/api/paddle/incubate/autograd/Overview_cn.rst
+++ b/docs/api/paddle/incubate/autograd/Overview_cn.rst
@@ -39,7 +39,7 @@ _________________________
                 return paddle.tanh(y)
 
 
-第三步：创建网络及声明输入数据，执行前向计算过程。注意，输入数据目前尚不支持可变形状，即类似 paddle.static.data('x', shape=(None, 2), dtype='float32')写法，如果您的输入数据形状会变化可以参考 :ref:`附 1 <autograd_appendix_1>` 写法。
+第三步：创建网络及声明输入数据，执行前向计算过程。注意，输入数据目前尚不支持可变形状，即类似 paddle.static.data('x', shape=(None, 2), dtype='float32') 写法，如果您的输入数据形状会变化可以参考 :ref:`附 1 <autograd_appendix_1>` 写法。
 
 ..  code-block:: python
 

--- a/docs/api/paddle/incubate/autograd/Overview_cn.rst
+++ b/docs/api/paddle/incubate/autograd/Overview_cn.rst
@@ -39,7 +39,7 @@ _________________________
                 return paddle.tanh(y)
 
 
-第三步：创建网络及声明输入数据，执行前向计算过程。注意，输入数据目前尚不支持可变形状，即类似 paddle.static.data('x', shape=(None, 2), dtype='float32') 写法，如果您的输入数据形状会变化可以参考 :ref:`附 1 <autograd_appendix_1>` 写法。
+第三步：创建网络及声明输入数据，执行前向计算过程。注意，输入数据目前尚不支持可变形状，即类似 ``paddle.static.data('x', shape=(None, 2), dtype='float32')`` 写法，如果您的输入数据形状会变化可以参考 :ref:`附 1 <autograd_appendix_1>` 写法。
 
 ..  code-block:: python
 

--- a/docs/api/paddle/incubate/optimizer/LBFGS_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/LBFGS_cn.rst
@@ -15,7 +15,7 @@ LBFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optim
 使用方法
 :::::::::
 - LBFGS 优化器此实现为类形式，与 Paddle 现有 SGD、Adam 优化器相似。
-  通过调用 backward()计算梯度，并使用 step(closure)更新网络参数，其中 closure 为需要优化的闭包函数。
+  通过调用 backward() 计算梯度，并使用 step(closure) 更新网络参数，其中 closure 为需要优化的闭包函数。
 
 
 .. warning::

--- a/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
@@ -22,7 +22,7 @@ BFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optimi
 使用方法
 :::::::::
 - minimize_bfgs 优化器当前实现为函数形式，与 Paddle 现有 SGD、Adam 优化器等使用略微有些区别。
-  SGD/Adam 等通过调用 backward()计算梯度，并使用 step()更新网络参数。 而 minimize_bfgs 传入
+  SGD/Adam 等通过调用 backward() 计算梯度，并使用 step() 更新网络参数。 而 minimize_bfgs 传入
   loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_assign` 以 inpalce 方式进行更新。具体参考代码示例 1.
 - 由于当前实现上一些限制，当前 minimize_bfgs 要求函数输入为一维 Tensor。当输入参数维度超过一维，
   可以先将参数展平，使用 minimize_bfgs 计算后，再 reshape 到原有形状，更新参数。具体参考代码示例 2.

--- a/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
@@ -22,7 +22,7 @@ BFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optimi
 使用方法
 :::::::::
 - minimize_bfgs 优化器当前实现为函数形式，与 Paddle 现有 SGD、Adam 优化器等使用略微有些区别。
-  SGD/Adam 等通过调用 backward() 计算梯度，并使用 step() 更新网络参数。 而 minimize_bfgs 传入
+  SGD/Adam 等通过调用 backward() 计算梯度，并使用 step() 更新网络参数。而 minimize_bfgs 传入
   loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_assign` 以 inpalce 方式进行更新。具体参考代码示例 1.
 - 由于当前实现上一些限制，当前 minimize_bfgs 要求函数输入为一维 Tensor。当输入参数维度超过一维，
   可以先将参数展平，使用 minimize_bfgs 计算后，再 reshape 到原有形状，更新参数。具体参考代码示例 2.

--- a/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst
@@ -23,7 +23,7 @@ BFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optimi
 :::::::::
 - minimize_bfgs 优化器当前实现为函数形式，与 Paddle 现有 SGD、Adam 优化器等使用略微有些区别。
   SGD/Adam 等通过调用 backward() 计算梯度，并使用 step() 更新网络参数。而 minimize_bfgs 传入
-  loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_assign` 以 inpalce 方式进行更新。具体参考代码示例 1.
+  loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_assign` 以 inplace 方式进行更新。具体参考代码示例 1.
 - 由于当前实现上一些限制，当前 minimize_bfgs 要求函数输入为一维 Tensor。当输入参数维度超过一维，
   可以先将参数展平，使用 minimize_bfgs 计算后，再 reshape 到原有形状，更新参数。具体参考代码示例 2.
 


### PR DESCRIPTION
## Summary

Fixed missing spaces between ASCII/English characters and Chinese characters in 3 API documentation files. This violates the documentation standard that requires a space between Chinese and English text (语法层面需要使用空格分隔).

## Files Changed

- **`docs/api/paddle/incubate/autograd/Overview_cn.rst`**
  - `dtype='float32')写法` → `dtype='float32') 写法`

- **`docs/api/paddle/incubate/optimizer/LBFGS_cn.rst`**
  - `backward()计算` → `backward() 计算`
  - `step(closure)更新` → `step(closure) 更新`

- **`docs/api/paddle/incubate/optimizer/functional/minimize_bfgs_cn.rst`**
  - `backward()计算` → `backward() 计算`
  - `step()更新` → `step() 更新`

## Standard Reference

Per the documentation guidelines in `.github/copilot-instructions.md`:
> 中英文之间(语法层面)需要使用空格分隔

A space must be added between ASCII/English characters (including closing parentheses `)`) and Chinese characters when they appear adjacent in text.




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22523620456)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22523620456, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22523620456 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/20