### PR TITLE
[API Compatibility No.13、75] Add param alias for hypot and hypot_

### DIFF
--- a/docs/api/paddle/hypot__cn.rst
+++ b/docs/api/paddle/hypot__cn.rst
@@ -3,7 +3,7 @@
 hypot\_
 -------------------------------
 
-.. py:function:: paddle.hypot_(x, y, name=None, *, out=None)
+.. py:function:: paddle.hypot_(x, y, name=None)
 
 Inplace 版本的 :ref:`cn_api_paddle_hypot` API，对输入 x 采用 Inplace 策略。
 

--- a/docs/api/paddle/hypot__cn.rst
+++ b/docs/api/paddle/hypot__cn.rst
@@ -3,7 +3,7 @@
 hypot\_
 -------------------------------
 
-.. py:function:: paddle.hypot_(x, y, name=None)
+.. py:function:: paddle.hypot_(x, y, name=None, *, out=None)
 
 Inplace 版本的 :ref:`cn_api_paddle_hypot` API，对输入 x 采用 Inplace 策略。
 

--- a/docs/api/paddle/hypot_cn.rst
+++ b/docs/api/paddle/hypot_cn.rst
@@ -3,7 +3,7 @@
 hypot
 -------------------------------
 
-.. py:function:: paddle.hypot(x, y, name=None)
+.. py:function:: paddle.hypot(x, y, name=None, *, out=None)
 
 
 `hypot` 函数对于给定直角三角形直角边 `x`, `y` 实现斜边长度求解的计算;
@@ -13,9 +13,13 @@ hypot
 
 参数
 ::::::::::
-    - **x** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64， int32， int64。
-    - **y** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64，int32， int64。
+    - **x** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64， int32， int64。别名 ``input``。
+    - **y** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64，int32， int64。别名 ``other``。
     - **name** (str，可选) - 具体用法请参见  :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
+
+关键字参数
+:::::::::
+    - **out** (Tensor，可选) - 输出 Tensor，若不为 ``None``，计算结果将保存在该 Tensor 中，默认值为 ``None``。
 返回
 ::::::::::
     - ``out`` (Tensor)：一个 n-d Tensor。如果 x、y 具有不同的形状并且是可广播的，则得到的张量形状是广播后 x 和 y 的形状。如果 x、y 具有相同的形状，则其形状与 x 和 y 相同。

--- a/docs/api/paddle/hypot_cn.rst
+++ b/docs/api/paddle/hypot_cn.rst
@@ -13,8 +13,8 @@ hypot
 
 参数
 ::::::::::
-    - **x** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64， int32， int64。别名 ``input``。
-    - **y** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64，int32， int64。别名 ``other``。
+    - **x** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64，int32，int64。别名 ``input``。
+    - **y** (Tensor) – 输入 Tensor，它的数据类型可以是 float32，float64，int32，int64。别名 ``other``。
     - **name** (str，可选) - 具体用法请参见  :ref:`api_guide_Name` ，一般无需设置，默认值为 None。
 
 关键字参数


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
* 为 `paddle.hypot`、`paddle.hypot_` 添加参数别名
* `paddle.hypot` 新增 `out` 参数
* 为新增参数增加单测

Related Issue: https://github.com/PaddlePaddle/Paddle/issues/76301

Related PRs: 
* https://github.com/PaddlePaddle/Paddle/pull/78046
* https://github.com/PaddlePaddle/PaConvert/pull/833

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

