### PR TITLE
[Docs] Fix Chinese-English spacing and backtick formatting in API docs

### DIFF
--- a/docs/api/paddle/searchsorted_cn.rst
+++ b/docs/api/paddle/searchsorted_cn.rst
@@ -12,7 +12,7 @@ searchsorted
     - **sorted_sequence** (Tensor) - 输入的 N 维或一维 Tensor，支持的数据类型：bfloat16、float16、float32、float64、int32、int64。该 Tensor 的数值在其最后一个维度递增。
     - **values** (Tensor) - 输入的 N 维 Tensor，支持的数据类型：bfloat16、float16、float32、float64、int32、int64。
     - **out_int32** (bool，可选) - 输出的数据类型支持 int32、int64。默认值为 False，表示默认的输出数据类型为 int64。
-    - **right** (bool，可选) - 根据给定 ``values`` 在 ``sorted_sequence`` 查找对应的上边界或下边界。如果 ``sorted_sequence``的值为 nan 或 inf，则返回最内层维度的大小。默认值为 False，表示在 ``sorted_sequence`` 的查找给定 ``values`` 的下边界。
+    - **right** (bool，可选) - 根据给定 ``values`` 在 ``sorted_sequence`` 查找对应的上边界或下边界。如果 ``sorted_sequence`` 的值为 nan 或 inf，则返回最内层维度的大小。默认值为 False，表示在 ``sorted_sequence`` 的查找给定 ``values`` 的下边界。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。
 
 返回

--- a/docs/api/paddle/square_cn.rst
+++ b/docs/api/paddle/square_cn.rst
@@ -5,7 +5,7 @@ square
 
 .. py:function:: paddle.square(x, name=None, *, out=None)
 
-对输入参数 x 进行逐元素取平方运算。
+对输入参数 ``x`` 进行逐元素取平方运算。
 
 .. math::
     out = x^2

--- a/docs/api/paddle/tril__cn.rst
+++ b/docs/api/paddle/tril__cn.rst
@@ -4,7 +4,8 @@ tril\_
 -------------------------------
 
 .. py:function:: paddle.tril_(x, diagonal=0, name=None)
-Inplace 版本的 :ref:`cn_api_paddle_tril` API，对输入 x 采用 Inplace 策略。
+
+Inplace 版本的 :ref:`cn_api_paddle_tril` API，对输入 ``x`` 采用 Inplace 策略。
 
 更多关于 inplace 操作的介绍请参考 `3.1.3 原位（Inplace）操作和非原位操作的区别`_ 了解详情。
 


### PR DESCRIPTION
## Changes

Fixed documentation standard violations in 3 API doc files:

### `docs/api/paddle/searchsorted_cn.rst`
- Added missing space between `` ``sorted_sequence`` `` and `的值` on line 15.
  - Before: `` ``sorted_sequence``的值为 nan 或 inf ``
  - After: `` ``sorted_sequence`` 的值为 nan 或 inf ``

### `docs/api/paddle/square_cn.rst`
- Wrapped bare variable name `x` in double backticks for proper RST inline code formatting.
  - Before: `对输入参数 x 进行逐元素取平方运算。`
  - After: `对输入参数 ``x`` 进行逐元素取平方运算。`

### `docs/api/paddle/tril__cn.rst`
- Wrapped bare variable name `x` in single backticks for proper RST inline code formatting.
- Added missing blank line between the `.. py:function::` directive and the description body (required by RST syntax).
  - Before: `对输入 x 采用 Inplace 策略。`
  - After: `对输入 ``x`` 采用 Inplace 策略。`

## Standards Applied

These fixes address the following documentation standards from `.github/copilot-instructions.md`:
- **中英文之间需要使用空格分隔**: Space required between Chinese text and English/code content.
- **在 Markdown/RST 中应当适当为变量名、代码片段等添加反引号标记**: Variable names like `x` should be enclosed in backticks.




> Generated by [API Docs Checker](https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22531148390)

<!-- gh-aw-agentic-workflow: API Docs Checker, engine: copilot, id: 22531148390, workflow_id: api-docs-checker, run: https://github.com/StatefulDust/paddle-docs-agent/actions/runs/22531148390 -->

<!-- gh-aw-workflow-id: api-docs-checker -->

---
> 🔄 Synced from https://github.com/StatefulDust/paddle-docs-agent/pull/27