### PR TITLE
[Docs] Fix English periods to Chinese periods in Chinese API docs

### DIFF
--- a/docs/api/paddle/is_floating_point_cn.rst
+++ b/docs/api/paddle/is_floating_point_cn.rst
@@ -17,7 +17,7 @@ is_floating_point
 返回
 :::::::::
 
-bool，输入 tensor 的数据类型为浮点数类型则为 True，反之为 False.
+bool，输入 tensor 的数据类型为浮点数类型则为 True，反之为 False。
 
 代码示例
 :::::::::

--- a/docs/api/paddle/logical_and_cn.rst
+++ b/docs/api/paddle/logical_and_cn.rst
@@ -11,7 +11,7 @@ logical_and
        Out = X \&\& Y
 
 .. note::
-    ``paddle.logical_and`` 遵守 broadcasting，如您想了解更多，请参见 `Tensor 介绍`_ .
+    ``paddle.logical_and`` 遵守 broadcasting，如您想了解更多，请参见 `Tensor 介绍`_。
 
     .. _Tensor 介绍: ../../guides/beginner/tensor_cn.html#id7
 

--- a/docs/api/paddle/logical_or_cn.rst
+++ b/docs/api/paddle/logical_or_cn.rst
@@ -11,7 +11,7 @@ logical_or
         Out = X || Y
 
 .. note::
-    ``paddle.logical_or`` 遵守 broadcasting，如您想了解更多，请参见 `Tensor 介绍`_ .
+    ``paddle.logical_or`` 遵守 broadcasting，如您想了解更多，请参见 `Tensor 介绍`_。
 
     .. _Tensor 介绍: ../../guides/beginner/tensor_cn.html#id7
 


### PR DESCRIPTION
## Summary

Fixed documentation standard violations where English periods (`.`) were used at the end of Chinese sentences instead of Chinese periods (`。`).

According to the documentation standards in `.github/copilot-instructions.md`:
> 中文文档中尽量避免使用英文标点符号,如逗号、句号、引号等,均应使用中文标点符号

## Changes

- **`docs/api/paddle/is_floating_point_cn.rst`**: Changed `False.` → `False。` in the return value description
- **`docs/api/paddle/logical_and_cn.rst`**: Changed `Tensor 介绍`_ .` → `Tensor 介绍`_。` in the note about broadcasting
- **`docs/api/paddle/logical_or_cn.rst`**: Changed `Tensor 介绍`_ .` → `Tensor 介绍`_。` in the note about broadcasting

## Type of Change

- [x] Documentation fix (non-breaking change which fixes documentation)




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22523906985)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22523906985, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22523906985 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/22