### PR TITLE
[Doc Link Fix No.51] Fix broken links in `docs/dev_guides/git_guides/submit_pr_guide_en.md`

### DIFF
--- a/docs/dev_guides/git_guides/submit_pr_guide_en.md
+++ b/docs/dev_guides/git_guides/submit_pr_guide_en.md
@@ -47,7 +47,7 @@ For the first time to submit Pull Request,you need to sign CLA(Contributor Licen
 
 ### Pass unit tests
 
-Every new commit in your Pull Request will trigger CI unit tests,so please make sure that necessary comments have been included in your commit message.Please refer to [commit](./local_dev_guide_cn.html#commit)
+Every new commit in your Pull Request will trigger CI unit tests,so please make sure that necessary comments have been included in your commit message.Please refer to [commit](./local_dev_guide_en.html#commit)
 
 Please note the procedure of CI unit tests in your Pull Request which will be finished in several hours.
 
@@ -60,7 +60,7 @@ Red cross after the tests means your commit hasn't passed certain unit test.Plea
 
 We can delete branches of remote repository in PR page after your PR is successfully merged into master repository.
 
-![delete_branch](../images/delete_branch.png)
+![delete_branch](../../dev_guides/images/delete_branch.png)
 
 We can also delete the branch of remote repository with `git push origin :the_branch_name`,such as:
 


### PR DESCRIPTION
## 修复内容

### 任务 51: docs/dev_guides/git_guides/submit_pr_guide_en.md
- 原链接: file:///home/runner/work/docs/docs/docs/dev_guides/git_guides/local_dev_guide_cn.html#commit
- 新链接: ./local_dev_guide_en.html#commit
- 原链接: file:///home/runner/work/docs/docs/docs/dev_guides/guides/10_contribution/img/delete_branch.png
- 新链接: ../../dev_guides/images/delete_branch.png

## 备注

（不必要，此处记录其他特殊情况）

## 验证结果

已确认文档内链接指向有效路径

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
