### PR TITLE
[CI] Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/codestyle-check.yml
+++ b/.github/workflows/codestyle-check.yml
@@ -29,7 +29,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 200
@@ -40,7 +40,7 @@ jobs:
           git checkout -b test FETCH_HEAD
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
           enable-cache: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,7 +7,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/results.md

--- a/.github/workflows/preview-url-comment.yml
+++ b/.github/workflows/preview-url-comment.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -50,7 +50,7 @@ jobs:
           body-includes: '本次 PR 文档预览链接'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.pr-metadata.outputs.pr_number }}

--- a/.github/workflows/preview-url-comment.yml
+++ b/.github/workflows/preview-url-comment.yml
@@ -14,6 +14,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     permissions:
+      actions: read
       pull-requests: write
 
     steps:

--- a/.github/workflows/preview-url-generate.yml
+++ b/.github/workflows/preview-url-generate.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
           ./ci_scripts/report_preview_url.sh ${{ github.event.pull_request.number }} > preview_urls.txt
 
       - name: Upload preview URLs as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: preview-urls-${{ github.event.pull_request.number }}
           path: preview_urls.txt
@@ -43,7 +43,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > pr_sha.txt
 
       - name: Upload PR metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-metadata-${{ github.event.pull_request.number }}
           path: |

--- a/docs/api/paddle/incubate/optimizer/functional/minimize_lbfgs_cn.rst
+++ b/docs/api/paddle/incubate/optimizer/functional/minimize_lbfgs_cn.rst
@@ -16,7 +16,7 @@ LBFGS 具体原理参考书籍 Jorge Nocedal, Stephen J. Wright, Numerical Optim
 :::::::::
 - minimize_bfgs 优化器当前实现为函数形式，与 Paddle 现有 SGD、Adam 优化器等使用略微有些区别。
   SGD/Adam 等通过调用 backward()计算梯度，并使用 step()更新网络参数，而 minimize_lbfgs 传入
-  loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_assign` 以 inpalce 方式进行更新。具体参考代码示例 1.
+  loss 函数，并返回优化后参数，返回参数需要通过 :ref:`cn_api_paddle_assign` 以 inplace 方式进行更新。具体参考代码示例 1.
 - 由于当前实现上一些限制，当前 minimize_bfgs 要求函数输入为一维 Tensor。当输入参数维度超过一维，
   可以先将参数展平，使用 minimize_bfgs 计算后，再 reshape 到原有形状，更新参数。具体参考代码示例 2.
 


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions that still rely on the Node 20 or Node 16 runtime
- align the workflow versions with upstream actions that already publish Node 24-compatible releases
- keep the reusable workflow and composite-action paths untouched where they are already safe

## Changes
- bump `actions/checkout` to `v6` in the codestyle, link-check, and preview URL workflows
- bump `astral-sh/setup-uv` to `v7` in codestyle
- bump `actions/download-artifact` to `v8` and `actions/upload-artifact` to `v7` in preview workflows
- bump `peter-evans/create-issue-from-file` to `v6` and `peter-evans/create-or-update-comment` to `v5`

## Why
The repository still referenced several JavaScript actions whose published `action.yml` files use `node20` or `node16`. GitHub is moving runners to Node 24, so these workflows need to be on majors that declare `runs.using: node24`.

## Validation
- reviewed every `uses:` entry under `.github/workflows`
- verified the upgraded actions publish Node 24-compatible runtimes in their upstream `action.yml`
- confirmed there are no remaining references to the older versions that were part of this fix

## Notes
- `PFCCLab/ci-bypass@v2` is already a Node 24 JavaScript action
- `lycheeverse/lychee-action@v2` is a composite action, so it is not affected by the Node runtime migration in the same way
