### PR TITLE
[Doc Link Fix No.64] Fix stale Paddle Inference links in docs

### DIFF
--- a/docs/faq/install_cn.md
+++ b/docs/faq/install_cn.md
@@ -27,7 +27,7 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/lib/
 > Windows: set PATH by `set PATH=XXX;
 + 问题分析：
 
-遇到该问题是因为使用的 paddle 默认开始了 TensorRT，但是本地环境中没有找到 TensorRT 的库，该问题只影响使用[Paddle Inference](https://paddleinference.paddlepaddle.org.cn/master/product_introduction/inference_intro.html)开启 TensorRT 预测的场景，对其它方面均不造成影响。
+遇到该问题是因为使用的 paddle 默认开始了 TensorRT，但是本地环境中没有找到 TensorRT 的库，该问题只影响使用[Paddle Inference](https://www.paddlepaddle.org.cn/inference/master/guides/introduction/index_intro.html)开启 TensorRT 预测的场景，对其它方面均不造成影响。
 
 + 解决办法：
 

--- a/docs/guides/custom_op/new_cpp_op_cn.md
+++ b/docs/guides/custom_op/new_cpp_op_cn.md
@@ -2267,8 +2267,8 @@ cd build
 
 ### 参考链接汇总
 
-- [Paddle Inference 快速开始](https://paddleinference.paddlepaddle.org.cn/quick_start/workflow.html)
-- [Paddle Inference API 文档](https://paddleinference.paddlepaddle.org.cn/api_reference/cxx_api_index.html)
+- [Paddle Inference 快速开始](https://www.paddlepaddle.org.cn/inference/master/guides/quick_start/quick_start.html)
+- [Paddle Inference API 文档](https://www.paddlepaddle.org.cn/inference/master/api_reference/cxx_api_doc/cxx_api_index.html)
 - [更多示例代码-自定义算子单元测试](https://github.com/PaddlePaddle/Paddle/tree/develop/test/custom_op)
 
 API 文档：

--- a/docs/guides/custom_op/new_cpp_op_cn.md
+++ b/docs/guides/custom_op/new_cpp_op_cn.md
@@ -2267,7 +2267,7 @@ cd build
 
 ### 参考链接汇总
 
-- [Paddle Inference 快速开始](https://www.paddlepaddle.org.cn/inference/master/guides/quick_start/quick_start.html)
+- [Paddle Inference 快速开始](https://www.paddlepaddle.org.cn/inference/master/guides/introduction/workflow.html)
 - [Paddle Inference API 文档](https://www.paddlepaddle.org.cn/inference/master/api_reference/cxx_api_doc/cxx_api_index.html)
 - [更多示例代码-自定义算子单元测试](https://github.com/PaddlePaddle/Paddle/tree/develop/test/custom_op)
 

--- a/docs/hardware_support/hardware_info_cn.md
+++ b/docs/hardware_support/hardware_info_cn.md
@@ -36,9 +36,9 @@
 
 |  分类  | 架构 | 公司 | 型号 | 预编译库 | 源码编译 |  完全支持推理 | 支持部分模型 |
 |  ----  | ----  | ---- | ---- |---- | ---- |---- | ---- |
-| 服务端 CPU | x86 | Intel | 常见 CPU 型号如 Xeon、Core 全系列以及 NUC | [预编译库](https://paddleinference.paddlepaddle.org.cn/user_guides/download_lib.html) | [源码编译](https://paddleinference.paddlepaddle.org.cn/user_guides/source_compile.html) | ✔️ |   |
-| 服务端 GPU |  | NVIDIA | Ada Lovelace、Hopper、 Ampere、Turing、 Volta 架构  | [预编译库](https://paddleinference.paddlepaddle.org.cn/user_guides/download_lib.html) | [源码编译](https://paddleinference.paddlepaddle.org.cn/user_guides/source_compile.html) | ✔️ |   |
-| 移动端 GPU |  | NVIDIA | Jetson 系列 | [预编译库](https://paddleinference.paddlepaddle.org.cn/user_guides/download_lib.html) | [源码编译](https://paddleinference.paddlepaddle.org.cn/user_guides/source_compile.html) | ✔️ |   |
+| 服务端 CPU | x86 | Intel | 常见 CPU 型号如 Xeon、Core 全系列以及 NUC | [预编译库](https://www.paddlepaddle.org.cn/inference/master/guides/install/download_lib.html) | [源码编译](https://www.paddlepaddle.org.cn/inference/master/guides/install/compile/source_compile.html) | ✔️ |   |
+| 服务端 GPU |  | NVIDIA | Ada Lovelace、Hopper、 Ampere、Turing、 Volta 架构  | [预编译库](https://www.paddlepaddle.org.cn/inference/master/guides/install/download_lib.html) | [源码编译](https://www.paddlepaddle.org.cn/inference/master/guides/install/compile/source_compile.html) | ✔️ |   |
+| 移动端 GPU |  | NVIDIA | Jetson 系列 | [预编译库](https://www.paddlepaddle.org.cn/inference/master/guides/install/download_lib.html) | [源码编译](https://www.paddlepaddle.org.cn/inference/master/guides/install/compile/source_compile.html) | ✔️ |   |
 | AI 加速芯片 | 达芬奇 | 华为 | 昇腾 910 系列 | | [源码编译](./npu/install_cn.html) |  | ✔️ |
 | AI 加速芯片 | MLU | 寒武纪 | MLU370 系列 | | [源码编译](./mlu/install_cn.html) |  | ✔️ |
 | AI 加速芯片 | MUSA | 摩尔线程 | MTT S 系列 GPU |  |  |  |  |


### PR DESCRIPTION
## 修复内容

本轮先完成任务 64 中 `docs/guides/custom_op/new_cpp_op_cn.md` 的 2 个失效链接修复；根据 review 反馈，又在当前 repo 全局搜索 `paddleinference.paddlepaddle.org.cn`，并把同域名的剩余失效链接一并修复。

### `docs/guides/custom_op/new_cpp_op_cn.md`
- 原链接: https://paddleinference.paddlepaddle.org.cn/quick_start/workflow.html
- 新链接: https://www.paddlepaddle.org.cn/inference/master/guides/introduction/workflow.html
- 原链接: https://paddleinference.paddlepaddle.org.cn/api_reference/cxx_api_index.html
- 新链接: https://www.paddlepaddle.org.cn/inference/master/api_reference/cxx_api_doc/cxx_api_index.html

### `docs/faq/install_cn.md`
- 原链接: https://paddleinference.paddlepaddle.org.cn/master/product_introduction/inference_intro.html
- 新链接: https://www.paddlepaddle.org.cn/inference/master/guides/introduction/index_intro.html

### `docs/hardware_support/hardware_info_cn.md`
- 原链接: https://paddleinference.paddlepaddle.org.cn/user_guides/download_lib.html
- 新链接: https://www.paddlepaddle.org.cn/inference/master/guides/install/download_lib.html
- 原链接: https://paddleinference.paddlepaddle.org.cn/user_guides/source_compile.html
- 新链接: https://www.paddlepaddle.org.cn/inference/master/guides/install/compile/source_compile.html

## 备注

- 额外检索了 `PaddlePaddle/Paddle`，未发现任务 64 对应的两个旧链接，因此该任务只需 docs repo PR。
- 当前 repo 中已无 `paddleinference.paddlepaddle.org.cn` 旧域名残留。

## 验证结果

- `git grep -n 'paddleinference\.paddlepaddle\.org\.cn'` 无输出
- 已手动访问本次更新后的新链接，均返回 HTTP 200
- Issue: https://github.com/PaddlePaddle/docs/issues/7735

@HZ1ovo @Echo-Nie
