### PR TITLE
[Doc Link Fix No.30] Fix gan_api.md image links

### DIFF
--- a/docs/design/others/gan_api.md
+++ b/docs/design/others/gan_api.md
@@ -7,14 +7,14 @@ It applies several important concepts in machine learning system design, includi
 In our GAN design, we wrap it as a user-friendly easily customized python API to design different models. We take the conditional DC-GAN (Unsupervised Representation Learning with Deep Convolutional Generative Adversarial Networks [https://arxiv.org/abs/1511.06434]) as an example due to its good performance on image generation.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/test.dot.png" width = "35%" align="center"/><br/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/others/test.dot.png" width = "35%" align="center"/><br/>
 Figure 1. The overall running logic of GAN. The black solid arrows indicate the forward pass; the green dashed arrows indicate the backward pass of generator training; the red dashed arrows indicate the backward pass of the discriminator training. The BP pass of the green (red) arrow should only update the parameters in the green (red) boxes. The diamonds indicate the data providers. d\_loss and g\_loss marked in red and green are the two targets we would like to run.
 </p>
 
 The operators, layers and functions required/optional to build a GAN demo is summarized in https://github.com/PaddlePaddle/Paddle/issues/4563.
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/doc/fluid/images/dcgan.png" width = "90%" align="center"/><br/>
+<img src="https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/others/dcgan.png" width = "90%" align="center"/><br/>
 Figure 2. Photo borrowed from the original DC-GAN paper.
 </p>
 


### PR DESCRIPTION
## 修复内容
### 任务 30: docs/design/others/gan_api.md

修复2个图片链接：

 - [test.dot.png](https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/others/test.dot.png)  
 -  [dcgan.png](https://raw.githubusercontent.com/PaddlePaddle/docs/refs/heads/develop/docs/design/others/dcgan.png)

## 验证结果

已手动访问所有更新后的链接，确认所有链接可正常访问

Fixes #7735 (Task 30)