### PR TITLE
[Docs] Fix English commas in Chinese API docs for logical operations

### DIFF
--- a/docs/api/paddle/logical_and_cn.rst
+++ b/docs/api/paddle/logical_and_cn.rst
@@ -21,9 +21,9 @@ logical_and
 参数
 ::::::::::::
 
-        - **x** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool, int8, int16, int32, int64, bfloat16, float16, float32, float64, complex64, complex128。
+        - **x** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``input``
-        - **y** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool, int8, int16, int32, int64, bfloat16, float16, float32, float64, complex64, complex128。
+        - **y** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``other``
         - **out** （Tensor，可选） - 指定算子输出结果的 `Tensor`，可以是程序中已经创建的任何 Tensor。默认值为 None，此时将创建新的 Tensor 来保存输出结果。
         - **name** （str，可选） - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。

--- a/docs/api/paddle/logical_not_cn.rst
+++ b/docs/api/paddle/logical_not_cn.rst
@@ -19,7 +19,7 @@ logical_not
 参数
 ::::::::::::
 
-        - **x** （Tensor） - 逻辑非运算的输入，是一个 Tensor，支持的数据类型为 bool, int8, int16, int32, int64, bfloat16, float16, float32, float64, complex64, complex128。
+        - **x** （Tensor） - 逻辑非运算的输入，是一个 Tensor，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``input``
         - **out** （Tensor，可选） - 指定算子输出结果的 Tensor，可以是程序中已经创建的任何 Tensor。默认值为 None，此时将创建新的 Tensor 来保存输出结果。
         - **name** （str，可选） - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。

--- a/docs/api/paddle/logical_or_cn.rst
+++ b/docs/api/paddle/logical_or_cn.rst
@@ -21,9 +21,9 @@ logical_or
 参数
 ::::::::::::
 
-        - **x** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool, int8, int16, int32, int64, bfloat16, float16, float32, float64, complex64, complex128。
+        - **x** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``input``
-        - **y** （Tensor）- 输入的 `Tensor`，支持的数据类型为 bool, int8, int16, int32, int64, bfloat16, float16, float32, float64, complex64, complex128。
+        - **y** （Tensor）- 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``other``
         - **out** （Tensor，可选） - 指定算子输出结果的 `Tensor`，可以是程序中已经创建的任何 Tensor。默认值为 None，此时将创建新的 Tensor 来保存输出结果。
         - **name** （str，可选） - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。

--- a/docs/api/paddle/logical_or_cn.rst
+++ b/docs/api/paddle/logical_or_cn.rst
@@ -23,7 +23,7 @@ logical_or
 
         - **x** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``input``
-        - **y** （Tensor）- 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
+        - **y** （Tensor） - 输入的 `Tensor`，支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128。
           别名： ``other``
         - **out** （Tensor，可选） - 指定算子输出结果的 `Tensor`，可以是程序中已经创建的任何 Tensor。默认值为 None，此时将创建新的 Tensor 来保存输出结果。
         - **name** （str，可选） - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。


### PR DESCRIPTION
## Summary

Fixed documentation standard violations in Chinese API documentation for logical operator files.

## Issue

The documentation standards require Chinese docs to use Chinese punctuation symbols instead of English ones:
> 中文文档中尽量避免使用英文标点符号,如逗号、句号、引号等,均应使用中文标点符号

In the affected files, data type lists were using English commas (`,`) as separators:
````
支持的数据类型为 bool, int8, int16, int32, int64, bfloat16, float16, float32, float64, complex64, complex128
```

## Fix

Replaced English commas (`,`) with Chinese enumeration marks (`、`) in data type listings within Chinese documentation:
```
支持的数据类型为 bool、int8、int16、int32、int64、bfloat16、float16、float32、float64、complex64、complex128
````

## Files Modified

- `docs/api/paddle/logical_and_cn.rst` - Fixed 2 parameter descriptions (x, y)
- `docs/api/paddle/logical_not_cn.rst` - Fixed 1 parameter description (x)
- `docs/api/paddle/logical_or_cn.rst` - Fixed 2 parameter descriptions (x, y)




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22525247530)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22525247530, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22525247530 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/25