### PR TITLE
[CodeStyle][yamlfmt] Bump `google-yamlfmt` to version 0.21.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,6 @@ repos:
         types_or: [python, pyi, jupyter]
   # For YAML files
   - repo: https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git
-    rev: v0.16.0
+    rev: v0.21.0
     hooks:
       - id: yamlfmt


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
将 `.pre-commit-config.yaml` 中 `PFCCLab/yamlfmt-pre-commit-mirror` 的 `rev` 从 `v0.16.0` 升级到 `v0.21.0`，对应同步 `google-yamlfmt` 到 `0.21.0`。

该同步与 PaddlePaddle/Paddle#78650 保持一致，避免 PaddlePaddle/docs 继续停留在旧版本。本 PR 只调整 pre-commit 中的 yamlfmt mirror 版本号，不涉及文档内容改动。

### Validation
- `pre-commit run yamlfmt --files .pre-commit-config.yaml`
- `pre-commit run --files .pre-commit-config.yaml`

### 是否引起精度变化
否
