### PR TITLE
[Docs] Fix English punctuation in Chinese API docs (Accuracy, Auc, triangular_solve)

### DIFF
--- a/docs/api/paddle/linalg/triangular_solve_cn.rst
+++ b/docs/api/paddle/linalg/triangular_solve_cn.rst
@@ -6,7 +6,7 @@ triangular_solve
 .. py:function:: paddle.linalg.triangular_solve(x, y, upper=True, transpose=False, unitriangular=False, name=None)
 
 
-计算具有唯一解的线性方程组解，其中参数 `x` 是上(下)三角系数矩阵，`y` 为线性方程组右边的矩阵。
+计算具有唯一解的线性方程组解，其中参数 `x` 是上（下）三角系数矩阵，`y` 为线性方程组右边的矩阵。
 
 记 :math:`x` 表示一个或一批方阵，:math:`y` 表示一个或一批矩阵。
 

--- a/docs/api/paddle/metric/Accuracy__upper_cn.rst
+++ b/docs/api/paddle/metric/Accuracy__upper_cn.rst
@@ -6,7 +6,7 @@ Accuracy
 .. py:class:: paddle.metric.Accuracy(topk=(1, ), name=None, *args, **kwargs)
 
 
-计算准确率(accuracy)。
+计算准确率（accuracy）。
 
 参数：
 :::::::::
@@ -33,12 +33,12 @@ compute(pred, label, *args)
 
 **参数**
 
-    - **pred** (Tensor) - 预测结果为是 float64 或 float32 类型的 Tensor。shape 为[batch_size, d0, ..., dN].
-    - **label** (Tensor) - 真实的标签值是一个 int64 类型的 Tensor，shape 为[batch_size, d0, ..., 1] 或 one hot 表示的形状[batch_size, d0, ..., num_classes].
+    - **pred** (Tensor) - 预测结果为是 float64 或 float32 类型的 Tensor。shape 为[batch_size, d0, ..., dN]。
+    - **label** (Tensor) - 真实的标签值是一个 int64 类型的 Tensor，shape 为[batch_size, d0, ..., 1] 或 one hot 表示的形状[batch_size, d0, ..., num_classes]。
 
 **返回**
 
-Tensor，shape 是[batch_size, d0, ..., topk], 值为 0 或 1，1 表示预测正确.
+Tensor，shape 是[batch_size, d0, ..., topk]，值为 0 或 1，1 表示预测正确。
 
 
 update(correct, *args)

--- a/docs/api/paddle/metric/Auc_cn.rst
+++ b/docs/api/paddle/metric/Auc_cn.rst
@@ -8,7 +8,7 @@ Auc
 .. note::
     目前只用 Python 实现 Auc，可能速度略慢。
 
-该接口计算 Auc，在二分类(binary classification)中广泛使用。
+该接口计算 Auc，在二分类（binary classification）中广泛使用。
 
 该接口创建四个局部变量 true_positives，true_negatives，false_positives 和 false_negatives，用于计算 Auc。为了离散化 AUC 曲线，使用临界值的线性间隔来计算召回率和准确率的值。用 false positive 的召回值高度计算 ROC 曲线面积，用 recall 的准确值高度计算 PR 曲线面积。
 


### PR DESCRIPTION
## Summary

Fix English punctuation used in Chinese API documentation, replacing them with the appropriate Chinese punctuation as required by the documentation standards.

## Changes

### `docs/api/paddle/metric/Accuracy__upper_cn.rst`
- `计算准确率(accuracy)。` → `计算准确率(accuracy)。` (English parentheses → Chinese parentheses)
- Fixed trailing English periods `.` to Chinese periods `。` in parameter descriptions

### `docs/api/paddle/metric/Auc_cn.rst`
- `在二分类(binary classification)中广泛使用。` → `在二分类(binary classification)中广泛使用。` (English parentheses → Chinese parentheses)

### `docs/api/paddle/linalg/triangular_solve_cn.rst`
- `上(下)三角系数矩阵` → `上(下)三角系数矩阵` (English parentheses → Chinese parentheses)

## Standard Reference

Per the documentation standards in `.github/copilot-instructions.md`:
> 中文文档中尽量避免使用英文标点符号,如逗号、句号、引号等,均应使用中文标点符号

These changes ensure Chinese API documentation uses Chinese punctuation consistently.




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22524897869)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22524897869, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22524897869 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/24