### PR TITLE
[API Compatibility No.252] Document paddle.autograd.enable_grad

### DIFF
--- a/docs/api/paddle/autograd/Overview_cn.rst
+++ b/docs/api/paddle/autograd/Overview_cn.rst
@@ -19,6 +19,7 @@ paddle.autograd 目录下包含飞桨框架支持的自动微分相关的 API �
     :widths: 10, 30
 
     " :ref:`backward <cn_api_paddle_autograd_backward>` ", "计算给定的 Tensors 的反向梯度"
+    " :ref:`enable_grad <cn_api_paddle_autograd_enable_grad>` ", "创建启用动态图梯度计算的上下文"
     " :ref:`hessian <cn_api_paddle_autograd_hessian>` ", "计算因变量 ``ys`` 对 自变量 ``xs`` 的海森矩阵"
     " :ref:`jacobian <cn_api_paddle_autograd_jacobian>` ", "计算因变量 ``ys`` 对 自变量 ``xs`` 的雅可比矩阵"
     " :ref:`saved_tensors_hooks <cn_api_paddle_autograd_saved_tensors_hooks>` ", "用于动态图中为保存的 Tensor 注册一对 pack / unpack hook"

--- a/docs/api/paddle/autograd/enable_grad_cn.rst
+++ b/docs/api/paddle/autograd/enable_grad_cn.rst
@@ -1,0 +1,18 @@
+.. _cn_api_paddle_autograd_enable_grad:
+
+enable_grad
+-------------------------------
+
+.. py:class:: paddle.autograd.enable_grad()
+
+
+创建一个上下文来启用动态图梯度计算。在此模式下，每次计算的结果都将具有 stop_gradient=False。
+
+也可以用作一个装饰器（需要创建实例对象作为装饰器）。
+
+该 API 与 :ref:`cn_api_paddle_enable_grad` 功能一致。
+
+代码示例
+::::::::::::
+
+COPY-FROM: paddle.autograd.enable_grad

--- a/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.autograd.enable_grad.md
+++ b/docs/guides/model_convert/convert_from_pytorch/api_difference/invok_only_diff/torch.autograd.enable_grad.md
@@ -6,13 +6,13 @@
 torch.autograd.enable_grad(*args, **kwargs)
 ```
 
-### [paddle.enable\_grad](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/enable_grad_cn.html#paddle.enable_grad)
+### [paddle.autograd.enable\_grad](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/autograd/enable_grad_cn.html#paddle.autograd.enable_grad)
 
 ```python
-paddle.enable_grad(*args, **kwargs)
+paddle.autograd.enable_grad(*args, **kwargs)
 ```
 
-两者功能一致，但调用方式不一致，具体如下：
+两者功能一致，Paddle 也支持在 ``paddle.autograd`` 命名空间下调用，具体如下：
 
 ### 转写示例
 
@@ -26,7 +26,7 @@ with torch.no_grad():
     result = doubler(x)
 
 # Paddle 写法
-@paddle.enable_grad()
+@paddle.autograd.enable_grad()
 def doubler(x):
     return x * 2
 


### PR DESCRIPTION
### Description
Document `paddle.autograd.enable_grad` for PyTorch compatibility task No.252 in PaddlePaddle/Paddle#76301.

Changes:
- add Chinese API documentation for `paddle.autograd.enable_grad`
- list `enable_grad` in the `paddle.autograd` overview
- update the PyTorch conversion difference page for `torch.autograd.enable_grad`

Related Paddle PR: PaddlePaddle/Paddle#79338.
Related PaConvert PR: PaddlePaddle/PaConvert#890.

### Tests
- `git diff --check`

Note: docs build was not run locally.