### PR TITLE
[API Compatibility No.186] Add target alias note for paddle.nn.functional.mse_loss docs -part

### DIFF
--- a/docs/api/paddle/nn/functional/mse_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/mse_loss_cn.rst
@@ -28,7 +28,7 @@ mse_loss
 参数
 :::::::::
     - **input** (Tensor) - 预测值，维度为 :math:`[N_1, N_2, ..., N_k]` 的多维 Tensor。数据类型为 float32 或 float64。
-    - **label** (Tensor) - 目标值，维度为 :math:`[N_1, N_2, ..., N_k]` 的多维 Tensor。数据类型为 float32 或 float64。
+    - **label** (Tensor) - 目标值，维度为 :math:`[N_1, N_2, ..., N_k]` 的多维 Tensor。数据类型为 float32 或 float64。别名 ``target``。
     - **reduction** (str, 可选) - 输出的归约方法可以是'none'、'mean'或'sum'。
 
         - 如果 :attr:`reduction` 是 ``'mean'``，则返回减少的平均损失。


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
- Update Chinese API docs for `paddle.nn.functional.mse_loss`.
- Add alias note for parameter `label`: alias `target`.

Related PRs:
- Paddle: https://github.com/PaddlePaddle/Paddle/pull/78128
- PaConvert: https://github.com/PaddlePaddle/PaConvert/pull/845