### PR TITLE
[Docs] Fix API documentation standards compliance in multiply_cn, AdaptiveLogSoftmaxWithLoss_cn, and AvgPool2D_cn

### DIFF
--- a/docs/api/paddle/multiply_cn.rst
+++ b/docs/api/paddle/multiply_cn.rst
@@ -17,7 +17,7 @@ multiply
 - :math:`X`：多维 Tensor。
 - :math:`Y`：维度必须小于等于 X 维度的 Tensor。
 
-对于这个运算算子有 2 种情况：
+对于这个运算算子有 3 种情况：
 
         1. :math:`Y` 的 ``shape`` 与 :math:`X` 相同。
         2. :math:`Y` 的 ``shape`` 是 :math:`X` 的连续子序列。
@@ -37,7 +37,6 @@ multiply
         - **y** （Tensor）- 多维 ``Tensor``。数据类型为 ``bfloat16`` 、 ``float16`` 、 ``float32`` 、 ``float64`` 、 ``int32`` 、 ``int64``、 ``bool``、 ``complex64`` 或  ``complex128``。
           ``别名：other``
         - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
-        - **out** (Tensor，可选)- 输出的结果。该参数为仅关键字参数，默认值为 None。
 
 关键字参数
 :::::::::

--- a/docs/api/paddle/nn/AdaptiveLogSoftmaxWithLoss_cn.rst
+++ b/docs/api/paddle/nn/AdaptiveLogSoftmaxWithLoss_cn.rst
@@ -20,12 +20,12 @@ AdaptiveLogSoftmaxWithLoss 将标签按照频率划分为多个组，每个组�
 
 参数
 :::::::::
-    - **in_features** (int): 输入 Tensor 的特征数量。
-    - **n_classes** (int): 数据集中类型的个数。
-    - **cutoffs** (Sequence): 用于将 label 分配到不同存储组的截断值。
-    - **div_value** (float, 可选): 用于计算组大小的指数值。默认值：4.0。
-    - **head_bias** (bool, 可选): 如果为 ``True``，AdaptiveLogSoftmaxWithLoss 的 ``head`` 添加偏置项。默认值： ``False``.
-    - **name** (str, 可选): 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
+    - **in_features** (int)：输入 Tensor 的特征数量。
+    - **n_classes** (int)：数据集中类型的个数。
+    - **cutoffs** (Sequence)：用于将 label 分配到不同存储组的截断值。
+    - **div_value** (float，可选)：用于计算组大小的指数值。默认值：4.0。
+    - **head_bias** (bool，可选)：如果为 ``True``，AdaptiveLogSoftmaxWithLoss 的 ``head`` 添加偏置项。默认值：``False``。
+    - **name** (str，可选)：具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 形状
 :::::::::

--- a/docs/api/paddle/nn/AvgPool2D_cn.rst
+++ b/docs/api/paddle/nn/AvgPool2D_cn.rst
@@ -31,10 +31,10 @@ AvgPool2D
 :::::::::
     - **kernel_size** (int|list|tuple)：池化核大小。如果它是一个元组或列表，它必须包含两个整数值，(pool_size_Height, pool_size_Width)。若为一个整数，则它的平方值将作为池化核大小，比如若 pool_size=2，则池化核大小为 2x2。
     - **stride** (int|list|tuple，可选)：池化层的步长。如果它是一个元组或列表，它将包含两个整数，(pool_stride_Height, pool_stride_Width)。若为一个整数，则表示 H 和 W 维度上 stride 均为该值。默认值为 None，这时会使用 kernel_size 作为 stride。
-    - **padding** (str|int|list|tuple，可选) 池化填充。如果它是一个字符串，可以是"VALID"或者"SAME"，表示填充算法。如果它是一个元组或列表，它可以有 3 种格式：(1)包含 2 个整数值：[pad_height, pad_width]；(2)包含 4 个整数值：[pad_height_top, pad_height_bottom, pad_width_left, pad_width_right]；(3)包含 4 个二元组：当 data_format 为"NCHW"时为 [[0,0], [0,0], [pad_height_top, pad_height_bottom], [pad_width_left, pad_width_right]]，当 data_format 为"NHWC"时为[[0,0], [pad_height_top, pad_height_bottom], [pad_width_left, pad_width_right], [0,0]]。若为一个整数，则表示 H 和 W 维度上均为该值。默认值：0。
-    - **ceil_mode** (bool，可选)：是否用 ceil 函数计算输出高度和宽度。如果是 True，则使用 `ceil` 计算输出形状的大小。默认为 False。
-    - **exclusive** (bool，可选)：是否在平均池化模式忽略填充值，默认是 `True`。
-    - **divisor_override** (int|float，可选)：如果指定，它将用作除数，否则根据`kernel_size`计算除数。默认`None`。
+    - **padding** (str|int|list|tuple，可选)：池化填充。如果它是一个字符串，可以是"VALID"或者"SAME"，表示填充算法。如果它是一个元组或列表，它可以有 3 种格式：(1)包含 2 个整数值：[pad_height, pad_width]；(2)包含 4 个整数值：[pad_height_top, pad_height_bottom, pad_width_left, pad_width_right]；(3)包含 4 个二元组：当 data_format 为"NCHW"时为 [[0,0], [0,0], [pad_height_top, pad_height_bottom], [pad_width_left, pad_width_right]]，当 data_format 为"NHWC"时为[[0,0], [pad_height_top, pad_height_bottom], [pad_width_left, pad_width_right], [0,0]]。若为一个整数，则表示 H 和 W 维度上均为该值。默认值：0。
+    - **ceil_mode** (bool，可选)：是否用 ceil 函数计算输出高度和宽度。如果是 True，则使用 ``ceil`` 计算输出形状的大小。默认为 False。
+    - **exclusive** (bool，可选)：是否在平均池化模式忽略填充值，默认是 ``True``。
+    - **divisor_override** (int|float，可选)：如果指定，它将用作除数，否则根据 ``kernel_size`` 计算除数。默认 ``None``。
     - **data_format** (str，可选)：输入和输出的数据格式，可以是"NCHW"和"NHWC"。N 是批尺寸，C 是通道数，H 是特征高度，W 是特征宽度。默认值："NCHW"
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 


### PR DESCRIPTION
Fix documentation standards violations found in 3 API documentation files under `docs/api/paddle`.

## Changes

### `docs/api/paddle/multiply_cn.rst`
- **Incorrect enumeration count**: Fixed `"有 2 种情况"` → `"有 3 种情况"` (the description listed 3 cases but stated only 2)
- **Duplicate parameter entry**: Removed the duplicate `out` parameter from the `参数` section. Since `out` is a keyword-only argument (`*, out=None` in the function signature), it should only appear under `关键字参数`, not in the main `参数` section

### `docs/api/paddle/nn/AdaptiveLogSoftmaxWithLoss_cn.rst`
- **English punctuation in Chinese document**: Fixed all parameter entries to use Chinese comma `,` instead of English `,` inside type annotations (e.g. `(float, 可选)` → `(float,可选)`)
- **English separator**: Fixed separator from English `:` to Chinese `:` (e.g. `(int): 描述` → `(int):描述`)
- **English period**: Fixed the `head_bias` parameter entry that ended with an English period `.` instead of Chinese period `。`

### `docs/api/paddle/nn/AvgPool2D_cn.rst`
- **Missing separator**: Added missing `:` separator in `padding` parameter entry (`(str|int|list|tuple,可选) 池化填充` → `(str|int|list|tuple,可选):池化填充`)
- **Single backtick in RST**: Fixed single backticks (`` `ceil` ``, `` `True` ``, `` `kernel_size` ``, `` `None` ``) to double backticks (` ``ceil`` `, ` ``True`` `, ` ``kernel_size`` `, ` ``None`` `) for proper inline code formatting in RST

## Standards Reference

Per the documentation standards in `.github/copilot-instructions.md`:
- Chinese documents should use Chinese punctuation, not English punctuation
- RST inline code should use double backticks




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22525574478)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22525574478, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22525574478 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/26