### PR TITLE
[Doc Link Fix No.18] Fix broken links in `docs/design/memory/memory_optimization.md`

### DIFF
--- a/docs/design/memory/memory_optimization.md
+++ b/docs/design/memory/memory_optimization.md
@@ -101,7 +101,7 @@ In-place is a built-in attribute of an operator. Since we treat in-place and oth
 
 #### construct control flow graph
 
-Following is the ProgramDesc protobuf of [machine translation](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/tests/book/test_machine_translation.py) example.
+Following is the ProgramDesc protobuf of [machine translation](https://github.com/PaddlePaddle/Paddle/blob/release/1.8/python/paddle/fluid/tests/book/test_machine_translation.py) example.
 
 - Block0:
 
@@ -212,6 +212,6 @@ else:
 
 ## Reference
 
-- [Lecture Notes From Artificial Intelligence Is The New Electricity By Andrew Ng](https://manavsehgal.com/lecture-notes-from-artificial-intelligence-is-the-new-electricity-by-andrew-ng-4712dcbf26e5)
+- [Lecture Notes From Artificial Intelligence Is The New Electricity By Andrew Ng](https://manavsehgal.com/lecture-notes-from-artificial-intelligence-is-the-new-electricity-by-andrew-ng)
 - Modern compiler implementation in ML, by Andrew W. Appel
-- [Optimizing Memory Consumption in Deep learning](https://mxnet.incubator.apache.org/architecture/note_memory.html)
+- [Optimizing Memory Consumption in Deep learning](https://web.archive.org/web/20180905150035/http://mxnet.incubator.apache.org/architecture/note_memory.html)

--- a/docs/design/memory/memory_optimization.md
+++ b/docs/design/memory/memory_optimization.md
@@ -212,6 +212,6 @@ else:
 
 ## Reference
 
-- [Lecture Notes From Artificial Intelligence Is The New Electricity By Andrew Ng](https://manavsehgal.com/lecture-notes-from-artificial-intelligence-is-the-new-electricity-by-andrew-ng)
+- [Lecture Notes From Artificial Intelligence Is The New Electricity By Andrew Ng](https://manavsehgal.com/lecture-notes-from-artificial-intelligence-is-the-new-electricity-by-andrew-ng-4712dcbf26e5)
 - Modern compiler implementation in ML, by Andrew W. Appel
 - [Optimizing Memory Consumption in Deep learning](https://web.archive.org/web/20180905150035/http://mxnet.incubator.apache.org/architecture/note_memory.html)


### PR DESCRIPTION
## 修复内容

### 任务 18: docs/design/memory/memory_optimization.md
- 原链接: https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/tests/book/test_machine_translation.py
- 新链接: https://github.com/PaddlePaddle/Paddle/blob/release/1.8/python/paddle/fluid/tests/book/test_machine_translation.py

- 原链接: https://manavsehgal.com/lecture-notes-from-artificial-intelligence-is-the-new-electricity-by-andrew-ng-4712dcbf26e5
- 新链接: https://manavsehgal.com/lecture-notes-from-artificial-intelligence-is-the-new-electricity-by-andrew-ng

- 原链接: https://mxnet.incubator.apache.org/architecture/note_memory.html
- 新链接: https://web.archive.org/web/20180905150035/http://mxnet.incubator.apache.org/architecture/note_memory.html

## 备注

（无）

## 验证结果

已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
