### PR TITLE
[Doc Link Fix No.67] Fix mobile_index_cn.md forum link

### DIFF
--- a/docs/guides/infer/mobile/mobile_index_cn.md
+++ b/docs/guides/infer/mobile/mobile_index_cn.md
@@ -55,4 +55,4 @@ Paddle-Lite 借鉴了以下开源项目：
 <p align="center"><img width="200" height="200"  src="https://user-images.githubusercontent.com/45189361/64117959-1969de80-cdc9-11e9-84f7-e1c2849a004c.jpeg"/>&#8194;&#8194;&#8194;&#8194;&#8194;<img width="200" height="200" margin="500" src="https://user-images.githubusercontent.com/45189361/64117844-cb54db00-cdc8-11e9-8c08-24bbe594608e.jpeg"/></p>
 <p align="center">  &#8194;&#8194;&#8194;微信公众号&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;&#8194;官方技术交流 QQ 群</p>
 
-* 论坛: 欢迎大家在[PaddlePaddle 论坛](https://ai.baidu.com/forum/topic/list/168)分享在使用 PaddlePaddle 中遇到的问题和经验, 营造良好的论坛氛围
+* 论坛: 欢迎大家在[PaddlePaddle GitHub Discussions](https://github.com/PaddlePaddle/Paddle/discussions)分享在使用 PaddlePaddle 中遇到的问题和经验, 营造良好的论坛氛围


### PR DESCRIPTION
## 修复内容
### 任务 67: docs/guides/infer/mobile/mobile_index_cn.md
- 原链接：https://ai.baidu.com/forum/topic/list/168
- 状态：503 Service Temporarily Unavailable
- 新链接：https://github.com/PaddlePaddle/Paddle/discussions

## 备注
- 失效原因：百度 AI 论坛服务已不可用
- 新链接来源：Paddle 官方 GitHub Discussions 社区
- 经检查，文件中其他链接均有效

## 验证结果
- [x] 确认失效链接状态（503）
- [x] 替换为有效的新链接
- [x] 验证新链接可正常访问
- [x] 验证其他链接正常

Related to #7735
@HZ1ovo @Echo-Nie