### PR TITLE
[API Compatibility No.154] add target alias docs for binary_cross_entropy -part

### DIFF
--- a/docs/api/paddle/nn/functional/binary_cross_entropy_cn.rst
+++ b/docs/api/paddle/nn/functional/binary_cross_entropy_cn.rst
@@ -36,7 +36,7 @@ binary_cross_entropy
 参数
 :::::::::
     - **input** (Tensor) - :math:`[N, *]`，其中 N 是 batch_size， ``*`` 是任意其他维度。输入数据 ``input`` 一般是 ``sigmoid`` 的输出。数据类型是 float16、float32、float64。
-    - **label** (Tensor) - :math:`[N, *]`，标签 ``label`` 的维度、数据类型与输入 ``input`` 相同。
+    - **label** (Tensor) - :math:`[N, *]`，标签 ``label`` 的维度、数据类型与输入 ``input`` 相同。别名：``target``。
     - **weight** (Tensor，可选) - 手动指定每个 batch 二值交叉熵的权重，如果指定的话，维度必须是一个 batch 的数据的维度。数据类型是 float16、float32, float64。默认值是：None。
     - **reduction** (str，可选) - 指定应用于输出结果的计算方式，可选值有：``'none'``, ``'mean'``, ``'sum'``。默认为 ``'mean'``，计算 ``BCELoss`` 的均值；设置为 ``'sum'`` 时，计算 ``BCELoss`` 的总和；设置为 ``'none'`` 时，则返回 bce_loss。
     - **name** (str，可选) - 具体用法请参见 :ref:`api_guide_Name`，一般无需设置，默认值为 None。


### PR DESCRIPTION
﻿### PR Category

User Experience

### PR Types

New features

### Description

Update the Chinese API docs for `paddle.nn.functional.binary_cross_entropy` to document the new `target` alias on `label`.

Changes in this PR:
- `docs/api/paddle/nn/functional/binary_cross_entropy_cn.rst`
  - Add `target` as the alias description for `label`

Related Issue: https://github.com/PaddlePaddle/Paddle/issues/76301 (No.154)

Related PRs:
- https://github.com/PaddlePaddle/Paddle/pull/78132
- https://github.com/PaddlePaddle/PaConvert/pull/863

### 是否引起精度变化

否
