### PR TITLE
[Docs] Fix English comma punctuation in Chinese API documentation

### DIFF
--- a/docs/api/paddle/nanquantile_cn.rst
+++ b/docs/api/paddle/nanquantile_cn.rst
@@ -5,7 +5,7 @@ nanquantile
 
 .. py:function:: paddle.nanquantile(x, q, axis=None, keepdim=False, interpolation='linear', name=None)
 
-沿给定的轴 ``axis`` 计算 ``x`` 中元素的分位数, 忽略元素中的 ``NaN`` 。
+沿给定的轴 ``axis`` 计算 ``x`` 中元素的分位数，忽略元素中的 ``NaN`` 。
 
 参数
 ::::::::::

--- a/docs/api/paddle/nn/functional/scaled_dot_product_attention_cn.rst
+++ b/docs/api/paddle/nn/functional/scaled_dot_product_attention_cn.rst
@@ -8,7 +8,7 @@ scaled_dot_product_attention
 
 ..  math::
     result=softmax(\frac{ Q * K^T }{\sqrt{d}}) * V
-其中, ``Q``、``K`` 和 ``V`` 表示注意力模块的三个输入参数。这三个参数的尺寸相同。``d`` 表示三个参数中最后一个维度的大小。
+其中，``Q``、``K`` 和 ``V`` 表示注意力模块的三个输入参数。这三个参数的尺寸相同。``d`` 表示三个参数中最后一个维度的大小。
 
 .. warning::
     此 API 仅支持数据类型为 float16 和 bfloat16 的输入。
@@ -20,11 +20,11 @@ scaled_dot_product_attention
     - **query** (Tensor) - 注意力模块中的查询张量。具有以下形状的四维张量：[batch_size, seq_len, num_heads, head_dim]，或者三维张量：[seq_len, num_heads, head_dim]。数据类型可以是 float61 或 bfloat16。
     - **key** (Tensor) - 注意力模块中的关键张量。具有以下形状的四维张量:[batch_size, seq_len, num_heads, head_dim]，或者三维张量：[seq_len, num_heads, head_dim]。数据类型可以是 float61 或 bfloat16。
     - **value** (Tensor) - 注意力模块中的值张量。具有以下形状的四维张量: [batch_size, seq_len, num_heads, head_dim]，或者三维张量：[seq_len, num_heads, head_dim]。数据类型可以是 float61 或 bfloat16。
-    - **attn_mask** (Tensor, 可选) - 与添加到注意力分数的 ``query``、 ``key``、 ``value`` 类型相同的浮点掩码, 默认值为空。
-    - **dropout_p** (float) - ``dropout`` 的比例, 默认值为 0.00 即不进行正则化。
-    - **is_causal** (bool) - 是否启用因果关系, 默认值为 False 即不启用。
-    - **training** (bool): - 是否处于训练阶段, 默认值为 True 即处于训练阶段。
-    - **name** (str, 可选) - 默认值为 None。通常不需要用户设置此属性。欲了解更多信息, 请参阅:ref:`api_guide_Name`。
+    - **attn_mask** (Tensor，可选) - 与添加到注意力分数的 ``query``、 ``key``、 ``value`` 类型相同的浮点掩码，默认值为空。
+    - **dropout_p** (float) - ``dropout`` 的比例，默认值为 0.00 即不进行正则化。
+    - **is_causal** (bool) - 是否启用因果关系，默认值为 False 即不启用。
+    - **training** (bool): - 是否处于训练阶段，默认值为 True 即处于训练阶段。
+    - **name** (str，可选) - 默认值为 None。通常不需要用户设置此属性。欲了解更多信息，请参阅:ref:`api_guide_Name`。
 
 
 返回

--- a/docs/api/paddle/random__cn.rst
+++ b/docs/api/paddle/random__cn.rst
@@ -15,7 +15,7 @@ random_ 为 Inplace 版本实现，对输入 `x` 采用 Inplace 策略。
     - **x** (Tensor) - 输入多维 Tensor，可选的数据类型为 'int32'、'int64'、'float32'、'float64'、'float16'、'bfloat16'。
     - **from** (int，可选) - 生成随机值的范围下限，默认为 0。。
     - **to** (int|None，可选) - 生成随机值的范围上限（开区间），默认为 None。
-    - **generator** (None) - 随机数生成器的占位参数,当前未实现，保留未来使用。
+    - **generator** (None) - 随机数生成器的占位参数，当前未实现，保留未来使用。
 
 返回
 ::::::::::::


### PR DESCRIPTION
## Summary

Fixed Chinese punctuation violations in 3 API documentation files. According to the repository's documentation standards, Chinese documents should use Chinese punctuation symbols (,。()etc.) instead of English ones (, . () etc.).

## Files Changed

### `docs/api/paddle/nanquantile_cn.rst`
- Fixed: `, 忽略元素中的` → `,忽略元素中的`

### `docs/api/paddle/random__cn.rst`
- Fixed: `占位参数,当前未实现` → `占位参数,当前未实现`

### `docs/api/paddle/nn/functional/scaled_dot_product_attention_cn.rst`
- Fixed `其中, ` → `其中,`
- Fixed `(Tensor, 可选)` → `(Tensor,可选)`
- Fixed multiple instances of `, 默认值为` → `,默认值为`
- Fixed `(str, 可选)` → `(str,可选)`
- Fixed `欲了解更多信息, 请参阅` → `欲了解更多信息,请参阅`

## Documentation Standard Reference

Per `.github/copilot-instructions.md`:
> 中文文档中尽量避免使用英文标点符号,如逗号、句号、引号等,均应使用中文标点符号

Translation: Chinese documents should avoid English punctuation marks (commas, periods, quotation marks, etc.) and should use Chinese punctuation marks instead.




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22524626351)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22524626351, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22524626351 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/23