### PR TITLE
[Doc Link Fix No.28] Fix deep_speech_2.md image links

### DIFF
--- a/docs/design/network/deep_speech_2.md
+++ b/docs/design/network/deep_speech_2.md
@@ -116,7 +116,7 @@ The classical DS2 network contains 15 layers (from bottom to top):
 - **One** CTC-loss layer
 
 <div align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/ds2_network.png" width=350><br/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/network/images/ds2_network.png" width=350><br/>
 Figure 1. Architecture of Deep Speech 2 Network.
 </div>
 
@@ -208,7 +208,7 @@ TODO by Assignees
 ### Beam Search with CTC and LM
 
 <div align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/beam_search.png" width=600><br/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/network/images/beam_search.png" width=600><br/>
 Figure 2. Algorithm for CTC Beam Search Decoder.
 </div>
 


### PR DESCRIPTION
## 修复内容

### 任务 28: docs/design/network/deep_speech_2.md

修复2个图片链接：
- ds2_network.png  
- beam_search.png

## 验证结果
已手动访问所有更新后的链接，确认所有链接可正常访问

Fixes #7735 (Task 28)