### PR TITLE
[API Compatibility No.190] add alias doc for paddle.nn.functional.pixel_unshuffle -part

### DIFF
--- a/docs/api/paddle/nn/functional/pixel_unshuffle_cn.rst
+++ b/docs/api/paddle/nn/functional/pixel_unshuffle_cn.rst
@@ -11,7 +11,7 @@ pixel_unshuffle
 
 参数
 :::::::::
-    - **x** (Tensor) – 当前算子的输入，其是一个形状为 :math:`[N, C, H, W]` 或 :math:`[N, H, W, C]` 的 4-D Tensor。其中 :math:`N` 是批大小，:math:`C` 是通道数，:math:`H` 是输入特征的高度，:math:`W` 是输入特征的宽度。其数据类型为 float32 或 float64。
+    - **x** (Tensor) – 当前算子的输入，其是一个形状为 :math:`[N, C, H, W]` 或 :math:`[N, H, W, C]` 的 4-D Tensor。其中 :math:`N` 是批大小，:math:`C` 是通道数，:math:`H` 是输入特征的高度，:math:`W` 是输入特征的宽度。其数据类型为 float32 或 float64。别名 ``input``。
     - **downscale_factor** (int) – 减小空间分辨率的减小因子。
     - **data_format** (str，可选) – 数据格式，可选 NCHW 或 NHWC，默认为 NCHW，即（批大小，通道数，高度，宽度）的格式。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。


### PR DESCRIPTION
## Summary
- Add alias notation `别名 input` to the `x` parameter description in Chinese documentation for `paddle.nn.functional.pixel_unshuffle`

## Related PR
- Paddle PR: https://github.com/PaddlePaddle/Paddle/pull/77920

PR Category: User Experience
PR Types: New features