### PR TITLE
[CodeStyle][Docs] Sync yamlfmt version in codestyle guide

### DIFF
--- a/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
+++ b/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
@@ -97,7 +97,7 @@ Date:   xxx
 | [clang-tidy](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-tidy) | C++ 代码风格检查 | 15.0.2.1 |
 | [cmake-format](https://github.com/cheshirekow/cmake-format-precommit) | CMake 代码格式化 | 0.6.13 |
 | [cmake-lint](https://github.com/PFCCLab/cmake-lint-paddle)| CMake 代码风格检查 | 1.5.1 |
-| [yamlfmt](https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git) | YAML 代码格式化 | 0.16.0 |
+| [yamlfmt](https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git) | YAML 代码格式化 | 0.21.0 |
 
 > 注：这些工具可能会更新，详细配置请查看：[https://github.com/PaddlePaddle/Paddle/blob/develop/.pre-commit-config.yaml](https://github.com/PaddlePaddle/Paddle/blob/develop/.pre-commit-config.yaml)。
 


### PR DESCRIPTION
### 背景
- 这是已合并 PR #7891 的 follow-up。
- 在 #7891 中，`.pre-commit-config.yaml` 已将 `PFCCLab/yamlfmt-pre-commit-mirror` 升级到 `v0.21.0`。
- 但 `docs/dev_guides/git_guides/codestyle_check_guide_cn.md` 里的 `yamlfmt` 版本说明仍停留在 `0.16.0`，与当前配置不一致。

### 本 PR 修改
- 将 `codestyle_check_guide_cn.md` 中 `yamlfmt` 的版本说明从 `0.16.0` 同步为 `0.21.0`

### 本地验证
- `git diff -- docs/dev_guides/git_guides/codestyle_check_guide_cn.md`
- `pre-commit run --files docs/dev_guides/git_guides/codestyle_check_guide_cn.md --color never`
