### PR TITLE
[CodeStyle][Typos] Bump `typos` to `v1.45.0` and sync codestyle docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: remove-tabs
         types: [text]
   - repo: https://github.com/PFCCLab/typos-pre-commit-mirror.git
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: typos
         args: [--force-exclude]

--- a/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
+++ b/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
@@ -88,7 +88,7 @@ Date:   xxx
 | [pre-commit/pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) | pre-commit 官方支持的 hook，执行一些通用检查 | 4.4.0 |
 | [Lucas-C/pre-commit-hooks](https://github.com/Lucas-C/pre-commit-hooks.git) | 社区维护的一些通用的 hook，含将 CRLF 改为 LF、移除 Tab 等 hook | 1.5.1 |
 | [copyright_checker](https://github.com/PaddlePaddle/Paddle/blob/develop/tools/codestyle/copyright.py) | Copyright 检查 | 本地脚本 |
-| [typos](https://github.com/crate-ci/typos) | 拼写错误检查 | 1.43.1 |
+| [typos](https://github.com/crate-ci/typos) | 拼写错误检查 | 1.45.0 |
 | [ruff](https://github.com/astral-sh/ruff) | Python 代码风格检查 | 0.15.0 |
 | [clang-format](https://github.com/llvm/llvm-project/tree/main/clang/tools/clang-format) | C++ 代码格式化 | 13.0.0 |
 | [cpplint](https://github.com/cpplint/cpplint) | C++ 代码风格检查 | 1.6.0 |

--- a/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
+++ b/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
@@ -43,6 +43,7 @@ trim trailing whitespace.................................................Passed
 CRLF end-lines remover...................................................Passed
 Tabs remover (C++).......................................................Passed
 Tabs remover (Python)................................(no files to check)Skipped
+ast-grep.................................................................Passed
 copyright_checker........................................................Passed
 typos....................................................................Passed
 ruff check...........................................(no files to check)Skipped
@@ -87,6 +88,7 @@ Date:   xxx
 | [pre-commit](https://github.com/pre-commit/pre-commit) | hook 管理工具 | >=2.17.0 |
 | [pre-commit/pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) | pre-commit 官方支持的 hook，执行一些通用检查 | 4.4.0 |
 | [Lucas-C/pre-commit-hooks](https://github.com/Lucas-C/pre-commit-hooks.git) | 社区维护的一些通用的 hook，含将 CRLF 改为 LF、移除 Tab 等 hook | 1.5.1 |
+| [ast-grep](https://github.com/ast-grep/ast-grep) | 基于语法树的结构规则检查 | 0.42.1 |
 | [copyright_checker](https://github.com/PaddlePaddle/Paddle/blob/develop/tools/codestyle/copyright.py) | Copyright 检查 | 本地脚本 |
 | [typos](https://github.com/crate-ci/typos) | 拼写错误检查 | 1.45.0 |
 | [ruff](https://github.com/astral-sh/ruff) | Python 代码风格检查 | 0.15.0 |


### PR DESCRIPTION
### 背景
- 这是对 PaddlePaddle/Paddle#78637 的配套 follow-up。
- `PaddlePaddle/docs` 当前 `.pre-commit-config.yaml` 里的 `typos-pre-commit-mirror` 仍是 `v1.44.0`。
- 同时，`docs/dev_guides/git_guides/codestyle_check_guide_cn.md` 中 `typos` 版本说明仍写的是 `1.43.1`，与当前 Paddle 侧 codestyle 配置不一致。

### 本 PR 修改
1. 将 `PaddlePaddle/docs` 的 `typos-pre-commit-mirror` 升级到 `v1.45.0`
2. 将 `codestyle_check_guide_cn.md` 中 `typos` 的版本说明同步为 `1.45.0`

### 本地验证
- `pre-commit run --files .pre-commit-config.yaml docs/dev_guides/git_guides/codestyle_check_guide_cn.md --color never`
- `pre-commit run typos --all-files --color never`

两项均已通过。