### PR TITLE
[Doc Link Fix No.20] Fix broken links in `docs/design/mkldnn/int8/QAT/README.md`

### DIFF
--- a/docs/design/mkldnn/int8/QAT/README.md
+++ b/docs/design/mkldnn/int8/QAT/README.md
@@ -1,6 +1,6 @@
 # SLIM Quantization-aware training (QAT) for INT8 OneDNN
 
-This document is based on [QAT INT8 MKL-DNN in Paddle](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/demo/mkldnn_quant), that describes how to use [Paddle Slim](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/docs) to convert a quantization-aware trained model (Quant model) into INT8 MKL-DNN quantized model and run it.
+This document is based on [QAT INT8 MKL-DNN in Paddle](https://github.com/PaddlePaddle/Paddle/tree/release/1.8/python/paddle/fluid/contrib/slim/tests), that describes how to use [Paddle Slim](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/docs) to convert a quantization-aware trained model (Quant model) into INT8 MKL-DNN quantized model and run it.
 
 In **Release 1.5**, we have released the first approach to the MKL-DNN-based quantization of Quant models, called Quant1. It enabled the `conv2d` and `mul` INT8 MKL-DNN kernels for Quant trained models (GoogleNet, MobileNetV1, MobileNetV2, ResNet50, ResNet101, VGG16, and VGG19) with 0.05% accuracy diff.
 

--- a/docs/design/mkldnn/int8/QAT/README.md
+++ b/docs/design/mkldnn/int8/QAT/README.md
@@ -1,6 +1,6 @@
 # SLIM Quantization-aware training (QAT) for INT8 OneDNN
 
-This document is based on [QAT INT8 MKL-DNN in Paddle](https://github.com/PaddlePaddle/Paddle/tree/develop/python/paddle/fluid/contrib/slim/tests), that describes how to use [Paddle Slim](https://paddlepaddle.github.io/PaddleSlim/index.html) to convert a quantization-aware trained model (Quant model) into INT8 MKL-DNN quantized model and run it.
+This document is based on [QAT INT8 MKL-DNN in Paddle](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/demo/mkldnn_quant), that describes how to use [Paddle Slim](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/docs) to convert a quantization-aware trained model (Quant model) into INT8 MKL-DNN quantized model and run it.
 
 In **Release 1.5**, we have released the first approach to the MKL-DNN-based quantization of Quant models, called Quant1. It enabled the `conv2d` and `mul` INT8 MKL-DNN kernels for Quant trained models (GoogleNet, MobileNetV1, MobileNetV2, ResNet50, ResNet101, VGG16, and VGG19) with 0.05% accuracy diff.
 


### PR DESCRIPTION
## 修复内容

### 任务 20: docs/design/mkldnn/int8/QAT/README.md
- 原链接: https://github.com/PaddlePaddle/Paddle/tree/develop/python/paddle/fluid/contrib/slim/tests
  新链接: https://github.com/PaddlePaddle/PaddleSlim/tree/develop/demo/mkldnn_quant
- 原链接: https://paddlepaddle.github.io/PaddleSlim/index.html
  新链接: https://github.com/PaddlePaddle/PaddleSlim/tree/develop/docs

## 备注
无

## 验证结果
已手动访问所有更新后的链接,确认所有链接可正常访问

- https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
