### PR TITLE
fix(docs): remove duplicated characters in dev_guides

### DIFF
--- a/docs/dev_guides/api_contributing_guides/new_cpp_op_cn.md
+++ b/docs/dev_guides/api_contributing_guides/new_cpp_op_cn.md
@@ -1067,7 +1067,7 @@ PADDLE_ENFORCE_EQ(比较对象 A, 比较对象 B, 错误提示信息)
 所以在定义反向算子时需要注意以下几点：
 
 - 如果反向不需要前向的某些输入或输出参数，则无需在 args 中设置。
-- 如果有些反向算子需要依赖前向算子的输入或输出变量的的 Shape 或 [LoD](new_cpp_op_cn.html#lod)，但不依赖于变量中 Tensor 的内存 Buffer 数据，且不能根据其他变量推断出该 Shape 和 [LoD](new_cpp_op_cn.html#lod)，则可以通过 `no_need_buffer` 对该变量进行配置，详见[YAML 配置规则](new_cpp_op_cn.html#yaml)。示例：
+- 如果有些反向算子需要依赖前向算子的输入或输出变量的 Shape 或 [LoD](new_cpp_op_cn.html#lod)，但不依赖于变量中 Tensor 的内存 Buffer 数据，且不能根据其他变量推断出该 Shape 和 [LoD](new_cpp_op_cn.html#lod)，则可以通过 `no_need_buffer` 对该变量进行配置，详见[YAML 配置规则](new_cpp_op_cn.html#yaml)。示例：
 ```yaml
 - backward_op : trace_grad
   forward : trace (Tensor x, int offset, int axis1, int axis2) -> Tensor(out)

--- a/docs/dev_guides/docs_contributing_guides_cn.md
+++ b/docs/dev_guides/docs_contributing_guides_cn.md
@@ -176,7 +176,7 @@ upstream
 
 ## 五、review & merge
 
-提交 PR 后，可以指定 Paddle 的同学进行 Review。目前 Paddle 负责文档的同学是 [@mattheliu](https://github.com/mattheliu)、[@sunzhongkai588](https://github.com/sunzhongkai588)、、[@jzhang533](https://github.com/jzhang533) 等。
+提交 PR 后，可以指定 Paddle 的同学进行 Review。目前 Paddle 负责文档的同学是 [@mattheliu](https://github.com/mattheliu)、[@sunzhongkai588](https://github.com/sunzhongkai588)、[@jzhang533](https://github.com/jzhang533) 等。
 
 
 ## CI
@@ -188,4 +188,4 @@ Paddle 中与文档相关的 CI 流水线是 `Docs-NEW` 等，主要对以下几
 - 检查 API 示例代码是否能正常从英文文档 copy
 - 检查渲染后的文档是否存在 WARNING 或 ERROR
 
-如果无法通过该 CI，请点击对应 CI 的标题，查看 CI 运行的的 log，并根据 log 修改你的 PR，直至通过 CI。
+如果无法通过该 CI，请点击对应 CI 的标题，查看 CI 运行的 log，并根据 log 修改你的 PR，直至通过 CI。


### PR DESCRIPTION
Fix 3 duplicated-character typos in `docs/dev_guides`:

- `api_contributing_guides/new_cpp_op_cn.md`: 「变量的的 Shape」→「变量的 Shape」
- `docs_contributing_guides_cn.md`: 分列表里多出的一个「、」
- `docs_contributing_guides_cn.md`: 「CI 运行的的 log」→「CI 运行的 log」
