### PR TITLE
[Doc Link Fix No.49] Fix docs link in page `docs/dev_guides/git_guides/local_dev_guide_en.md`

### DIFF
--- a/docs/dev_guides/git_guides/local_dev_guide_en.md
+++ b/docs/dev_guides/git_guides/local_dev_guide_en.md
@@ -6,19 +6,19 @@ You will learn how to develop programs in local environment under the guidelines
 - Please refer to the coding comment format of [Doxygen](http://www.doxygen.nl/)
 - Unit test is needed for all codes.
 - Pass through all unit tests.
-- Please follow [regulations of submitting codes](./code_review_cn.html).
+- Please follow [regulations of submitting codes](./code_review_en.html).
 
 The following guidiance tells you how to submit code.
 ## [Fork](https://help.github.com/articles/fork-a-repo/)
 
-Transfer to the home page of GitHub [PaddlePaddle](https://github.com/PaddlePaddle/Paddle) ,and then click button `Fork`  to generate the git under your own file directory,such as <https://github.com/USERNAME/Paddle>。
+Transfer to the home page of GitHub [PaddlePaddle](https://github.com/PaddlePaddle/Paddle) ,and then click button `Fork`  to generate the git under your own file directory,such as `https://github.com/your-github-username/Paddle`.
 
 ## Clone
 
 Clone remote git to local:
 
 ```bash
-➜  git clone https://github.com/USERNAME/Paddle
+➜  git clone https://github.com/your-github-username/Paddle
 ➜  cd Paddle
 ```
 
@@ -77,7 +77,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 
 ## Build
 
-Please refer to [Compile From Source Code](../../../install/compile/fromsource_en.html) about more information of building PaddlePaddle source codes.
+Please refer to [Compile From Source Code](../../install/compile/fromsource_en.html) about more information of building PaddlePaddle source codes.
 
 ## Test
 
@@ -138,8 +138,8 @@ Check the name of current remote repository with `git remote`.
 ➜  git remote
 origin
 ➜  git remote -v
-origin    https://github.com/USERNAME/Paddle (fetch)
-origin    https://github.com/USERNAME/Paddle (push)
+origin    https://github.com/your-github-username/Paddle (fetch)
+origin    https://github.com/your-github-username/Paddle (push)
 ```
 
 origin is the name of remote repository that we clone,which is also the Paddle under your own account. Next we create a remote host of an original Paddle and name it upstream.
@@ -160,7 +160,7 @@ Get the latest code of upstream and update current branch.
 
 ## Push to remote repository
 
-Push local modification to GitHub(https://github.com/USERNAME/Paddle).
+Push local modification to GitHub (`https://github.com/your-github-username/Paddle`).
 
 ```bash
 # submit it to remote git the branch my-cool-stuff of origin

--- a/docs/dev_guides/git_guides/local_dev_guide_en.md
+++ b/docs/dev_guides/git_guides/local_dev_guide_en.md
@@ -11,14 +11,14 @@ You will learn how to develop programs in local environment under the guidelines
 The following guidiance tells you how to submit code.
 ## [Fork](https://help.github.com/articles/fork-a-repo/)
 
-Transfer to the home page of GitHub [PaddlePaddle](https://github.com/PaddlePaddle/Paddle) ,and then click button `Fork`  to generate the git under your own file directory,such as `https://github.com/your-github-username/Paddle`.
+Transfer to the home page of GitHub [PaddlePaddle](https://github.com/PaddlePaddle/Paddle) ,and then click button `Fork`  to generate the git under your own file directory,such as `https://github.com/USERNAME/Paddle`.
 
 ## Clone
 
 Clone remote git to local:
 
 ```bash
-➜  git clone https://github.com/your-github-username/Paddle
+➜  git clone https://github.com/USERNAME/Paddle
 ➜  cd Paddle
 ```
 
@@ -138,8 +138,8 @@ Check the name of current remote repository with `git remote`.
 ➜  git remote
 origin
 ➜  git remote -v
-origin    https://github.com/your-github-username/Paddle (fetch)
-origin    https://github.com/your-github-username/Paddle (push)
+origin    https://github.com/USERNAME/Paddle (fetch)
+origin    https://github.com/USERNAME/Paddle (push)
 ```
 
 origin is the name of remote repository that we clone,which is also the Paddle under your own account. Next we create a remote host of an original Paddle and name it upstream.
@@ -160,7 +160,7 @@ Get the latest code of upstream and update current branch.
 
 ## Push to remote repository
 
-Push local modification to GitHub (`https://github.com/your-github-username/Paddle`).
+Push local modification to GitHub (`https://github.com/USERNAME/Paddle`).
 
 ```bash
 # submit it to remote git the branch my-cool-stuff of origin


### PR DESCRIPTION
## 修复内容

### 任务 49: docs/dev_guides/git_guides/local_dev_guide_en.md
- 原链接: file:///home/runner/work/docs/docs/docs/dev_guides/git_guides/code_review_cn.html
- 新链接: ./code_review_en.html
- 原链接: file:///home/runner/work/docs/docs/install/compile/fromsource_en.html
- 新链接: ../../install/compile/fromsource_en.html
- 原链接: https://github.com/USERNAME/Paddle
- 新链接: https://github.com/your-github-username/Paddle

## 备注

（无）

## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
