### PR TITLE
[API Compatibility No.188] Update nll_loss docs for target alias support -part

### DIFF
--- a/docs/api/paddle/nn/functional/nll_loss_cn.rst
+++ b/docs/api/paddle/nn/functional/nll_loss_cn.rst
@@ -9,7 +9,7 @@ nll_loss
 参数
 :::::::::
     - **input** (Tensor) - 输入 `Tensor`，其形状为 :math:`[N, C]`，其中 `C` 为类别数。但是对于多维度的情形下，它的形状为 :math:`[N, C, d_1, d_2, ..., d_K]`。数据类型为 float32 或 float64。
-    - **label** (Tensor) - 输入 x 对应的标签值。其形状为 :math:`[N,]` 或者 :math:`[N, d_1, d_2, ..., d_K]`，数据类型为 int64。
+    - **label** (Tensor) - 输入 x 对应的标签值。其形状为 :math:`[N,]` 或者 :math:`[N, d_1, d_2, ..., d_K]`，数据类型为 int64。别名：``target``。
     - **weight** (Tensor，可选) - 手动指定每个类别的权重。其默认为 `None`。如果提供该参数的话，长度必须为 `num_classes`。数据类型为 float32 或 float64。
     - **ignore_index** (int，可选) - 指定一个忽略的标签值，此标签值不参与计算。默认值为-100。数据类型为 int64。
     - **reduction** (str，可选) - 指定应用于输出结果的计算方式，可选值有：`none`, `mean`, `sum`。默认为 `mean`，计算 `mini-batch` loss 均值。设置为 `sum` 时，计算 `mini-batch` loss 的总和。设置为 `none` 时，则返回 loss Tensor。数据类型为 string。

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/torch_more_args/torch.nn.functional.nll_loss.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/torch_more_args/torch.nn.functional.nll_loss.md
@@ -26,7 +26,7 @@ paddle.nn.functional.nll_loss(input,
 | PyTorch       | PaddlePaddle | 备注                                                   |
 | ------------- | ------------ | ------------------------------------------------------ |
 | input          | input         | 输入 Tensor。                                     |
-| target          | label         | 输入 Tensor 对应的标签值,仅参数名不一致。        |
+| target          | label         | 输入 Tensor 对应的标签值，仅参数名不一致，Paddle 同时支持 `target`。       |
 | weight          | weight  | 手动指定每个类别的权重。                          |
 | size_average          | -         | 已弃用，需要转写。                                      |
 | ignore_index          | ignore_index  |  指定一个忽略的标签值，此标签值不参与计算。                   |


### PR DESCRIPTION
## Summary
- Update `nll_loss_cn.rst`: add alias annotation `别名：``target``` for `label`.
- Update `torch.nn.functional.nll_loss.md`: in parameter mapping, clarify Paddle also supports `target`.

## Related PRs
- Paddle: https://github.com/PaddlePaddle/Paddle/pull/78133
- PaConvert: https://github.com/PaddlePaddle/PaConvert/pull/844

## PR Category
User Experience

## PR Types
New features