### PR TITLE
[CodeStyle] Bump Ruff to v0.16.0 and sync tooling docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: check-case-conflict
   # For Python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
+++ b/docs/dev_guides/git_guides/codestyle_check_guide_cn.md
@@ -88,10 +88,10 @@ Date:   xxx
 | [pre-commit](https://github.com/pre-commit/pre-commit) | hook 管理工具 | >=2.17.0 |
 | [pre-commit/pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) | pre-commit 官方支持的 hook，执行一些通用检查 | 4.4.0 |
 | [Lucas-C/pre-commit-hooks](https://github.com/Lucas-C/pre-commit-hooks.git) | 社区维护的一些通用的 hook，含将 CRLF 改为 LF、移除 Tab 等 hook | 1.5.1 |
-| [ast-grep](https://github.com/ast-grep/ast-grep) | 基于语法树的结构规则检查 | 0.44.0 |
+| [ast-grep](https://github.com/ast-grep/ast-grep) | 基于语法树的结构规则检查 | 0.45.0 |
 | [copyright_checker](https://github.com/PaddlePaddle/Paddle/blob/develop/tools/codestyle/copyright.py) | Copyright 检查 | 本地脚本 |
 | [typos](https://github.com/crate-ci/typos) | 拼写错误检查 | 1.48.0 |
-| [ruff](https://github.com/astral-sh/ruff) | Python 代码风格检查 | 0.15.0 |
+| [ruff](https://github.com/astral-sh/ruff) | Python 代码风格检查 | 0.16.0 |
 | [clang-format](https://github.com/llvm/llvm-project/tree/main/clang/tools/clang-format) | C++ 代码格式化 | 13.0.0 |
 | [cpplint](https://github.com/cpplint/cpplint) | C++ 代码风格检查 | 1.6.0 |
 | [clang-tidy](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-tidy) | C++ 代码风格检查 | 15.0.2.1 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.ruff]
+extend-exclude = ["*.md"]
 line-length = 80
 target-version = "py39"
 


### PR DESCRIPTION
同步 [PaddlePaddle/Paddle#79546](https://github.com/PaddlePaddle/Paddle/pull/79546) 的代码检查工具版本：

- 将 docs 仓库的 Ruff pre-commit pin 从 `0.15.0` 升级到 `0.16.0`；
- 将代码规范指南中的 ast-grep 版本从 `0.44.0` 更新为 `0.45.0`；
- 将代码规范指南中的 Ruff 版本从 `0.15.0` 更新为 `0.16.0`；
- 在 Ruff 配置中明确排除 Markdown，继续由 docs 仓库现有的专用 Markdown hooks 负责格式检查，避免直接运行 `ruff format` 时批量改写文档代码块。

ast-grep 未作为 docs 仓库的 pre-commit hook 引入，指南中的版本仅用于同步 Paddle 仓库的实际配置。

本地验证：

- Ruff 0.16 全仓 lint 通过；
- Ruff 0.16 format check 仅覆盖 69 个 Python/PYI/Jupyter 文件并通过，Markdown 排除策略生效；
- 变更文件上的完整 pre-commit hooks 全部通过；
- `git diff --check` 通过。
